### PR TITLE
Improve startup performance of `istio-cluster-configuration` & `networkpolicy` controllers

### DIFF
--- a/pkg/resourcemanager/controller/add.go
+++ b/pkg/resourcemanager/controller/add.go
@@ -70,7 +70,7 @@ func AddToManager(ctx context.Context, mgr manager.Manager, sourceCluster, targe
 	if cfg.Controllers.NetworkPolicy.Enabled {
 		if err := (&networkpolicy.Reconciler{
 			Config: cfg.Controllers.NetworkPolicy,
-		}).AddToManager(mgr, targetCluster); err != nil {
+		}).AddToManager(ctx, mgr, targetCluster); err != nil {
 			return fmt.Errorf("failed adding networkpolicy controller: %w", err)
 		}
 	}

--- a/pkg/resourcemanager/controller/add.go
+++ b/pkg/resourcemanager/controller/add.go
@@ -78,7 +78,7 @@ func AddToManager(ctx context.Context, mgr manager.Manager, sourceCluster, targe
 	if cfg.Controllers.IstioClusterConfiguration.Enabled {
 		if err := (&istioclusterconfiguration.Reconciler{
 			Config: cfg.Controllers.IstioClusterConfiguration,
-		}).AddToManager(mgr, targetCluster); err != nil {
+		}).AddToManager(ctx, mgr, targetCluster); err != nil {
 			return fmt.Errorf("failed adding istio cluster configuration controller: %w", err)
 		}
 	}

--- a/pkg/resourcemanager/controller/istioclusterconfiguration/add.go
+++ b/pkg/resourcemanager/controller/istioclusterconfiguration/add.go
@@ -39,7 +39,9 @@ import (
 const ControllerName = "istio-cluster-configuration"
 
 // AddToManager adds Reconciler to the given manager.
-func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Cluster) error {
+func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, targetCluster cluster.Cluster) error {
+	logger := mgr.GetLogger().WithValues("controller", ControllerName)
+
 	if r.TargetClient == nil {
 		r.TargetClient = targetCluster.GetClient()
 	}
@@ -53,9 +55,16 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Clu
 		if !meta.IsNoMatchError(err) {
 			return err
 		}
-		mgr.GetLogger().WithValues("controller", ControllerName).Info("No watches will be added because Istio CRDs are not installed")
+		logger.Info("No watches will be added because Istio CRDs are not installed")
 		return nil
 	}
+
+	go func() {
+		if mgr.GetCache().WaitForCacheSync(ctx) {
+			r.CacheSynced = true
+			logger.Info("Cache is synced. Controller starts handling service create events")
+		}
+	}()
 
 	_, err = builder.
 		ControllerManagedBy(mgr).
