### PR TITLE
Use merge patch instead of strategic merge patch when deploying `ShootState`

### DIFF
--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -51,11 +51,8 @@ func Deploy(ctx context.Context, clock clock.Clock, gardenClient, seedClient cli
 		return fmt.Errorf("failed computing spec of ShootState for shoot %s: %w", client.ObjectKeyFromObject(shoot), err)
 	}
 
-	// We must use a regular merge patch here instead of a strategic merge patch. Strategic merge
-	// patch would attempt to introspect the RawExtension payloads in ShootState.Spec.Gardener to
-	// resolve merge keys and strategies. The SecretState type stored in those payloads contains a
-	// nested "data" map, which causes the strategic merge patch schema lookup to descend into the
-	// RawExtension struct — but RawExtension has no exported JSON fields, so the lookup fails with
+	// Use a regular merge patch here. A strategic merge patch fails when computing the diff over
+	// SecretState payloads inside the RawExtension entries of the Spec.Gardener with
 	// "unable to find api field in struct RawExtension for the json field \"data\"".
 	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, gardenClient, shootState, func() error {
 		metav1.SetMetaDataAnnotation(&shootState.ObjectMeta, v1beta1constants.GardenerTimestamp, clock.Now().UTC().Format(time.RFC3339))

--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -51,7 +51,13 @@ func Deploy(ctx context.Context, clock clock.Clock, gardenClient, seedClient cli
 		return fmt.Errorf("failed computing spec of ShootState for shoot %s: %w", client.ObjectKeyFromObject(shoot), err)
 	}
 
-	_, err = controllerutils.GetAndCreateOrStrategicMergePatch(ctx, gardenClient, shootState, func() error {
+	// We must use a regular merge patch here instead of a strategic merge patch. Strategic merge
+	// patch would attempt to introspect the RawExtension payloads in ShootState.Spec.Gardener to
+	// resolve merge keys and strategies. The SecretState type stored in those payloads contains a
+	// nested "data" map, which causes the strategic merge patch schema lookup to descend into the
+	// RawExtension struct — but RawExtension has no exported JSON fields, so the lookup fails with
+	// "unable to find api field in struct RawExtension for the json field \"data\"".
+	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, gardenClient, shootState, func() error {
 		metav1.SetMetaDataAnnotation(&shootState.ObjectMeta, v1beta1constants.GardenerTimestamp, clock.Now().UTC().Format(time.RFC3339))
 
 		if overwriteSpec {

--- a/test/integration/gardenlet/shoot/state/state_test.go
+++ b/test/integration/gardenlet/shoot/state/state_test.go
@@ -16,10 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/state"
-	shootstate "github.com/gardener/gardener/pkg/utils/gardener/shootstate"
+	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
@@ -271,10 +270,10 @@ var _ = Describe("Shoot State controller tests", func() {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
 				g.Expect(shootState.Spec.Gardener).To(HaveLen(1))
 
-				secretEntry := findGardenerEntry(shootState.Spec.Gardener, v1beta1constants.DataTypeSecret)
-				g.Expect(secretEntry).NotTo(BeNil())
-
-				var secretState shootstate.SecretState
+				var (
+					secretEntry = shootState.Spec.Gardener[0]
+					secretState shootstate.SecretState
+				)
 				g.Expect(json.Unmarshal(secretEntry.Data.Raw, &secretState)).To(Succeed())
 				g.Expect(secretState.Data).To(HaveKeyWithValue("key", []byte("initial-value")))
 			}).Should(Succeed())
@@ -295,22 +294,13 @@ var _ = Describe("Shoot State controller tests", func() {
 				g.Expect(shootState.Annotations).To(HaveKeyWithValue("gardener.cloud/timestamp", Not(Equal(lastBackup))))
 				g.Expect(shootState.Spec.Gardener).To(HaveLen(1))
 
-				secretEntry := findGardenerEntry(shootState.Spec.Gardener, v1beta1constants.DataTypeSecret)
-				g.Expect(secretEntry).NotTo(BeNil())
-
-				var secretState shootstate.SecretState
+				var (
+					secretEntry = shootState.Spec.Gardener[0]
+					secretState shootstate.SecretState
+				)
 				g.Expect(json.Unmarshal(secretEntry.Data.Raw, &secretState)).To(Succeed())
 				g.Expect(secretState.Data).To(HaveKeyWithValue("key", []byte("updated-value")))
 			}).Should(Succeed())
 		})
 	})
 })
-
-func findGardenerEntry(entries []gardencorev1beta1.GardenerResourceData, entryType string) *gardencorev1beta1.GardenerResourceData {
-	for i := range entries {
-		if entries[i].Type == entryType {
-			return &entries[i]
-		}
-	}
-	return nil
-}

