### PR TITLE
Support cluster-autoscaler resources declaration in the shoot spec

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2213,6 +2213,18 @@ boolean
 <p>MaxBinpackingTime is the maximum time spent on binpacking for a single scale-up.<br />If binpacking is limited by this, scale-up continues with the already calculated scale-up options (default: 5m).</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>autoscaling</code></br>
+<em>
+<a href="#controlplaneautoscaling">ControlPlaneAutoscaling</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Autoscaling contains auto-scaling configuration options for the cluster-autoscaler.</p>
+</td>
+</tr>
 
 </tbody>
 </table>
@@ -2542,7 +2554,7 @@ ControlPlane holds information about the general settings for the control plane 
 
 
 <p>
-(<em>Appears on:</em><a href="#etcdconfig">ETCDConfig</a>, <a href="#kubeapiserverconfig">KubeAPIServerConfig</a>)
+(<em>Appears on:</em><a href="#clusterautoscaler">ClusterAutoscaler</a>, <a href="#etcdconfig">ETCDConfig</a>, <a href="#kubeapiserverconfig">KubeAPIServerConfig</a>)
 </p>
 
 <p>

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -337,6 +337,10 @@ spec:
   #   ignoreDaemonsetsUtilization: false
   #   emitPerNodeGroupMetrics: false
   #   verbosity: 2
+  #   autoscaling:
+  #     minAllowed:
+  #       cpu: "2"
+  #       memory: 6Gi
   # verticalPodAutoscaler:
   #   enabled: true
   #   evictAfterOOMThreshold: 10m0s

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -1597,6 +1597,7 @@ func ValidateClusterAutoscaler(autoScaler core.ClusterAutoscaler, kubernetesVers
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.MaxNodeGroupBackoffDuration, fldPath.Child("maxNodeGroupBackoffDuration"))...)
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.NodeGroupBackoffResetTimeout, fldPath.Child("nodeGroupBackoffResetTimeout"))...)
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.MaxBinpackingTime, fldPath.Child("maxBinpackingTime"))...)
+	allErrs = append(allErrs, ValidateControlPlaneAutoscaling(autoScaler.Autoscaling, corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m"), corev1.ResourceMemory: resource.MustParse("30M")}, fldPath.Child("autoscaling"))...)
 
 	return allErrs
 }

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -4467,6 +4467,55 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Field":  Equal("maxBinpackingTime"),
 					"Detail": Equal("must be non-negative"),
 				})))),
