### PR TITLE
Allow skipping care health checks by care controller via annotation

### DIFF
--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -398,6 +398,12 @@ The following table explains which `ManagedResource`s are considered for which c
 |-------------------------------|----------------------------------------|
 | `SeedSystemComponentsHealthy` | `.spec.class` is set                   |
 
+`ManagedResource`s and `Prometheus`es can be temporarily excluded from condition aggregation by annotating them with `care.gardener.cloud/skip-health-checks-until=<RFC3339 timestamp>`.
+While the timestamp lies in the future, the care reconciler skips health checks for that resource and reports no failure for the respective condition, regardless of its actual status.
+An absent, malformed, or already-elapsed value is treated as if the annotation were not set.
+
+The reconciler automatically removes this annotation from any resource whose timestamp has expired.
+
 #### ["Lease" Reconciler](../../pkg/gardenlet/controller/seed/lease)
 
 This reconciler checks whether the connection to the seed cluster's `/healthz` endpoint works.
@@ -486,6 +492,14 @@ The following table explains which `ManagedResource`s are considered for which c
 | `ControlPlaneHealthy`            | `.spec.class=seed` and `care.gardener.cloud/condition-type` label either unset, or set to `ControlPlaneHealthy` |
 | `ObservabilityComponentsHealthy` | `care.gardener.cloud/condition-type` label set to `ObservabilityComponentsHealthy`                              |
 | `SystemComponentsHealthy`        | `.spec.class` unset or `care.gardener.cloud/condition-type` label set to `SystemComponentsHealthy`              |
+
+##### Skipping Individual Resources
+
+`Deployment`s, `Etcd`s, `ManagedResource`s, and `Prometheus`es can be temporarily excluded from condition aggregation by annotating them with `care.gardener.cloud/skip-health-checks-until=<RFC3339 timestamp>`.
+While the timestamp lies in the future, the care reconciler skips health checks for that resource and reports no failure for the respective condition, regardless of its actual status.
+An absent, malformed, or already-elapsed value is treated as if the annotation were not set.
+
+The reconciler automatically removes this annotation from any resource whose timestamp has expired.
 
 ##### Constraints And Automatic Webhook Remediation
 

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -550,6 +550,12 @@ The following table explains which `ManagedResource`s are considered for which c
 | `VirtualComponentsHealthy`       | `.spec.class` unset or `care.gardener.cloud/condition-type` label set to `VirtualComponentsHealthy`                  |
 | `ObservabilityComponentsHealthy` | `care.gardener.cloud/condition-type` label set to `ObservabilityComponentsHealthy`                                   |
 
