### PR TITLE
Fix Shoot/Seed testmachinery logging tests

### DIFF
--- a/test/testmachinery/shoots/logging/seed_logging_stack.go
+++ b/test/testmachinery/shoots/logging/seed_logging_stack.go
@@ -264,7 +264,8 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 			seedClient.Get(ctx,
 				types.NamespacedName{
 					Namespace: shootFramework.ShootSeedNamespace(),
-					Name:      v1beta1constants.DeploymentNamePlutono},
+					Name:      fmt.Sprintf("%s-%s", v1beta1constants.DeploymentNamePlutono, shootFramework.ShootSeedNamespace()),
+				},
 				plutonoVirtualService),
 		)
 	}, initializationTimeout)

--- a/test/testmachinery/shoots/logging/seed_logging_stack.go
+++ b/test/testmachinery/shoots/logging/seed_logging_stack.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
-	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -80,7 +79,6 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		shootValiPriorityClass = &schedulingv1.PriorityClass{}
 		shootValiConfMap       = &corev1.ConfigMap{}
 
-		plutonoVirtualService client.Object = &istionetworkingv1beta1.VirtualService{}
 		// This shoot is used as seed for this test only
 		shootClient     kubernetes.Interface
 		shootValiLabels = map[string]string{
@@ -257,16 +255,6 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 					Namespace: shootFramework.ShootSeedNamespace(),
 					Name:      shootValiPriorityClassName},
 				shootValiPriorityClass),
-		)
-
-		// Get the plutono VirtualService
-		framework.ExpectNoError(
-			seedClient.Get(ctx,
-				types.NamespacedName{
-					Namespace: shootFramework.ShootSeedNamespace(),
-					Name:      fmt.Sprintf("%s-%s", v1beta1constants.DeploymentNamePlutono, shootFramework.ShootSeedNamespace()),
-				},
-				plutonoVirtualService),
 		)
 	}, initializationTimeout)
 

--- a/test/testmachinery/shoots/logging/shoot_logging.go
+++ b/test/testmachinery/shoots/logging/shoot_logging.go
@@ -6,21 +6,16 @@ package logging
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
-	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -53,8 +48,6 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 	shootFramework := framework.NewShootFramework(nil)
 
 	var (
-		plutonoVirtualService client.Object = &istionetworkingv1beta1.VirtualService{}
-
 		shootNamespace           = &corev1.Namespace{}
 		shootNamespaceLabelKey   = "gardener.cloud/test"
 		shootNamespaceLabelValue = "logging"
@@ -68,16 +61,6 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		shootNamespace.Name = shootFramework.ShootSeedNamespace()
 
 		seedClient := shootFramework.SeedClient.Client()
-		// Get the plutono VirtualService
-		framework.ExpectNoError(
-			seedClient.Get(ctx,
-				types.NamespacedName{
-					Namespace: shootFramework.ShootSeedNamespace(),
-					Name:      fmt.Sprintf("%s-%s", v1beta1constants.DeploymentNamePlutono, shootFramework.ShootSeedNamespace()),
-				},
-				plutonoVirtualService,
-			),
-		)
 		// Set label to the testing namespace
 		_, err := controllerutils.GetAndCreateOrMergePatch(ctx,
 			seedClient, shootNamespace,

--- a/test/testmachinery/shoots/logging/shoot_logging.go
+++ b/test/testmachinery/shoots/logging/shoot_logging.go
@@ -6,6 +6,7 @@ package logging
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -72,7 +73,8 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 			seedClient.Get(ctx,
 				types.NamespacedName{
 					Namespace: shootFramework.ShootSeedNamespace(),
-					Name:      v1beta1constants.DeploymentNamePlutono},
+					Name:      fmt.Sprintf("%s-%s", v1beta1constants.DeploymentNamePlutono, shootFramework.ShootSeedNamespace()),
+				},
 				plutonoVirtualService,
 			),
 		)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/area networking
/area testing
/kind flake
/kind bug

**What this PR does / why we need it**:

Fix Shoot/Seed testmachinery logging tests.

**Which issue(s) this PR fixes**:
Fixes #15184
Fixes #15186 

**Special notes for your reviewer**:

https://github.com/gardener/gardener/pull/14142 and https://github.com/gardener/gardener/pull/14660 missed that the name of the resource changed during the migration. Hence, the test always failed. Unfortunately, this was not obvious on the PR as testmachinery tests are executed in a very detached manner.

Thanks to @ialidzhikov for catching it.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
