### PR TITLE
Avoid unnecessary updates to `istio-basic-auth-server`

### DIFF
--- a/pkg/component/networking/istiobasicauthserver/istiobasicauthserver.go
+++ b/pkg/component/networking/istiobasicauthserver/istiobasicauthserver.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -290,6 +291,14 @@ func (i *istioBasicAuthServer) calculateConfiguration(
 			MountPath: rootMountPath,
 		})
 	}
+
+	// Sort volumes and volume mounts to prevent unnecessary updates to the deployment.
+	slices.SortFunc(volumes, func(a, b corev1.Volume) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	slices.SortFunc(volumeMounts, func(a, b corev1.VolumeMount) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	return volumes, volumeMounts, configPatches, nil
 }

--- a/pkg/component/networking/istiobasicauthserver/istiobasicauthserver_test.go
+++ b/pkg/component/networking/istiobasicauthserver/istiobasicauthserver_test.go
@@ -6,6 +6,8 @@ package istiobasicauthserver_test
 
 import (
 	"context"
+	"slices"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,6 +61,11 @@ var _ = Describe("IstioBasicAuthServer", func() {
 		deployment = func(isGarden bool, prefixToSecret []prefixToSecretMapping) string {
 			volumes := ""
 			volumeMounts := ""
+
+			slices.SortFunc(prefixToSecret, func(a, b prefixToSecretMapping) int {
+				return strings.Compare(a.prefix, b.prefix)
+			})
+
 			for _, entry := range prefixToSecret {
 				prefix := entry.prefix
 				secret := entry.secret
@@ -140,20 +147,20 @@ spec:
             drop:
             - ALL
         volumeMounts:
-        - mountPath: /tls
+` + volumeMounts + `        - mountPath: /tls
           name: tls-server-certificate
           readOnly: true
-` + volumeMounts + `      priorityClassName: some-priority-class
+      priorityClassName: some-priority-class
       securityContext:
         fsGroup: 65532
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
       volumes:
-      - name: tls-server-certificate
+` + volumes + `      - name: tls-server-certificate
         secret:
           secretName: ` + prefix + `istio-basic-auth-server
-` + volumes + `status: {}
+status: {}
 `
 		}
 		destinationRule = func(isGarden bool) string {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Avoids unnecessary updates and rollouts of the `istio-basic-auth-server` deployment by sorting the volumes and volume mounts.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ @LucaBernstein

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `istio-basic-auth-server` deployment procedure has been improved to prevent unnecessary rollouts.
```