+`Deployment`s, `Etcd`s, `ManagedResource`s, and `Prometheus`es can be temporarily excluded from condition aggregation by annotating them with `care.gardener.cloud/skip-health-checks-until=<RFC3339 timestamp>`.
+While the timestamp lies in the future, the care reconciler skips health checks for that resource and reports no failure for the respective condition, regardless of its actual status.
+An absent, malformed, or already-elapsed value is treated as if the annotation were not set.
+
+The reconciler automatically removes this annotation from any resource whose timestamp has expired.
+
 #### [`Reference` Reconciler](../../pkg/operator/controller/garden/reference)
 
 `Garden` objects may specify references to other objects in the Garden cluster which are required for certain features.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -823,6 +823,10 @@ const (
 	// LabelCareConditionType is a key for a label on a ManagedResource indicating to which condition type its status
 	// should be aggregated.
 	LabelCareConditionType = "care.gardener.cloud/condition-type"
+	// AnnotationCareSkipHealthChecksUntil is an annotation on individual resources (Deployment, Etcd,
+	// ManagedResource). When present and its RFC3339 value is a future timestamp, the care health checker skips
+	// this resource during condition aggregation. An invalid or past timestamp is treated as absent.
+	AnnotationCareSkipHealthChecksUntil = "care.gardener.cloud/skip-health-checks-until"
 	// ObservabilityComponentsHealthy is a constant for a condition type indicating the health of observability components.
 	ObservabilityComponentsHealthy = "ObservabilityComponentsHealthy"
 

--- a/pkg/component/gardener/dashboard/configmap.go
+++ b/pkg/component/gardener/dashboard/configmap.go
@@ -26,11 +26,10 @@ import (
 )
 
 const (
-	configMapNamePrefix       = "gardener-dashboard-config"
-	configMapAssetsNamePrefix = "gardener-dashboard-assets"
-	dataKeyConfig             = "config.yaml"
-	dataKeyFrontendConfig     = "frontend-config.yaml"
-	dataKeyLoginConfig        = "login-config.json"
+	configMapNamePrefix   = "gardener-dashboard-config"
+	dataKeyConfig         = "config.yaml"
+	dataKeyFrontendConfig = "frontend-config.yaml"
+	dataKeyLoginConfig    = "login-config.json"
 )
 
 func (g *gardenerDashboard) configMap(ctx context.Context) (*corev1.ConfigMap, error) {

--- a/pkg/gardenlet/controller/seed/care/health.go
+++ b/pkg/gardenlet/controller/seed/care/health.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -19,6 +20,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	commonprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 	"github.com/gardener/gardener/pkg/features"
+	kuberneteshealth "github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	healthchecker "github.com/gardener/gardener/pkg/utils/kubernetes/health/checker"
 )
 
@@ -53,6 +55,8 @@ func (h *health) Check(
 	ctx context.Context,
 	conditions SeedConditions,
 ) []gardencorev1beta1.Condition {
+	log := logf.FromContext(ctx)
+
 	managedResources, err := h.listManagedResources(ctx)
 	if err != nil {
 		conditions.systemComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.systemComponentsHealthy, nil, err)
@@ -64,6 +68,14 @@ func (h *health) Check(
 		conditions.systemComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.systemComponentsHealthy, nil, err)
 		return conditions.ConvertToSlice()
 	}
+
+	kuberneteshealth.RemoveExpiredSkipAnnotations(ctx, log, h.seedClient, ptr.Deref(h.namespace, v1beta1constants.GardenNamespace),
+		monitoringv1.SchemeGroupVersion.WithKind("PrometheusList"),
+		resourcesv1alpha1.SchemeGroupVersion.WithKind("ManagedResourceList"),
+	)
+	kuberneteshealth.RemoveExpiredSkipAnnotations(ctx, log, h.seedClient, ptr.Deref(h.namespace, v1beta1constants.IstioSystemNamespace),
+		resourcesv1alpha1.SchemeGroupVersion.WithKind("ManagedResourceList"),
+	)
 
 	var checkedConditions []gardencorev1beta1.Condition
 	checkedConditions = append(checkedConditions, v1beta1helper.NewConditionOrError(h.clock, conditions.systemComponentsHealthy, h.checkSystemComponents(ctx, conditions.systemComponentsHealthy, managedResources, prometheuses), nil))

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	druidcorev1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -175,6 +176,13 @@ func (h *Health) Check(
 			return nil
 		})
 	}
+
+	health.RemoveExpiredSkipAnnotations(ctx, h.log, h.seedClient.Client(), h.shoot.ControlPlaneNamespace,
+		appsv1.SchemeGroupVersion.WithKind("DeploymentList"),
+		druidcorev1alpha1.SchemeGroupVersion.WithKind("EtcdList"),
+		resourcesv1alpha1.SchemeGroupVersion.WithKind("ManagedResourceList"),
+		monitoringv1.SchemeGroupVersion.WithKind("PrometheusList"),
+	)
 
 	// Health checks with dependencies to the Kube-Apiserver.
 	shootClient, apiServerRunning, err := h.initializeShootClients()

--- a/pkg/operator/controller/garden/care/health.go
+++ b/pkg/operator/controller/garden/care/health.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"time"
 
+	druidcorev1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -98,6 +100,17 @@ func (h *health) Check(ctx context.Context, conditions GardenConditions) []garde
 			return nil
 		})
 	}
