### PR TITLE
Default worker architecture from machine type in shoot mutator

### DIFF
--- a/pkg/apis/core/v1beta1/defaults_shoot.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot.go
@@ -48,10 +48,6 @@ func SetDefaults_Shoot(obj *Shoot) {
 	}
 
 	for i, worker := range obj.Spec.Provider.Workers {
-		if worker.Machine.Architecture == nil {
-			obj.Spec.Provider.Workers[i].Machine.Architecture = new(v1beta1constants.ArchitectureAMD64)
-		}
-
 		if worker.CRI == nil {
 			obj.Spec.Provider.Workers[i].CRI = &CRI{Name: CRINameContainerD}
 		}

--- a/pkg/apis/core/v1beta1/defaults_shoot_test.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	. "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
 var _ = Describe("Shoot defaulting", func() {
@@ -863,19 +862,6 @@ var _ = Describe("Shoot defaulting", func() {
 
 			Expect(obj.Spec.Provider.WorkersSettings).To(Equal(&WorkersSettings{SSHAccess: &SSHAccess{Enabled: false}}))
 		})
-	})
-
-	It("should default architecture of worker's machine to amd64", func() {
-		obj.Spec.Provider.Workers = []Worker{
-			{Name: "Default Worker"},
-			{Name: "Worker with machine architecture type",
-				Machine: Machine{Architecture: new("test")}},
-		}
-
-		SetObjectDefaults_Shoot(obj)
-
-		Expect(*obj.Spec.Provider.Workers[0].Machine.Architecture).To(Equal(v1beta1constants.ArchitectureAMD64))
-		Expect(*obj.Spec.Provider.Workers[1].Machine.Architecture).To(Equal("test"))
 	})
 
 	It("should default worker cri.name to containerd", func() {

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -170,7 +170,7 @@ func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSEn
 		labels = map[string]string{}
 	}
 	labels["node.kubernetes.io/role"] = "node"
-	labels["kubernetes.io/arch"] = *workerPool.Machine.Architecture
+	labels["kubernetes.io/arch"] = ptr.Deref(workerPool.Machine.Architecture, v1beta1constants.ArchitectureAMD64)
 
 	labels[v1beta1constants.LabelNodeLocalDNS] = strconv.FormatBool(nodeLocalDNSEnabled)
 

--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -196,6 +196,7 @@ func (m *MutateShoot) Admit(_ context.Context, a admission.Attributes, _ admissi
 	mutationContext.defaultShootNetworks(helper.IsWorkerless(shoot))
 	allErrs = append(allErrs, mutationContext.defaultKubernetes()...)
 	allErrs = append(allErrs, mutationContext.defaultKubernetesVersionForWorkers()...)
+	mutationContext.defaultWorkerArchitectures()
 	allErrs = append(allErrs, mutationContext.ensureMachineImages()...)
 
 	if len(allErrs) > 0 {
@@ -479,6 +480,27 @@ func (c *mutationContext) defaultKubernetesVersionForWorker(idxPath *field.Path,
 		worker.Kubernetes.Version = defaultVersion
 	}
 	return nil
+}
+
+// defaultWorkerArchitectures sets the architecture for workers that have none specified.
+// It infers the architecture from the machine type in the cloud profile when the machine type
+// supports exactly one architecture; otherwise it falls back to amd64.
+func (c *mutationContext) defaultWorkerArchitectures() {
+	for i, worker := range c.shoot.Spec.Provider.Workers {
+		if worker.Machine.Architecture != nil {
+			continue
+		}
+
+		arch := v1beta1constants.ArchitectureAMD64
+
+		if machineType := v1beta1helper.FindMachineTypeByName(c.cloudProfileSpec.MachineTypes, worker.Machine.Type); machineType != nil {
+			if inferredArch := machineType.GetArchitecture(c.cloudProfileSpec.MachineCapabilities); inferredArch != "" {
+				arch = inferredArch
+			}
+		}
+
+		c.shoot.Spec.Provider.Workers[i].Machine.Architecture = &arch
+	}
 }
 
 func (c *mutationContext) ensureMachineImages() field.ErrorList {

--- a/plugin/pkg/shoot/mutator/admission_test.go
+++ b/plugin/pkg/shoot/mutator/admission_test.go
@@ -768,6 +768,116 @@ var _ = Describe("mutator", func() {
 			})
 		})
 
+		Context("worker architecture defaulting", func() {
+			BeforeEach(func() {
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+			})
+
+			It("should not change architecture if it is already set", func() {
+				shoot.Spec.Provider.Workers[0].Machine.Architecture = new(v1beta1constants.ArchitectureAMD64)
+
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(shoot.Spec.Provider.Workers[0].Machine.Architecture).To(Equal(new(v1beta1constants.ArchitectureAMD64)))
+			})
+
+			It("should infer architecture from machine type when architecture is nil and machine type supports exactly one architecture", func() {
+				shoot.Spec.Provider.Workers[0].Machine.Architecture = nil
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(shoot.Spec.Provider.Workers[0].Machine.Architecture).To(Equal(new(v1beta1constants.ArchitectureAMD64)))
+			})
+
+			It("should infer arm64 architecture for an arm64-only machine type when architecture is nil", func() {
+				cloudProfile.Spec.MachineTypes = append(cloudProfile.Spec.MachineTypes, gardencorev1beta1.MachineType{
+					Name:         "arm64-only-type",
+					CPU:          resource.MustParse("2"),
+					GPU:          resource.MustParse("0"),
+					Memory:       resource.MustParse("8Gi"),
+					Architecture: new(v1beta1constants.ArchitectureARM64),
+					Usable:       new(true),
+					Capabilities: gardencorev1beta1.Capabilities{
+						"architecture": []string{v1beta1constants.ArchitectureARM64},
+					},
+				})
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Update(&cloudProfile)).To(Succeed())
+
+				shoot.Spec.Provider.Workers[0].Machine.Type = "arm64-only-type"
+				shoot.Spec.Provider.Workers[0].Machine.Architecture = nil
+
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(shoot.Spec.Provider.Workers[0].Machine.Architecture).To(Equal(new(v1beta1constants.ArchitectureARM64)))
+			})
+
+			It("should default to amd64 when machine type is not found in cloud profile and architecture is nil", func() {
+				shoot.Spec.Provider.Workers[0].Machine.Type = "unknown-machine-type"
+				shoot.Spec.Provider.Workers[0].Machine.Architecture = nil
+
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(shoot.Spec.Provider.Workers[0].Machine.Architecture).To(Equal(new(v1beta1constants.ArchitectureAMD64)))
+			})
+
+			It("should default to amd64 when machine type supports multiple architectures and architecture is nil", func() {
+				cloudProfile.Spec.MachineTypes = append(cloudProfile.Spec.MachineTypes, gardencorev1beta1.MachineType{
+					Name:   "multi-arch-type",
+					CPU:    resource.MustParse("2"),
+					GPU:    resource.MustParse("0"),
+					Memory: resource.MustParse("8Gi"),
+					Usable: new(true),
+					Capabilities: gardencorev1beta1.Capabilities{
+						"architecture": []string{v1beta1constants.ArchitectureAMD64, v1beta1constants.ArchitectureARM64},
+					},
+				})
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Update(&cloudProfile)).To(Succeed())
+
+				shoot.Spec.Provider.Workers[0].Machine.Type = "multi-arch-type"
+				shoot.Spec.Provider.Workers[0].Machine.Architecture = nil
+
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(shoot.Spec.Provider.Workers[0].Machine.Architecture).To(Equal(new(v1beta1constants.ArchitectureAMD64)))
+			})
+
+			It("should infer arm64 from legacy Architecture field when no capabilities are defined", func() {
+				cloudProfile.Spec.MachineTypes = append(cloudProfile.Spec.MachineTypes, gardencorev1beta1.MachineType{
+					Name:         "arm64-legacy-type",
+					CPU:          resource.MustParse("2"),
+					GPU:          resource.MustParse("0"),
+					Memory:       resource.MustParse("8Gi"),
+					Architecture: new(v1beta1constants.ArchitectureARM64),
+					Usable:       new(true),
+				})
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Update(&cloudProfile)).To(Succeed())
+
+				shoot.Spec.Provider.Workers[0].Machine.Type = "arm64-legacy-type"
+				shoot.Spec.Provider.Workers[0].Machine.Architecture = nil
+
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(shoot.Spec.Provider.Workers[0].Machine.Architecture).To(Equal(new(v1beta1constants.ArchitectureARM64)))
+			})
+
+			It("should default to amd64 when no capabilities and no legacy Architecture field are defined on the machine type", func() {
+				cloudProfile.Spec.MachineTypes = append(cloudProfile.Spec.MachineTypes, gardencorev1beta1.MachineType{
+					Name:   "no-arch-type",
+					CPU:    resource.MustParse("2"),
+					GPU:    resource.MustParse("0"),
+					Memory: resource.MustParse("8Gi"),
+					Usable: new(true),
+				})
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Update(&cloudProfile)).To(Succeed())
+
+				shoot.Spec.Provider.Workers[0].Machine.Type = "no-arch-type"
+				shoot.Spec.Provider.Workers[0].Machine.Architecture = nil
+
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(shoot.Spec.Provider.Workers[0].Machine.Architecture).To(Equal(new(v1beta1constants.ArchitectureAMD64)))
+			})
+		})
+
 		DescribeTableSubtree("machine image", func(isCapabilityCloudProfile bool) {
 			var (
 				classificationPreview = gardencorev1beta1.ClassificationPreview

--- a/plugin/pkg/shoot/mutator/admission_test.go
+++ b/plugin/pkg/shoot/mutator/admission_test.go
@@ -774,11 +774,11 @@ var _ = Describe("mutator", func() {
 			})
 
 			It("should not change architecture if it is already set", func() {
-				shoot.Spec.Provider.Workers[0].Machine.Architecture = new(v1beta1constants.ArchitectureAMD64)
+				shoot.Spec.Provider.Workers[0].Machine.Architecture = new(v1beta1constants.ArchitectureARM64)
 
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
-				Expect(shoot.Spec.Provider.Workers[0].Machine.Architecture).To(Equal(new(v1beta1constants.ArchitectureAMD64)))
+				Expect(shoot.Spec.Provider.Workers[0].Machine.Architecture).To(Equal(new(v1beta1constants.ArchitectureARM64)))
 			})
 
 			It("should infer architecture from machine type when architecture is nil and machine type supports exactly one architecture", func() {

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -386,8 +386,9 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 							Minimum: 2,
 							Maximum: 2,
 							Machine: gardencorev1beta1.Machine{
-								Image: &testMachineImage,
-								Type:  "large",
+								Image:        &testMachineImage,
+								Type:         "large",
+								Architecture: new(v1beta1constants.ArchitectureAMD64),
 							},
 						},
 						{
@@ -397,7 +398,7 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 							Machine: gardencorev1beta1.Machine{
 								Image:        &testMachineImage,
 								Type:         "large-arm",
-								Architecture: new("arm64"),
+								Architecture: new(v1beta1constants.ArchitectureARM64),
 							},
 						},
 					},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR moves architecture defaulting into the ShootMutator admission plugin, which defaults the worker architecture based on machine type architecture if present, otherwise defaults to amd64.


**Which issue(s) this PR fixes**:
Fixes #14492

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