@@ -182,8 +191,11 @@ func (r *Reconciler) DestinationRulePredicate() predicate.Predicate {
 // ServicePredicate filters Service events to port name changes.
 func (r *Reconciler) ServicePredicate() predicate.Predicate {
 	return predicate.Funcs{
-		CreateFunc: func(_ event.CreateEvent) bool { return true },
-		DeleteFunc: func(_ event.DeleteEvent) bool { return true },
+		// MapServiceToNamespaces is expensive so we enqueue based on create events only after the caches are synced to
+		// avoid cache sync timeouts. When the controller is starting all namespaces will be enqueued by
+		// DestinationRules anyway. We do not want to skip create events while the controller is running because a
+		// Service might be created after a DestinationRule.
+		CreateFunc: func(_ event.CreateEvent) bool { return r.CacheSynced },
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			newService, ok := e.ObjectNew.(*corev1.Service)
 			if !ok {

--- a/pkg/resourcemanager/controller/istioclusterconfiguration/add_test.go
+++ b/pkg/resourcemanager/controller/istioclusterconfiguration/add_test.go
@@ -148,7 +148,12 @@ var _ = Describe("Add", func() {
 		})
 
 		Describe("#Create", func() {
-			It("should return true", func() {
+			It("should return false when the cache is not synced yet", func() {
+				Expect(pred.Create(event.CreateEvent{Object: service})).To(BeFalse())
+			})
+
+			It("should return true once the cache is synced", func() {
+				reconciler.CacheSynced = true
 				Expect(pred.Create(event.CreateEvent{Object: service})).To(BeTrue())
 			})
 		})

--- a/pkg/resourcemanager/controller/istioclusterconfiguration/reconciler.go
+++ b/pkg/resourcemanager/controller/istioclusterconfiguration/reconciler.go
@@ -51,6 +51,7 @@ const (
 type Reconciler struct {
 	TargetClient client.Client
 	Config       resourcemanagerconfigv1alpha1.IstioClusterConfigurationControllerConfig
+	CacheSynced  bool
 }
 
 // Reconcile performs the reconciliation for a source namespace containing DestinationRules.

--- a/pkg/resourcemanager/controller/networkpolicy/add.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add.go
@@ -47,7 +47,9 @@ import (
 const ControllerName = "networkpolicy"
 
 // AddToManager adds Reconciler to the given manager.
-func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Cluster) error {
+func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, targetCluster cluster.Cluster) error {
+	logger := mgr.GetLogger().WithValues("controller", ControllerName)
+
 	if r.TargetClient == nil {
 		r.TargetClient = targetCluster.GetClient()
 	}
@@ -104,18 +106,25 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Clu
 		WatchesRawSource(source.Kind[client.Object](
 			targetCluster.GetCache(),
 			namespace,
-			r.EventHandlerForNamespace(mgr.GetLogger().WithValues("controller", ControllerName)),
+			r.EventHandlerForNamespace(logger),
 		)).
 		WatchesRawSource(source.Kind[client.Object](
 			targetCluster.GetCache(),
 			pod,
-			r.EventHandlerForPod(mgr.GetLogger().WithValues("controller", ControllerName)),
+			r.EventHandlerForPod(logger),
 			r.PodPredicate(),
 		)).
 		Build(r)
 	if err != nil {
 		return err
 	}
+
+	go func() {
+		if targetCluster.GetCache().WaitForCacheSync(ctx) {
+			r.CacheSynced = true
+			logger.Info("Cache is synced. Controller starts handling pod create events")
+		}
+	}()
 
 	if r.Config.IngressControllerSelector != nil {
 		if err := c.Watch(source.Kind[client.Object](
@@ -137,7 +146,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Clu
 		if !meta.IsNoMatchError(err) {
 			return err
 		}
-		mgr.GetLogger().WithValues("controller", ControllerName).Info("VirtualService watch will not be added because Istio CRDs are not installed")
+		logger.Info("VirtualService watch will not be added because Istio CRDs are not installed")
 		return nil
 	}
 	r.istioCRDsFound = true
@@ -368,8 +377,11 @@ func (r *Reconciler) MapIngressToServices(_ context.Context, obj client.Object) 
 // PodPredicate returns a predicate which filters for pods with `networking.resources.gardener.cloud/to-*` labels.
 func (r *Reconciler) PodPredicate() predicate.Predicate {
 	return predicate.Funcs{
+		// EventHandlerForPod is expensive so we enqueue based on create events only after the caches are synced to
+		// avoid cache sync timeouts. When the controller is starting all namespaces will be enqueued by
+		// Services anyway.
 		CreateFunc: func(e event.CreateEvent) bool {
-			return hasNetworkPolicyToLabels(e.Object.GetLabels())
+			return r.CacheSynced && hasNetworkPolicyToLabels(e.Object.GetLabels())
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return !maps.Equal(getNetworkPolicyToLabels(e.ObjectOld.GetLabels()), getNetworkPolicyToLabels(e.ObjectNew.GetLabels()))

--- a/pkg/resourcemanager/controller/networkpolicy/add.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add.go
@@ -378,8 +378,7 @@ func (r *Reconciler) MapIngressToServices(_ context.Context, obj client.Object) 
 func (r *Reconciler) PodPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		// EventHandlerForPod is expensive so we enqueue based on create events only after the caches are synced to
-		// avoid cache sync timeouts. When the controller is starting all namespaces will be enqueued by
-		// Services anyway.
+		// avoid cache sync timeouts. When the controller is starting pods will be considered by services anyway.
 		CreateFunc: func(e event.CreateEvent) bool {
 			return r.CacheSynced && hasNetworkPolicyToLabels(e.Object.GetLabels())
 		},

--- a/pkg/resourcemanager/controller/networkpolicy/add_test.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add_test.go
@@ -441,14 +441,21 @@ var _ = Describe("Add", func() {
 		})
 
 		Describe("#Create", func() {
-			It("should return false for pod without netpol labels", func() {
+			It("should return false for pod without netpol labels when cache is synced", func() {
+				reconciler.CacheSynced = true
 				pod.Labels = map[string]string{"app": "foo"}
 				Expect(p.Create(event.CreateEvent{Object: pod})).To(BeFalse())
 			})
 
-			It("should return true for pod with netpol to-label", func() {
+			It("should return true for pod with netpol to-label when cache is synced", func() {
+				reconciler.CacheSynced = true
 				pod.Labels = map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"}
 				Expect(p.Create(event.CreateEvent{Object: pod})).To(BeTrue())
+			})
+
+			It("should return false for pod with netpol to-label when cache is not synced", func() {
+				pod.Labels = map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"}
+				Expect(p.Create(event.CreateEvent{Object: pod})).To(BeFalse())
 			})
 		})
 

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -42,6 +42,7 @@ type Reconciler struct {
 	TargetClient client.Client
 	Config       resourcemanagerconfigv1alpha1.NetworkPolicyControllerConfig
 	Recorder     events.EventRecorder
+	CacheSynced  bool
 
 	selectors      []labels.Selector
 	istioCRDsFound bool

--- a/test/integration/resourcemanager/istioclusterconfiguration/istioclusterconfiguration_suite_test.go
+++ b/test/integration/resourcemanager/istioclusterconfiguration/istioclusterconfiguration_suite_test.go
@@ -86,7 +86,7 @@ var _ = BeforeSuite(func() {
 			Enabled:         true,
 			ConcurrentSyncs: new(5),
 		},
-	}).AddToManager(mgr, mgr)).To(Succeed())
+	}).AddToManager(ctx, mgr, mgr)).To(Succeed())
 
 	Expect((&namespacefinalizer.Reconciler{}).AddToManager(mgr)).To(Succeed())
 

--- a/test/integration/resourcemanager/networkpolicy/networkpolicy_suite_test.go
+++ b/test/integration/resourcemanager/networkpolicy/networkpolicy_suite_test.go
@@ -118,7 +118,7 @@ var _ = BeforeSuite(func() {
 				PodSelector: ingressControllerPodSelector,
 			},
 		},
-	}).AddToManager(mgr, mgr)).To(Succeed())
+	}).AddToManager(ctx, mgr, mgr)).To(Succeed())
 
 	// We create and delete namespace in every test, so let's ensure they get finalized.
 	Expect((&namespacefinalizer.Reconciler{Exceptions: sets.New(finalizer)}).AddToManager(mgr)).To(Succeed())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane performance
/kind enhancement

**What this PR does / why we need it**:
The `MapServiceToNamespaces` method of `istio-cluster-configuration` controller is expensive because it lists `DestinationRules`, of which there can be a large number in a big seed.

The reconciler acts only if a `DestinationRule` and a corresponding `Service` both exist. Thus, it is sufficient to only use `DestinationRule`s for enqueuing the namespaces while the controller is starting. Their mapper is much less expensive. The controller starts enqueuing based on create events of Services only after the caches are synced.

We do not want to skip create event while the controller is running because a service might be created after a DestinationRule.

`EventHandlerForPod` method of `networkpolicy` controller is expensive too. The same logic is implemented here into `PodPredicate`. When the controller is starting, `Service`s already trigger the reconciliations.

**Which issue(s) this PR fixes**:
Part of #15178

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Startup performance of `istio-cluster-configuration` & `networkpolicy` controllers has been improved to avoid cache sync timeouts.
```
