### PR TITLE
Disable `health_check` extension in otel-collector config

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -93,6 +93,7 @@ extensions:
     create_directory: true
   bearertokenauth:
     filename: /var/lib/opentelemetry-collector/auth-token
+  # TODO(rrhubenov): health check can be enabled when ` + "`sd_notify`" + ` integration is implemented: https://github.com/open-telemetry/opentelemetry-collector/issues/15128
   # The 13133 port should be changed to something else in the future,
   # since it's the default value and might conflict with other instances of
   # otel collector from shoot owners.

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -93,9 +93,12 @@ extensions:
     create_directory: true
   bearertokenauth:
     filename: /var/lib/opentelemetry-collector/auth-token
-  health_check:
-    endpoint: 0.0.0.0:13133
-    path: /healthz
+  # The 13133 port should be changed to something else in the future,
+  # since it's the default value and might conflict with other instances of
+  # otel collector from shoot owners.
+  # health_check:
+  #   endpoint: 0.0.0.0:13133
+  #   path: /healthz
 
 receivers:
   journald/journal:
@@ -219,7 +222,7 @@ service:
       level: INFO
       encoding: json
 
-  extensions: [file_storage, bearertokenauth, health_check]
+  extensions: [file_storage, bearertokenauth]
   pipelines:
     logs/journal:
       receivers: [journald/journal]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
@@ -9,6 +9,7 @@ extensions:
     create_directory: true
   bearertokenauth:
     filename: {{ .pathAuthToken }}
+  # TODO(rrhubenov): health check can be enabled when `sd_notify` integration is implemented: https://github.com/open-telemetry/opentelemetry-collector/issues/15128
   # The 13133 port should be changed to something else in the future,
   # since it's the default value and might conflict with other instances of
   # otel collector from shoot owners.

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
@@ -9,9 +9,12 @@ extensions:
     create_directory: true
   bearertokenauth:
     filename: {{ .pathAuthToken }}
-  health_check:
-    endpoint: 0.0.0.0:13133
-    path: /healthz
+  # The 13133 port should be changed to something else in the future,
+  # since it's the default value and might conflict with other instances of
+  # otel collector from shoot owners.
+  # health_check:
+  #   endpoint: 0.0.0.0:13133
+  #   path: /healthz
 
 receivers:
   journald/journal:
@@ -135,7 +138,7 @@ service:
       level: INFO
       encoding: json
 
-  extensions: [file_storage, bearertokenauth, health_check]
+  extensions: [file_storage, bearertokenauth]
   pipelines:
     logs/journal:
       receivers: [journald/journal]


### PR DESCRIPTION
/area logging
/kind cleanup

**What this PR does / why we need it**:
Comments out the `health_check` extension in the otel-collector config template. The default `13133` port might conflict with other otel-collector instances run by shoot owners on the node. A comment is left noting the port should be changed to a non-default value in the future before re-enabling.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
```other operator
Disable the `health_check` extension in the OpenTelemetry Collector config on shoot nodes to avoid port conflicts (`13133`) with shoot-owner-managed otel-collector instances.
```