### PR TITLE
Add jitter to containerd logrotate timer

### DIFF
--- a/docs/usage/logging.md
+++ b/docs/usage/logging.md
@@ -33,6 +33,11 @@ The values of the `containerLogMaxSize` and `containerLogMaxFiles` fields need t
 
 In the majority of the cases, the defaults should do just fine. Custom configuration might be of use under rare conditions.
 
+### Container Logs Rotation and Retention by logrotate
+
+A security requirement mandates that no log entry older than 14 days is present on the host.
+kubelet only supports size-based log rotation, not time-based retention, so `logrotate` is used to enforce daily rotation and a 14-day retention window on top of the kubelet's own size-based rotation.
+
 ## Logs Retention in Vali
 
 Logs in Vali are preserved for a maximum of 14 days. Note that the retention period is also restricted to the Vali's persistent volume size and in some cases, it can be less than 14 days. The oldest logs are deleted when a configured threshold of free disk space is crossed.

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -48,10 +48,11 @@ WantedBy=multi-user.target`),
 				Command: new(extensionsv1alpha1.CommandStart),
 				Enable:  new(true),
 				Content: new(`[Unit]
-Description=Log Rotation at each 10 minutes
+Description=Log Rotation once a day
 [Timer]
-OnCalendar=*:0/10
+OnCalendar=daily
 AccuracySec=1min
+RandomizedDelaySec=4h
 Persistent=true
 [Install]
 WantedBy=multi-user.target`),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -53,10 +53,11 @@ WantedBy=multi-user.target`),
 		Command: new(extensionsv1alpha1.CommandStart),
 		Enable:  new(true),
 		Content: new(`[Unit]
-Description=Log Rotation at each 10 minutes
+Description=Log Rotation once a day
 [Timer]
-OnCalendar=*:0/10
+OnCalendar=daily
 AccuracySec=1min
+RandomizedDelaySec=4h
 Persistent=true
 [Install]
 WantedBy=multi-user.target`),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -14,6 +14,12 @@ import (
 //
 // Prefix carries the target container runtime (such as  containerd, docker).
 // When containerd is used the log rotation based on size is performed by kubelet.
+//
+// A security requirement mandates that no log entry older than 14 days is present on the host.
+// kubelet and containerd only support size-based log rotation, not time-based retention, so
+// logrotate is used to enforce daily rotation and a 14-day retention window on top of the
+// container runtime's own size-based rotation.
+// See https://github.com/gardener/gardener/issues/653 for the historical context.
 func Config(pathConfig, pathLogFiles, prefix string) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File) {
 	serviceFile := extensionsv1alpha1.File{
 		Path:        pathConfig,

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -19,7 +19,11 @@ import (
 // kubelet and containerd only support size-based log rotation, not time-based retention, so
 // logrotate is used to enforce daily rotation and a 14-day retention window on top of the
 // container runtime's own size-based rotation.
-// See https://github.com/gardener/gardener/issues/653 for the historical context.
+// See: https://github.com/gardener/gardener/issues/653 for the historical context.
+//
+// The timer is configured with jitter to avoid all nodes rotating logs at the same time
+// which can cause spikes on the storage backend.
+// See: https://github.com/gardener/gardener/issues/15149 for more context.
 func Config(pathConfig, pathLogFiles, prefix string) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File) {
 	serviceFile := extensionsv1alpha1.File{
 		Path:        pathConfig,

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -16,14 +16,14 @@ import (
 // When containerd is used the log rotation based on size is performed by kubelet.
 //
 // A security requirement mandates that no log entry older than 14 days is present on the host.
-// kubelet and containerd only support size-based log rotation, not time-based retention, so
+// kubelet only supports size-based log rotation, not time-based retention, so
 // logrotate is used to enforce daily rotation and a 14-day retention window on top of the
-// container runtime's own size-based rotation.
-// See: https://github.com/gardener/gardener/issues/653 for the historical context.
+// kubelet's own size-based rotation.
+// For the historical context, see https://github.com/gardener/gardener/issues/653.
 //
 // The timer is configured with jitter to avoid all nodes rotating logs at the same time
 // which can cause spikes on the storage backend.
-// See: https://github.com/gardener/gardener/issues/15149 for more context.
+// For more context, see https://github.com/gardener/gardener/issues/15149.
 func Config(pathConfig, pathLogFiles, prefix string) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File) {
 	serviceFile := extensionsv1alpha1.File{
 		Path:        pathConfig,

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
@@ -48,10 +48,11 @@ WantedBy=multi-user.target`),
 					Command: new(extensionsv1alpha1.CommandStart),
 					Enable:  new(true),
 					Content: new(`[Unit]
-Description=Log Rotation at each 10 minutes
+Description=Log Rotation once a day
 [Timer]
-OnCalendar=*:0/10
+OnCalendar=daily
 AccuracySec=1min
+RandomizedDelaySec=4h
 Persistent=true
 [Install]
 WantedBy=multi-user.target`),


### PR DESCRIPTION
**How to categorize this PR?**

/area logging
/kind enhancement

**What this PR does / why we need it**:

- Change `containerd-logrotate.timer` to daily with jitter. Avoids all nodes rotating simultaneously. The logrotate config already uses `daily`, so effective rotation cadence is unchanged.
- Document why the custom logrotate units exist (14-day retention requirement per #653; kubelet/containerd only do size-based rotation).

Based on: [stackitcloud/gardener#172](https://github.com/stackitcloud/gardener/pull/172)

**Which issue(s) this PR fixes**:

Fixes #15149

**Special notes for your reviewer**:

/cc @timebertt @Kumm-Kai @oliver-goetz 
/cc @ialidzhikov @vpnachev 

ℹ️ @JordanJordanov 

**Release note**:

```other operator
`containerd-logrotate.timer` now fires once per day with up to 4h jitter instead of every 10 minutes. 14-day retention is unchanged.
```