+
+	log := logf.FromContext(ctx)
+	kuberneteshealth.RemoveExpiredSkipAnnotations(ctx, log, h.runtimeClient, h.gardenNamespace,
+		appsv1.SchemeGroupVersion.WithKind("DeploymentList"),
+		druidcorev1alpha1.SchemeGroupVersion.WithKind("EtcdList"),
+		monitoringv1.SchemeGroupVersion.WithKind("PrometheusList"),
+		resourcesv1alpha1.SchemeGroupVersion.WithKind("ManagedResourceList"),
+	)
+	kuberneteshealth.RemoveExpiredSkipAnnotations(ctx, log, h.runtimeClient, v1beta1constants.IstioSystemNamespace,
+		resourcesv1alpha1.SchemeGroupVersion.WithKind("ManagedResourceList"),
+	)
 
 	_ = flow.Parallel(taskFns...)(ctx)
 

--- a/pkg/utils/kubernetes/health/checker/checker.go
+++ b/pkg/utils/kubernetes/health/checker/checker.go
@@ -121,6 +121,10 @@ func (h *HealthChecker) checkRequiredDeployments(condition gardencorev1beta1.Con
 
 func (h *HealthChecker) checkDeployments(condition gardencorev1beta1.Condition, objects []appsv1.Deployment) *gardencorev1beta1.Condition {
 	for _, object := range objects {
+		if health.IsSkippedUntil(&object.ObjectMeta) {
+			return nil
+		}
+
 		if err := health.CheckDeployment(&object); err != nil {
 			c := v1beta1helper.FailedCondition(h.clock, h.lastOperation, h.conditionThresholds, condition, "DeploymentUnhealthy", fmt.Sprintf("Deployment %q is unhealthy: %v", object.Name, err.Error()))
 			return &c
@@ -141,6 +145,10 @@ func (h *HealthChecker) checkRequiredEtcds(condition gardencorev1beta1.Condition
 
 func (h *HealthChecker) checkEtcds(condition gardencorev1beta1.Condition, objects []druidcorev1alpha1.Etcd) *gardencorev1beta1.Condition {
 	for _, object := range objects {
+		if health.IsSkippedUntil(&object.ObjectMeta) {
+			return nil
+		}
+
 		if err := health.CheckEtcd(&object); err != nil {
 			var (
 				message = fmt.Sprintf("Etcd extension resource %q is unhealthy: %v", object.Name, err.Error())
@@ -272,6 +280,10 @@ func (h *HealthChecker) CheckManagedResources(
 	for _, managedResource := range managedResources {
 		if !filterFunc(managedResource) {
 			continue
+		}
+
+		if health.IsSkippedUntil(&managedResource.ObjectMeta) {
+			return nil
 		}
 
 		if exitCondition := h.CheckManagedResource(condition, &managedResource, progressingThreshold); exitCondition != nil {
@@ -602,6 +614,10 @@ func (h *HealthChecker) CheckPrometheuses(
 	)
 
 	for i, prometheus := range prometheusesSorted.Items {
+		if health.IsSkippedUntil(&prometheus.ObjectMeta) {
+			return nil
+		}
+
 		if filterFunc != nil && !filterFunc(&prometheus) {
 			continue
 		}

--- a/pkg/utils/kubernetes/health/checker/checker_test.go
+++ b/pkg/utils/kubernetes/health/checker/checker_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	druidcorev1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	. "github.com/gardener/gardener/pkg/utils/kubernetes/health/checker"
+	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -253,6 +255,38 @@ var _ = Describe("HealthChecker", func() {
 				PointTo(beConditionWithFalseStatusReasonAndMsg("Unknown", "bar is unknown"))),
 		)
 
+		Describe("#CheckManagedResources", func() {
+			It("should skip unhealthy managed resource with future skip annotation", func() {
+				DeferCleanup(test.WithVar(&health.Clock, fakeClock))
+
+				checker := NewHealthChecker(log, fakeClient, fakeClock)
+
+				skipped := resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "skipped",
+						Annotations: map[string]string{
+							v1beta1constants.AnnotationCareSkipHealthChecksUntil: fakeClock.Now().Add(10 * time.Minute).Format(time.RFC3339),
+						},
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						Conditions: []gardencorev1beta1.Condition{
+							{Type: resourcesv1alpha1.ResourcesHealthy, Status: gardencorev1beta1.ConditionFalse, Reason: "Broken"},
+							{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionFalse, Reason: "Broken"},
+							{Type: resourcesv1alpha1.ResourcesProgressing, Status: gardencorev1beta1.ConditionFalse, Reason: "Broken"},
+						},
+					},
+				}
+
+				exitCondition := checker.CheckManagedResources(
+					condition,
+					[]resourcesv1alpha1.ManagedResource{skipped},
+					func(resourcesv1alpha1.ManagedResource) bool { return true },
+					nil,
+				)
+				Expect(exitCondition).To(BeNil())
+			})
+		})
+
 		var (
 			eventLoggerDepployment = newDeployment(namespace, v1beta1constants.DeploymentNameEventLogger, v1beta1constants.GardenRoleLogging, true)
 
@@ -295,6 +329,21 @@ var _ = Describe("HealthChecker", func() {
 				BeNil(),
 			),
 		)
+
+		It("should skip unhealthy deployment with future skip annotation", func() {
+			DeferCleanup(test.WithVar(&health.Clock, fakeClock))
+
+			unhealthyDeployment := newDeployment(namespace, v1beta1constants.DeploymentNameEventLogger, v1beta1constants.GardenRoleLogging, false)
+			unhealthyDeployment.Annotations = map[string]string{
+				v1beta1constants.AnnotationCareSkipHealthChecksUntil: fakeClock.Now().Add(10 * time.Minute).Format(time.RFC3339),
+			}
+			Expect(fakeClient.Create(ctx, unhealthyDeployment)).To(Succeed())
+
+			checker := NewHealthChecker(log, fakeClient, fakeClock)
+			exitCondition, err := checker.CheckLoggingControlPlane(ctx, namespace, true, condition)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exitCondition).To(BeNil())
+		})
 
 		// CheckExtensionCondition
 		DescribeTable("#CheckExtensionCondition - HealthCheckReport",
@@ -472,6 +521,38 @@ var _ = Describe("HealthChecker", func() {
 				},
 				PointTo(beConditionWithStatus(gardencorev1beta1.ConditionFalse))),
 		)
+
+		It("should skip unhealthy etcd with future skip annotation", func() {
+			DeferCleanup(test.WithVar(&health.Clock, fakeClock))
+
+			unhealthyEtcd := &druidcorev1alpha1.Etcd{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "etcd-main",
+					Namespace: namespace,
+					Labels: map[string]string{
+						v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
+					},
+					Annotations: map[string]string{
+						v1beta1constants.AnnotationCareSkipHealthChecksUntil: fakeClock.Now().Add(10 * time.Minute).Format(time.RFC3339),
+					},
+				},
+				Status: druidcorev1alpha1.EtcdStatus{
+					Ready: new(false),
+				},
+			}
+			Expect(fakeClient.Create(ctx, unhealthyEtcd)).To(Succeed())
+
+			checker := NewHealthChecker(log, fakeClient, fakeClock)
+			exitCondition, err := checker.CheckControlPlane(
+				ctx,
+				namespace,
+				sets.New[string](),
+				sets.New[string](),
+				condition,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exitCondition).To(BeNil())
+		})
 
 		DescribeTable("#CheckControllerInstallation",
 			func(conditions []gardencorev1beta1.Condition, upToDate bool, stepTime bool, conditionMatcher types.GomegaMatcher) {
@@ -887,6 +968,21 @@ var _ = Describe("HealthChecker", func() {
 				}
 
 				prometheuses.Items[0].Spec.Replicas = new(int32(0))
+				result := healthChecker.CheckPrometheuses(ctx, condition, prometheuses, filterTrueFunc)
+				Expect(result).To(BeNil())
+			})
+
+			It("should skip unhealthy prometheus with future skip annotation", func() {
+				DeferCleanup(test.WithVar(&health.Clock, fakeClock))
+
+				testPrometheusHealthChecker = func(_ context.Context, _ string, _ int) (health.PrometheusHealthCheckResult, error) {
+					return unhealthy()
+				}
+
+				prometheuses.Items[0].Annotations = map[string]string{
+					v1beta1constants.AnnotationCareSkipHealthChecksUntil: fakeClock.Now().Add(10 * time.Minute).Format(time.RFC3339),
+				}
+
 				result := healthChecker.CheckPrometheuses(ctx, condition, prometheuses, filterTrueFunc)
 				Expect(result).To(BeNil())
 			})

--- a/pkg/utils/kubernetes/health/checker/checker_test.go
+++ b/pkg/utils/kubernetes/health/checker/checker_test.go
@@ -282,6 +282,7 @@ var _ = Describe("HealthChecker", func() {
 					[]resourcesv1alpha1.ManagedResource{skipped},
 					func(resourcesv1alpha1.ManagedResource) bool { return true },
 					nil,
+					nil,
 				)
 				Expect(exitCondition).To(BeNil())
 			})

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -6,10 +6,14 @@ package health
 
 import (
 	"fmt"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
 func requiredConditionMissing(conditionType string) error {
@@ -41,3 +45,20 @@ func ObjectHasAnnotationWithValue(key, value string) Func {
 
 // ConditionerFunc to update a condition with type and message
 type conditionerFunc func(conditionType string, message string) gardencorev1beta1.Condition
+
+// Clock is an alias for the clock.Clock interface, which is used to get the current time. Exposed for tests.
+var Clock clock.Clock = clock.RealClock{}
+
+// IsSkippedUntil returns true when obj carries the AnnotationCareSkipHealthChecksUntil annotation
+// with a valid RFC3339 timestamp that lies in the future. An absent, invalid, or past value returns false.
+func IsSkippedUntil(obj metav1.Object) bool {
+	val, ok := obj.GetAnnotations()[v1beta1constants.AnnotationCareSkipHealthChecksUntil]
+	if !ok {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, val)
+	if err != nil {
+		return false
+	}
+	return Clock.Now().Before(t)
+}

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -5,15 +5,19 @@
 package health
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils/flow"
 )
 
 func requiredConditionMissing(conditionType string) error {
@@ -61,4 +65,39 @@ func IsSkippedUntil(obj metav1.Object) bool {
 		return false
 	}
 	return Clock.Now().Before(t)
+}
+
+// RemoveExpiredSkipAnnotations lists all resources of the given GVKs (which must be list kinds, e.g.
+// appsv1.SchemeGroupVersion.WithKind("DeploymentList")) in namespace using partial metadata and removes the
+// AnnotationCareSkipHealthChecksUntil annotation from any object whose timestamp has already passed.
+func RemoveExpiredSkipAnnotations(ctx context.Context, log logr.Logger, c client.Client, namespace string, gvks ...schema.GroupVersionKind) {
+	tasks := make([]flow.TaskFn, 0, len(gvks))
+	for _, gvk := range gvks {
+		tasks = append(tasks, func(ctx context.Context) error {
+			list := &metav1.PartialObjectMetadataList{}
+			list.SetGroupVersionKind(gvk)
+			if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
+				log.Error(err, "Failed to list resources for skip annotation cleanup", "gvk", gvk)
+				return nil
+			}
+			for i := range list.Items {
+				item := &list.Items[i]
+				val, ok := item.Annotations[v1beta1constants.AnnotationCareSkipHealthChecksUntil]
+				if !ok {
+					continue
+				}
+				t, err := time.Parse(time.RFC3339, val)
+				if err != nil || Clock.Now().Before(t) {
+					continue
+				}
+				patch := client.MergeFrom(item.DeepCopy())
+				delete(item.Annotations, v1beta1constants.AnnotationCareSkipHealthChecksUntil)
+				if err := c.Patch(ctx, item, patch); err != nil {
+					log.Error(err, "Failed to remove expired skip-health-checks annotation", "object", client.ObjectKeyFromObject(item))
+				}
+			}
+			return nil
+		})
+	}
+	_ = flow.Parallel(tasks...)(ctx)
 }

--- a/pkg/utils/kubernetes/health/health_test.go
+++ b/pkg/utils/kubernetes/health/health_test.go
@@ -5,15 +5,24 @@
 package health_test
 
 import (
+	"context"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	druidcorev1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
@@ -58,8 +67,11 @@ var _ = Describe("health", func() {
 		})
 	})
 
-	DescribeTable("#IsSkippedUntil", func(annotations map[string]string, expected bool) {
+	BeforeEach(func() {
 		DeferCleanup(test.WithVar(&health.Clock, fakeClock))
+	})
+
+	DescribeTable("#IsSkippedUntil", func(annotations map[string]string, expected bool) {
 
 		skipped := health.IsSkippedUntil(&metav1.ObjectMeta{
 			Annotations: annotations,
@@ -75,4 +87,163 @@ var _ = Describe("health", func() {
 		Entry("invalid RFC3339: not skipped",
 			map[string]string{v1beta1constants.AnnotationCareSkipHealthChecksUntil: "not-a-timestamp"}, false),
 	)
+
+	Describe("#RemoveExpiredSkipAnnotations", func() {
+		var (
+			ctx        = context.TODO()
+			fakeClient client.Client
+			namespace  = "test-namespace"
+			deploy     *appsv1.Deployment
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+			deploy = &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deploy",
+					Namespace: namespace,
+				},
+			}
+		})
+
+		It("should do nothing when there are no objects", func() {
+			health.RemoveExpiredSkipAnnotations(ctx, logr.Discard(), fakeClient, namespace,
+				appsv1.SchemeGroupVersion.WithKind("DeploymentList"),
+			)
+		})
+
+		It("should not patch object without annotation", func() {
+			Expect(fakeClient.Create(ctx, deploy)).To(Succeed())
+
+			health.RemoveExpiredSkipAnnotations(ctx, logr.Discard(), fakeClient, namespace,
+				appsv1.SchemeGroupVersion.WithKind("DeploymentList"),
+			)
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(Succeed())
+			Expect(deploy.Annotations).NotTo(HaveKey(v1beta1constants.AnnotationCareSkipHealthChecksUntil))
+		})
+
+		It("should preserve annotation when timestamp is in the future", func() {
+			metav1.SetMetaDataAnnotation(&deploy.ObjectMeta, v1beta1constants.AnnotationCareSkipHealthChecksUntil,
+				fakeClock.Now().Add(10*time.Minute).Format(time.RFC3339))
+			Expect(fakeClient.Create(ctx, deploy)).To(Succeed())
+
+			health.RemoveExpiredSkipAnnotations(ctx, logr.Discard(), fakeClient, namespace,
+				appsv1.SchemeGroupVersion.WithKind("DeploymentList"),
+			)
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(Succeed())
+			Expect(deploy.Annotations).To(HaveKey(v1beta1constants.AnnotationCareSkipHealthChecksUntil))
+		})
+
+		It("should remove annotation when timestamp has passed", func() {
+			metav1.SetMetaDataAnnotation(&deploy.ObjectMeta, v1beta1constants.AnnotationCareSkipHealthChecksUntil,
+				fakeClock.Now().Add(-1*time.Minute).Format(time.RFC3339))
+			Expect(fakeClient.Create(ctx, deploy)).To(Succeed())
+
+			health.RemoveExpiredSkipAnnotations(ctx, logr.Discard(), fakeClient, namespace,
+				appsv1.SchemeGroupVersion.WithKind("DeploymentList"),
+			)
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(Succeed())
+			Expect(deploy.Annotations).NotTo(HaveKey(v1beta1constants.AnnotationCareSkipHealthChecksUntil))
+		})
+
+		It("should preserve annotation when timestamp is not valid RFC3339", func() {
+			metav1.SetMetaDataAnnotation(&deploy.ObjectMeta, v1beta1constants.AnnotationCareSkipHealthChecksUntil, "not-a-timestamp")
+			Expect(fakeClient.Create(ctx, deploy)).To(Succeed())
+
+			health.RemoveExpiredSkipAnnotations(ctx, logr.Discard(), fakeClient, namespace,
+				appsv1.SchemeGroupVersion.WithKind("DeploymentList"),
+			)
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(Succeed())
+			Expect(deploy.Annotations).To(HaveKey(v1beta1constants.AnnotationCareSkipHealthChecksUntil))
+		})
+
+		It("should only remove expired annotations, leaving future ones intact", func() {
+			expiredDeploy := deploy
+			metav1.SetMetaDataAnnotation(&expiredDeploy.ObjectMeta, v1beta1constants.AnnotationCareSkipHealthChecksUntil,
+				fakeClock.Now().Add(-1*time.Minute).Format(time.RFC3339))
+			Expect(fakeClient.Create(ctx, expiredDeploy)).To(Succeed())
+
+			deploy2 := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deploy-2",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						v1beta1constants.AnnotationCareSkipHealthChecksUntil: fakeClock.Now().Add(10 * time.Minute).Format(time.RFC3339),
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, deploy2)).To(Succeed())
+
+			health.RemoveExpiredSkipAnnotations(ctx, logr.Discard(), fakeClient, namespace,
+				appsv1.SchemeGroupVersion.WithKind("DeploymentList"),
+			)
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expiredDeploy), expiredDeploy)).To(Succeed())
+			Expect(expiredDeploy.Annotations).NotTo(HaveKey(v1beta1constants.AnnotationCareSkipHealthChecksUntil))
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deploy2), deploy2)).To(Succeed())
+			Expect(deploy2.Annotations).To(HaveKey(v1beta1constants.AnnotationCareSkipHealthChecksUntil))
+		})
+
+		It("should process multiple GVKs in parallel", func() {
+			expiredAnnotation := map[string]string{
+				v1beta1constants.AnnotationCareSkipHealthChecksUntil: fakeClock.Now().Add(-1 * time.Minute).Format(time.RFC3339),
+			}
+
+			metav1.SetMetaDataAnnotation(&deploy.ObjectMeta, v1beta1constants.AnnotationCareSkipHealthChecksUntil,
+				fakeClock.Now().Add(-1*time.Minute).Format(time.RFC3339))
+			Expect(fakeClient.Create(ctx, deploy)).To(Succeed())
+
+			prometheus := &monitoringv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-prometheus", Namespace: namespace, Annotations: expiredAnnotation},
+			}
+			Expect(fakeClient.Create(ctx, prometheus)).To(Succeed())
+
+			etcd := &druidcorev1alpha1.Etcd{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-etcd", Namespace: namespace, Annotations: expiredAnnotation},
+			}
+			Expect(fakeClient.Create(ctx, etcd)).To(Succeed())
+
+			mr := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mr", Namespace: namespace, Annotations: expiredAnnotation},
+			}
+			Expect(fakeClient.Create(ctx, mr)).To(Succeed())
+
+			health.RemoveExpiredSkipAnnotations(ctx, logr.Discard(), fakeClient, namespace,
+				appsv1.SchemeGroupVersion.WithKind("DeploymentList"),
+				druidcorev1alpha1.SchemeGroupVersion.WithKind("EtcdList"),
+				monitoringv1.SchemeGroupVersion.WithKind("PrometheusList"),
+				resourcesv1alpha1.SchemeGroupVersion.WithKind("ManagedResourceList"),
+			)
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(Succeed())
+			Expect(deploy.Annotations).NotTo(HaveKey(v1beta1constants.AnnotationCareSkipHealthChecksUntil))
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(prometheus), prometheus)).To(Succeed())
+			Expect(prometheus.Annotations).NotTo(HaveKey(v1beta1constants.AnnotationCareSkipHealthChecksUntil))
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+			Expect(etcd.Annotations).NotTo(HaveKey(v1beta1constants.AnnotationCareSkipHealthChecksUntil))
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(mr), mr)).To(Succeed())
+			Expect(mr.Annotations).NotTo(HaveKey(v1beta1constants.AnnotationCareSkipHealthChecksUntil))
+		})
+
+		It("should not affect objects in a different namespace", func() {
+			metav1.SetMetaDataAnnotation(&deploy.ObjectMeta, v1beta1constants.AnnotationCareSkipHealthChecksUntil,
+				fakeClock.Now().Add(-1*time.Minute).Format(time.RFC3339))
+			Expect(fakeClient.Create(ctx, deploy)).To(Succeed())
+
+			health.RemoveExpiredSkipAnnotations(ctx, logr.Discard(), fakeClient, "other-namespace",
+				appsv1.SchemeGroupVersion.WithKind("DeploymentList"),
+			)
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(Succeed())
+			Expect(deploy.Annotations).To(HaveKey(v1beta1constants.AnnotationCareSkipHealthChecksUntil))
+		})
+	})
 })

