### PR TITLE
Cap parallel Skaffold builds during Gardener e2e upgrade

### DIFF
--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -72,6 +72,14 @@ function install_previous_release() {
 }
 
 function upgrade_to_next_release() {
+  # Cap parallel Skaffold builds during the upgrade to avoid starving the kind host.
+  # `make gardener-up` builds all Gardener artifacts with SKAFFOLD_BUILD_CONCURRENCY=0 (unlimited) by default.
+  # In HA test setups, this saturated the host so heavily that kubelet housekeeping stalled for >2 minutes
+  # and all shoot kube-apiserver replicas simultaneously failed their liveness probes, tripping the
+  # zero-downtime validator. Limiting concurrency
+  # keeps enough headroom for the running shoot control planes during the rolling update.
+  export SKAFFOLD_BUILD_CONCURRENCY=4
+
   # downloads and upgrades to GARDENER_NEXT_RELEASE release if GARDENER_NEXT_RELEASE is not same as version mentioned in VERSION file.
   # if GARDENER_NEXT_RELEASE is same as version mentioned in VERSION file then it is considered as local release and install gardener from local repo.
   if [[ -n $GARDENER_NEXT_RELEASE && $GARDENER_NEXT_RELEASE != $VERSION ]]; then


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind test

**What this PR does / why we need it**:
Cap parallel Skaffold builds during Gardener e2e upgrade to prevent flake.

See Motivation - https://github.com/gardener/gardener/pull/15177#issuecomment-4874865114

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
