### PR TITLE
Update Istio networking API version examples

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -867,7 +867,7 @@ This way, neither custom `NetworkPolicy`s nor custom labels must be provided.
 As an example, let's assume that istio ingress gateway is running in namespace `istio-ingress` and  above `gardener-resource-manager` `Service` was exposed via the following `VirtualService` and `Gateway` resources:
 
 ```yaml
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: grm-gateway
@@ -883,7 +883,7 @@ spec:
       number: 443
       protocol: HTTPS
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: gardener-resource-manager


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area documentation
/kind cleanup

**What this PR does / why we need it**:

Updates the Istio `Gateway` and `VirtualService` examples in `docs/concepts/resource-manager.md` from `networking.istio.io/v1beta1` to `networking.istio.io/v1`.

This aligns the examples with the current Istio Gateway reference documentation:
https://istio.io/latest/docs/reference/config/networking/gateway/

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Documentation-only cleanup. No code changes.

**Release note**:

```doc operator
Updated Istio networking API version examples in the resource-manager documentation from `networking.istio.io/v1beta1` to `networking.istio.io/v1`.