--- a/pkg/utils/kubernetes/health/health_test.go
+++ b/pkg/utils/kubernetes/health/health_test.go
@@ -5,15 +5,24 @@
 package health_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclock "k8s.io/utils/clock/testing"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("health", func() {
+	var (
+		fakeClock = testclock.NewFakeClock(time.Now())
+	)
+
 	Describe("ObjectHasAnnotationWithValue", func() {
 		var (
 			healthFunc health.Func
@@ -48,4 +57,22 @@ var _ = Describe("health", func() {
 			})).To(Succeed())
 		})
 	})
+
+	DescribeTable("#IsSkippedUntil", func(annotations map[string]string, expected bool) {
+		DeferCleanup(test.WithVar(&health.Clock, fakeClock))
+
+		skipped := health.IsSkippedUntil(&metav1.ObjectMeta{
+			Annotations: annotations,
+		})
+
+		Expect(skipped).To(Equal(expected))
+	},
+		Entry("no annotation: not skipped", nil, false),
+		Entry("future timestamp: skipped",
+			map[string]string{v1beta1constants.AnnotationCareSkipHealthChecksUntil: fakeClock.Now().Add(1 * time.Hour).Format(time.RFC3339)}, true),
+		Entry("past timestamp: not skipped",
+			map[string]string{v1beta1constants.AnnotationCareSkipHealthChecksUntil: fakeClock.Now().Add(-1 * time.Hour).Format(time.RFC3339)}, false),
+		Entry("invalid RFC3339: not skipped",
+			map[string]string{v1beta1constants.AnnotationCareSkipHealthChecksUntil: "not-a-timestamp"}, false),
+	)
 })

