### PR TITLE
Changes the etcd defrag schedule format for existing etcd resources.

### DIFF
--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -1041,7 +1041,8 @@ func (e *etcd) computeReplicas(existingEtcd *druidcorev1alpha1.Etcd) int32 {
 
 func (e *etcd) computeDefragmentationSchedule(existingEtcd *druidcorev1alpha1.Etcd) *string {
 	defragmentationSchedule := e.values.DefragmentationSchedule
-	if existingEtcd != nil && existingEtcd.Spec.Etcd.DefragmentationSchedule != nil {
+	if existingEtcd != nil && existingEtcd.Spec.Etcd.DefragmentationSchedule != nil &&
+		!isEveryThreeDaysScheduleExist(*existingEtcd.Spec.Etcd.DefragmentationSchedule) {
 		defragmentationSchedule = existingEtcd.Spec.Etcd.DefragmentationSchedule
 	}
 	return defragmentationSchedule
@@ -1065,4 +1066,12 @@ func (e *etcd) defaultPortOrEtcdEventsStaticPodPort(defaultPort, etcdEventsPortW
 // Name returns the name of the etcd based on its role.
 func Name(role string) string {
 	return "etcd-" + role
+}
+
+// isEveryThreeDaysScheduleExist reports whether the defrag schedule cron expression uses a "- - */3 * *" day-of-month field,
+// which was the old defragmentation schedule.
+// Existing Etcd resource with this pattern should be updated to the new defrag schedule.
+func isEveryThreeDaysScheduleExist(schedule string) bool {
+	fields := strings.Fields(schedule)
+	return len(fields) == 5 && fields[2] == "*/3"
 }

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -1069,9 +1069,13 @@ func Name(role string) string {
 }
 
 // isEveryNDaysSchedule reports whether the cron expression schedules on every Nth day-of-month
-// (i.e. the day-of-month field matches "*/N"). Such schedules were used as the old defragmentation
-// schedule and should be updated to the new daily schedule on existing Etcd resources.
+// where N > 1 (i.e. the day-of-month field matches "*/N" with N > 1). Such schedules were used
+// as the old defragmentation schedule and should be updated to the new daily schedule on existing Etcd resources.
 func isEveryNDaysSchedule(schedule string) bool {
 	fields := strings.Fields(schedule)
-	return len(fields) == 5 && strings.HasPrefix(fields[2], "*/")
+	if len(fields) != 5 || !strings.HasPrefix(fields[2], "*/") {
+		return false
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(fields[2], "*/"))
+	return err == nil && n > 1
 }

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -1042,7 +1042,7 @@ func (e *etcd) computeReplicas(existingEtcd *druidcorev1alpha1.Etcd) int32 {
 func (e *etcd) computeDefragmentationSchedule(existingEtcd *druidcorev1alpha1.Etcd) *string {
 	defragmentationSchedule := e.values.DefragmentationSchedule
 	if existingEtcd != nil && existingEtcd.Spec.Etcd.DefragmentationSchedule != nil &&
-		!isEveryThreeDaysScheduleExist(*existingEtcd.Spec.Etcd.DefragmentationSchedule) {
+		!isEveryNDaysSchedule(*existingEtcd.Spec.Etcd.DefragmentationSchedule) {
 		defragmentationSchedule = existingEtcd.Spec.Etcd.DefragmentationSchedule
 	}
 	return defragmentationSchedule
@@ -1068,10 +1068,10 @@ func Name(role string) string {
 	return "etcd-" + role
 }
 
-// isEveryThreeDaysScheduleExist reports whether the defrag schedule cron expression uses a "- - */3 * *" day-of-month field,
-// which was the old defragmentation schedule.
-// Existing Etcd resource with this pattern should be updated to the new defrag schedule.
-func isEveryThreeDaysScheduleExist(schedule string) bool {
+// isEveryNDaysSchedule reports whether the cron expression schedules on every Nth day-of-month
+// (i.e. the day-of-month field matches "*/N"). Such schedules were used as the old defragmentation
+// schedule and should be updated to the new daily schedule on existing Etcd resources.
+func isEveryNDaysSchedule(schedule string) bool {
 	fields := strings.Fields(schedule)
-	return len(fields) == 5 && fields[2] == "*/3"
+	return len(fields) == 5 && strings.HasPrefix(fields[2], "*/")
 }

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -939,37 +939,13 @@ var _ = Describe("Etcd", func() {
 			Expect(etcd.Annotations).To(HaveKeyWithValue("foo", "bar"))
 		})
 
-		It("should successfully deploy (normal etcd) and keep the existing defragmentation schedule when it is not a every-N-days schedule", func() {
-			existingDefragmentationSchedule := "24 3 * * *"
-
-			Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{
-				ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace},
-				Spec: druidcorev1alpha1.EtcdSpec{
-					Etcd: druidcorev1alpha1.EtcdConfig{
-						DefragmentationSchedule: &existingDefragmentationSchedule,
-					},
-				},
-				Status: druidcorev1alpha1.EtcdStatus{
-					Etcd: &druidcorev1alpha1.CrossVersionObjectReference{Name: etcdName},
-				},
-			})).To(Succeed())
-
-			Expect(etcd.Deploy(ctx)).To(Succeed())
-
-			etcd := &druidcorev1alpha1.Etcd{}
-			Expect(c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, etcd)).To(Succeed())
-			Expect(etcd.Spec.Etcd.DefragmentationSchedule).To(HaveValue(Equal(existingDefragmentationSchedule)))
-		})
-
-		It("should successfully deploy (normal etcd) and update the existing defragmentation schedule when it is an every-N-days schedule", func() {
-			for _, existingDefragmentationSchedule := range []string{"24 3 */2 * *", "24 3 */3 * *", "24 3 */4 * *"} {
-				Expect(c.Delete(ctx, &druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace}})).To(Or(Succeed(), MatchError(ContainSubstring("not found"))))
-
+		DescribeTable("should correctly handle the existing defragmentation schedule",
+			func(existingSchedule string, expectedSchedule string) {
 				Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{
 					ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace},
 					Spec: druidcorev1alpha1.EtcdSpec{
 						Etcd: druidcorev1alpha1.EtcdConfig{
-							DefragmentationSchedule: &existingDefragmentationSchedule,
+							DefragmentationSchedule: &existingSchedule,
 						},
 					},
 					Status: druidcorev1alpha1.EtcdStatus{
@@ -981,9 +957,13 @@ var _ = Describe("Etcd", func() {
 
 				deployed := &druidcorev1alpha1.Etcd{}
 				Expect(c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, deployed)).To(Succeed())
-				Expect(deployed.Spec.Etcd.DefragmentationSchedule).To(HaveValue(Equal(defragmentationSchedule)), "expected schedule to be updated for existing schedule %q", existingDefragmentationSchedule)
-			}
-		})
+				Expect(deployed.Spec.Etcd.DefragmentationSchedule).To(HaveValue(Equal(expectedSchedule)))
+			},
+			Entry("should keep daily defrag schedule", "24 3 * * *", "24 3 * * *"),
+			Entry("should keep daily defrag schedule (*/1)", "24 3 */1 * *", "24 3 */1 * *"),
+			Entry("should update every-Two-days defrag schedule to daily", "24 3 */2 * *", defragmentationSchedule),
+			Entry("should update every-Three-days defrag schedule to daily", "24 3 */3 * *", defragmentationSchedule),
+		)
 
 		It("should successfully deploy (normal etcd) and not keep the existing resource request settings", func() {
 			existingResourceRequests := &corev1.ResourceRequirements{

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -939,7 +939,7 @@ var _ = Describe("Etcd", func() {
 			Expect(etcd.Annotations).To(HaveKeyWithValue("foo", "bar"))
 		})
 
-		It("should successfully deploy (normal etcd) and keep the existing defragmentation schedule when it is not a three-day schedule", func() {
+		It("should successfully deploy (normal etcd) and keep the existing defragmentation schedule when it is not a every-N-days schedule", func() {
 			existingDefragmentationSchedule := "24 3 * * *"
 
 			Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{
@@ -961,26 +961,28 @@ var _ = Describe("Etcd", func() {
 			Expect(etcd.Spec.Etcd.DefragmentationSchedule).To(HaveValue(Equal(existingDefragmentationSchedule)))
 		})
 
-		It("should successfully deploy (normal etcd) and update the existing defragmentation schedule when it is an every-three-day schedule", func() {
-			existingDefragmentationSchedule := "24 3 */3 * *"
+		It("should successfully deploy (normal etcd) and update the existing defragmentation schedule when it is an every-N-days schedule", func() {
+			for _, existingDefragmentationSchedule := range []string{"24 3 */2 * *", "24 3 */3 * *", "24 3 */4 * *"} {
+				Expect(c.Delete(ctx, &druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace}})).To(Or(Succeed(), MatchError(ContainSubstring("not found"))))
 
-			Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{
-				ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace},
-				Spec: druidcorev1alpha1.EtcdSpec{
-					Etcd: druidcorev1alpha1.EtcdConfig{
-						DefragmentationSchedule: &existingDefragmentationSchedule,
+				Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace},
+					Spec: druidcorev1alpha1.EtcdSpec{
+						Etcd: druidcorev1alpha1.EtcdConfig{
+							DefragmentationSchedule: &existingDefragmentationSchedule,
+						},
 					},
-				},
-				Status: druidcorev1alpha1.EtcdStatus{
-					Etcd: &druidcorev1alpha1.CrossVersionObjectReference{Name: etcdName},
-				},
-			})).To(Succeed())
+					Status: druidcorev1alpha1.EtcdStatus{
+						Etcd: &druidcorev1alpha1.CrossVersionObjectReference{Name: etcdName},
+					},
+				})).To(Succeed())
 
-			Expect(etcd.Deploy(ctx)).To(Succeed())
+				Expect(etcd.Deploy(ctx)).To(Succeed())
 
-			etcd := &druidcorev1alpha1.Etcd{}
-			Expect(c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, etcd)).To(Succeed())
-			Expect(etcd.Spec.Etcd.DefragmentationSchedule).To(HaveValue(Equal(defragmentationSchedule)))
+				deployed := &druidcorev1alpha1.Etcd{}
+				Expect(c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, deployed)).To(Succeed())
+				Expect(deployed.Spec.Etcd.DefragmentationSchedule).To(HaveValue(Equal(defragmentationSchedule)), "expected schedule to be updated for existing schedule %q", existingDefragmentationSchedule)
+			}
 		})
 
 		It("should successfully deploy (normal etcd) and not keep the existing resource request settings", func() {

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -939,8 +939,8 @@ var _ = Describe("Etcd", func() {
 			Expect(etcd.Annotations).To(HaveKeyWithValue("foo", "bar"))
 		})
 
-		It("should successfully deploy (normal etcd) and keep the existing defragmentation schedule", func() {
-			existingDefragmentationSchedule := "foobardefragexisting"
+		It("should successfully deploy (normal etcd) and keep the existing defragmentation schedule when it is not a three-day schedule", func() {
+			existingDefragmentationSchedule := "24 3 * * *"
 
 			Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{
 				ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace},
@@ -959,6 +959,28 @@ var _ = Describe("Etcd", func() {
 			etcd := &druidcorev1alpha1.Etcd{}
 			Expect(c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, etcd)).To(Succeed())
 			Expect(etcd.Spec.Etcd.DefragmentationSchedule).To(HaveValue(Equal(existingDefragmentationSchedule)))
+		})
+
+		It("should successfully deploy (normal etcd) and update the existing defragmentation schedule when it is an every-three-day schedule", func() {
+			existingDefragmentationSchedule := "24 3 */3 * *"
+
+			Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{
+				ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace},
+				Spec: druidcorev1alpha1.EtcdSpec{
+					Etcd: druidcorev1alpha1.EtcdConfig{
+						DefragmentationSchedule: &existingDefragmentationSchedule,
+					},
+				},
+				Status: druidcorev1alpha1.EtcdStatus{
+					Etcd: &druidcorev1alpha1.CrossVersionObjectReference{Name: etcdName},
+				},
+			})).To(Succeed())
+
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+
+			etcd := &druidcorev1alpha1.Etcd{}
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, etcd)).To(Succeed())
+			Expect(etcd.Spec.Etcd.DefragmentationSchedule).To(HaveValue(Equal(defragmentationSchedule)))
 		})
 
 		It("should successfully deploy (normal etcd) and not keep the existing resource request settings", func() {


### PR DESCRIPTION
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
I had opened this PR: https://github.com/gardener/gardener/pull/15125 to change the etcd's defragmentation schedule to run daily in a maintenance window, but I missed to update the defrag schedule for an existing etcd resources. 
This PR rectifies that by changing the etcd defrag schedule format for all existing etcd resources as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- Re-populating the release note as previous PR release note seems missing by g/g release: https://github.com/gardener/gardener/releases/tag/v1.146.0


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The etcd defragmentation schedule has been changed from once every 3 days to once daily, within the shoot's maintenance window. For HA clusters, defragmentation runs in a rolling fashion across etcd members, so there is no downtime.
```

/cc @shreyas-s-rao @Shreyas-s14 