--- a/test/integration/gardenlet/shoot/state/state_test.go
+++ b/test/integration/gardenlet/shoot/state/state_test.go
@@ -5,6 +5,7 @@
 package state_test
 
 import (
+	"encoding/json"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,8 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/state"
+	shootstate "github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
@@ -255,5 +258,59 @@ var _ = Describe("Shoot State controller tests", func() {
 				g.Expect(shootState.Spec.Gardener).To(HaveLen(1))
 			}).Should(Succeed())
 		})
+
+		It("should update ShootState when persisted secret data is modified", func() {
+			secret.Data = map[string][]byte{"key": []byte("initial-value")}
+			createPersistableSecret()
+
+			By("Step clock to trigger first backup")
+			fakeClock.Step(2 * syncPeriod)
+
+			By("Ensure ShootState is created with initial secret data")
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
+				g.Expect(shootState.Spec.Gardener).To(HaveLen(1))
+
+				secretEntry := findGardenerEntry(shootState.Spec.Gardener, v1beta1constants.DataTypeSecret)
+				g.Expect(secretEntry).NotTo(BeNil())
+
+				var secretState shootstate.SecretState
+				g.Expect(json.Unmarshal(secretEntry.Data.Raw, &secretState)).To(Succeed())
+				g.Expect(secretState.Data).To(HaveKeyWithValue("key", []byte("initial-value")))
+			}).Should(Succeed())
+
+			lastBackup := shootState.Annotations["gardener.cloud/timestamp"]
+
+			By("Update secret data")
+			patch := client.MergeFrom(secret.DeepCopy())
+			secret.Data = map[string][]byte{"key": []byte("updated-value")}
+			Expect(testClient.Patch(ctx, secret, patch)).To(Succeed())
+
+			By("Step clock to trigger next backup")
+			fakeClock.Step(2 * syncPeriod)
+
+			By("Ensure ShootState is updated with new secret data")
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
+				g.Expect(shootState.Annotations).To(HaveKeyWithValue("gardener.cloud/timestamp", Not(Equal(lastBackup))))
+				g.Expect(shootState.Spec.Gardener).To(HaveLen(1))
+
+				secretEntry := findGardenerEntry(shootState.Spec.Gardener, v1beta1constants.DataTypeSecret)
+				g.Expect(secretEntry).NotTo(BeNil())
+
+				var secretState shootstate.SecretState
+				g.Expect(json.Unmarshal(secretEntry.Data.Raw, &secretState)).To(Succeed())
+				g.Expect(secretState.Data).To(HaveKeyWithValue("key", []byte("updated-value")))
+			}).Should(Succeed())
+		})
 	})
 })
+
+func findGardenerEntry(entries []gardencorev1beta1.GardenerResourceData, entryType string) *gardencorev1beta1.GardenerResourceData {
+	for i := range entries {
+		if entries[i].Type == entryType {
+			return &entries[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
Strategic merge patch fails when the ShootState's Gardener field contains entries whose RawExtension payload has a nested map structure. The SecretState type introduced in #14268 wraps secret data in a {"data":{...}} object, causing the strategic merge patch schema lookup to descend into the RawExtension struct. Since RawExtension has no exported JSON fields, this lookup fails with "unable to find api field in struct RawExtension for the json field \"data\"".

Switch to a regular merge patch at the Deploy call site. The patchMergeKey and patchStrategy tags on ShootStateSpec.Gardener are intentionally preserved as correct API metadata for any future caller that does not have this constraint.

**Which issue(s) this PR fixes**:
Part of #14906

**Special notes for your reviewer**:
As part of resolving the issue, we could potentially also add an e2e test for the `ShootState` controller, however I have opted to leave this for a subsequent PR, as I did not have time to also tackle it as the `ShootState` controller is also explicitly disabled in the e2e tests.
Instead, this PR now only includes an integration test for updating the secret data in the `ShootState`.

I have not removed the 
```
	// +patchMergeKey=name
	// +patchStrategy=merge
```
on the `ShootState` api as strategic merge patches could still be used on [GardenerResourceData](https://github.com/gardener/gardener/blob/f4a88d4f055acaed3c32a1a576366a8b6cd7bc73/pkg/apis/core/v1beta1/types_shootstate.go#L56-L67) fields, if their `Data` entries, that are being modified, do not contain a custom struct.
But I don't have a strong opinion on that and those could also be dropped.

/cc @ialidzhikov 
/cc @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug in the `shoot-state` controller where periodic `ShootState` backups would fail with `unable to find api field in struct RawExtension for the json field "data"` when a persisted secret's data had been modified.
```