--- a/pkg/utils/kubernetes/health/health_test.go
+++ b/pkg/utils/kubernetes/health/health_test.go
@@ -8,11 +8,11 @@ import (
 	"context"
 	"time"
 
+	druidcorev1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	druidcorev1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclock "k8s.io/utils/clock/testing"

--- a/pkg/utils/kubernetes/health/managedresource.go
+++ b/pkg/utils/kubernetes/health/managedresource.go
@@ -15,6 +15,10 @@ import (
 // CheckManagedResource checks if all conditions of a ManagedResource ('ResourcesApplied' and 'ResourcesHealthy')
 // are True and .status.observedGeneration matches the current .metadata.generation
 func CheckManagedResource(mr *resourcesv1alpha1.ManagedResource) error {
+	if IsSkippedUntil(&mr.ObjectMeta) {
+		return nil
+	}
+
 	if err := CheckManagedResourceApplied(mr); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Introduces a `care.gardener.cloud/skip-health-checks-until` annotation that operators can place on individual resources (Deployments, Etcds, Prometheuses, ManagedResources) to suppress health check failures until a given RFC3339 timestamp. Once the timestamp passes, the annotation is removed automatically.

The garden, shoot, and seed care controllers will ignore the resources they are responsible for if the resource has the said annotation.

**Usage**:
To skip health-check failures for a deployment until a certain time period:
`kubectl annotate managedresource <name> care.gardener.cloud/skip-health-checks-until="2026-07-04T06:00:00Z"`
The annotation is removed automatically once the timestamp passes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Operators can now annotate individual resources (Deployments, Etcds, Prometheuses, ManagedResources) which are health checked by the care controllers (garden, seed, shoot) with `care.gardener.cloud/skip-health-checks-until: <RFC3339 timestamp>` to suppress health-check failures until the given time. The annotation is removed automatically once the timestamp passes.
```