+				Entry("valid with autoscaling minAllowed", core.ClusterAutoscaler{
+					Autoscaling: &core.ControlPlaneAutoscaling{
+						MinAllowed: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("500Mi"),
+						},
+					},
+				}, version_1_32, BeEmpty()),
+				Entry("invalid autoscaling with empty minAllowed", core.ClusterAutoscaler{
+					Autoscaling: &core.ControlPlaneAutoscaling{
+						MinAllowed: corev1.ResourceList{},
+					},
+				}, version_1_32, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("autoscaling.minAllowed"),
+					"Detail": Equal("must provide minAllowed"),
+				})))),
+				Entry("invalid autoscaling with unsupported resource in minAllowed", core.ClusterAutoscaler{
+					Autoscaling: &core.ControlPlaneAutoscaling{
+						MinAllowed: corev1.ResourceList{
+							"hugepages-1Gi": resource.MustParse("1"),
+						},
+					},
+				}, version_1_32, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("autoscaling.minAllowed.hugepages-1Gi"),
+				})))),
+				Entry("invalid autoscaling with below minRequired cpu resource in minAllowed", core.ClusterAutoscaler{
+					Autoscaling: &core.ControlPlaneAutoscaling{
+						MinAllowed: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("5m"),
+							corev1.ResourceMemory: resource.MustParse("500Mi"),
+						},
+					},
+				}, version_1_32, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("autoscaling.minAllowed.cpu"),
+				})))),
+				Entry("invalid autoscaling with below minRequired memory resource in minAllowed", core.ClusterAutoscaler{
+					Autoscaling: &core.ControlPlaneAutoscaling{
+						MinAllowed: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("5Mi"),
+						},
+					},
+				}, version_1_32, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("autoscaling.minAllowed.memory"),
+				})))),
 			)
 
 			Describe("taint validation", func() {

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -623,6 +623,8 @@ type ClusterAutoscaler struct {
 	MaxBinpackingTime *metav1.Duration
 	// Verbosity allows CA to modify its log level.
 	Verbosity *int32
+	// Autoscaling contains auto-scaling configuration options for the cluster-autoscaler.
+	Autoscaling *ControlPlaneAutoscaling
 }
 
 // ExpanderMode is type used for Expander values

--- a/pkg/apis/core/v1beta1/generated.pb.go
+++ b/pkg/apis/core/v1beta1/generated.pb.go
@@ -2217,6 +2217,20 @@ func (m *ClusterAutoscaler) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.Autoscaling != nil {
+		{
+			size, err := m.Autoscaling.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintGenerated(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xc2
+	}
 	if m.MaxBinpackingTime != nil {
 		{
 			size, err := m.MaxBinpackingTime.MarshalToSizedBuffer(dAtA[:i])
@@ -14255,6 +14269,10 @@ func (m *ClusterAutoscaler) Size() (n int) {
 		l = m.MaxBinpackingTime.Size()
 		n += 2 + l + sovGenerated(uint64(l))
 	}
+	if m.Autoscaling != nil {
+		l = m.Autoscaling.Size()
+		n += 2 + l + sovGenerated(uint64(l))
+	}
 	return n
 }
 
@@ -18869,6 +18887,7 @@ func (this *ClusterAutoscaler) String() string {
 		`NodeGroupBackoffResetTimeout:` + strings.Replace(fmt.Sprintf("%v", this.NodeGroupBackoffResetTimeout), "Duration", "v11.Duration", 1) + `,`,
 		`EmitPerNodeGroupMetrics:` + valueToStringGenerated(this.EmitPerNodeGroupMetrics) + `,`,
 		`MaxBinpackingTime:` + strings.Replace(fmt.Sprintf("%v", this.MaxBinpackingTime), "Duration", "v11.Duration", 1) + `,`,
+		`Autoscaling:` + strings.Replace(this.Autoscaling.String(), "ControlPlaneAutoscaling", "ControlPlaneAutoscaling", 1) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -27387,6 +27406,42 @@ func (m *ClusterAutoscaler) Unmarshal(dAtA []byte) error {
 				m.MaxBinpackingTime = &v11.Duration{}
 			}
 			if err := m.MaxBinpackingTime.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 24:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Autoscaling", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Autoscaling == nil {
+				m.Autoscaling = &ControlPlaneAutoscaling{}
+			}
+			if err := m.Autoscaling.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -613,6 +613,10 @@ message ClusterAutoscaler {
   // If binpacking is limited by this, scale-up continues with the already calculated scale-up options (default: 5m).
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration maxBinpackingTime = 23;
+
+  // Autoscaling contains auto-scaling configuration options for the cluster-autoscaler.
+  // +optional
+  optional ControlPlaneAutoscaling autoscaling = 24;
 }
 
 // ClusterAutoscalerOptions contains the cluster autoscaler configurations for a worker pool.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -794,6 +794,9 @@ type ClusterAutoscaler struct {
 	// If binpacking is limited by this, scale-up continues with the already calculated scale-up options (default: 5m).
 	// +optional
 	MaxBinpackingTime *metav1.Duration `json:"maxBinpackingTime,omitempty" protobuf:"bytes,23,opt,name=maxBinpackingTime"`
+	// Autoscaling contains auto-scaling configuration options for the cluster-autoscaler.
+	// +optional
+	Autoscaling *ControlPlaneAutoscaling `json:"autoscaling,omitempty" protobuf:"bytes,24,opt,name=autoscaling"`
 }
 
 // ExpanderMode is type used for Expander values

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -3073,6 +3073,7 @@ func autoConvert_v1beta1_ClusterAutoscaler_To_core_ClusterAutoscaler(in *Cluster
 	out.NodeGroupBackoffResetTimeout = (*metav1.Duration)(unsafe.Pointer(in.NodeGroupBackoffResetTimeout))
 	out.EmitPerNodeGroupMetrics = (*bool)(unsafe.Pointer(in.EmitPerNodeGroupMetrics))
 	out.MaxBinpackingTime = (*metav1.Duration)(unsafe.Pointer(in.MaxBinpackingTime))
+	out.Autoscaling = (*core.ControlPlaneAutoscaling)(unsafe.Pointer(in.Autoscaling))
 	return nil
 }
 
@@ -3105,6 +3106,7 @@ func autoConvert_core_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(in *core.Cl
 	out.EmitPerNodeGroupMetrics = (*bool)(unsafe.Pointer(in.EmitPerNodeGroupMetrics))
 	out.MaxBinpackingTime = (*metav1.Duration)(unsafe.Pointer(in.MaxBinpackingTime))
 	out.Verbosity = (*int32)(unsafe.Pointer(in.Verbosity))
+	out.Autoscaling = (*ControlPlaneAutoscaling)(unsafe.Pointer(in.Autoscaling))
 	return nil
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -1109,6 +1109,11 @@ func (in *ClusterAutoscaler) DeepCopyInto(out *ClusterAutoscaler) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.Autoscaling != nil {
+		in, out := &in.Autoscaling, &out.Autoscaling
+		*out = new(ControlPlaneAutoscaling)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -1109,6 +1109,11 @@ func (in *ClusterAutoscaler) DeepCopyInto(out *ClusterAutoscaler) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Autoscaling != nil {
+		in, out := &in.Autoscaling, &out.Autoscaling
+		*out = new(ControlPlaneAutoscaling)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -2629,11 +2629,17 @@ func schema_pkg_apis_core_v1beta1_ClusterAutoscaler(ref common.ReferenceCallback
 							Ref:         ref(metav1.Duration{}.OpenAPIModelName()),
 						},
 					},
+					"autoscaling": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Autoscaling contains auto-scaling configuration options for the cluster-autoscaler.",
+							Ref:         ref(v1beta1.ControlPlaneAutoscaling{}.OpenAPIModelName()),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			metav1.Duration{}.OpenAPIModelName()},
+			v1beta1.ControlPlaneAutoscaling{}.OpenAPIModelName(), metav1.Duration{}.OpenAPIModelName()},
 	}
 }
 

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
@@ -274,12 +274,18 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 		vpa.Spec.UpdatePolicy = &vpaautoscalingv1.PodUpdatePolicy{
 			UpdateMode: new(vpaautoscalingv1.UpdateModeRecreate),
 		}
+
+		containerPolicy := vpaautoscalingv1.ContainerResourcePolicy{
+			ContainerName:    containerName,
+			ControlledValues: new(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+		}
+		if c.config != nil && c.config.Autoscaling != nil {
+			containerPolicy.MinAllowed = c.config.Autoscaling.MinAllowed
+		}
+
 		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
 			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-				{
-					ContainerName:    containerName,
-					ControlledValues: new(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-				},
+				containerPolicy,
 				{
 					ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
 					Mode:          new(vpaautoscalingv1.ContainerScalingModeOff),

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
@@ -778,6 +778,31 @@ var _ = Describe("ClusterAutoscaler", func() {
 			It("w/ config, k8s v1.35", func() { test(true, false, false, true) })
 			It("w/ config, w/ workerConfig", func() { test(true, true, false, false) })
 			It("w/ config, w/ workerConfig, w/ 'priority' expander already configured", func() { test(true, true, true, false) })
+
+			It("w/ config, w/ minAllowed in VPA", func() {
+				config := configFull.DeepCopy()
+				config.Autoscaling = &gardencorev1beta1.ControlPlaneAutoscaling{
+					MinAllowed: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+				}
+
+				clusterAutoscaler = New(fakeClient, namespace, sm, image, replicas, config, nil, semver.MustParse("1.33.1"), semver.MustParse("1.33.1"))
+				clusterAutoscaler.SetNamespaceUID(namespaceUID)
+				clusterAutoscaler.SetMachineDeployments(machineDeployments)
+
+				Expect(clusterAutoscaler.Deploy(ctx)).To(Succeed())
+
+				actualVPA := &vpaautoscalingv1.VerticalPodAutoscaler{}
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: vpaName, Namespace: namespace}, actualVPA)).To(Succeed())
+				Expect(actualVPA.Spec.ResourcePolicy.ContainerPolicies).To(HaveLen(2))
+				Expect(actualVPA.Spec.ResourcePolicy.ContainerPolicies[0].ContainerName).To(Equal(containerName))
+				Expect(actualVPA.Spec.ResourcePolicy.ContainerPolicies[0].MinAllowed).To(Equal(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("500Mi"),
+				}))
+			})
 		})
 	})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR updates the shoot spec to adds a new optional `autoscaling` field to `shoot.spec.kubernetes.clusterAutoscaler`.

The field allows operators to configure `minAllowed` resource constraints for the cluster-autoscaler's VPA. This allows operators to pre-configure sufficient resources for the cluster-autoscaler before Maintenance Upgrade Windows of large clusters
```
  clusterAutoscaler:
    autoscaling:
      minAllowed:
        cpu: "4"
        memory: "6Gi"
```

**Which issue(s) this PR fixes**:
Fixes #14846 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`shoot.spec.kubernetes.clusterAutoscaler` now supports an optional `autoscaling.minAllowed` that sets a minimum resource value for the cluster-autoscaler's VPA.
```
