### PR TITLE
[GEP-28] Do not regenerate the Shoot `.status.uid` during control plane Node restoration

### DIFF
--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -392,13 +392,19 @@ func initializeShootResource(resources gardenadm.Resources, fs afero.Afero, runs
 	shoot.Status.Gardener = gardencorev1beta1.Gardener{Name: "gardenadm", Version: version.Get().GitVersion}
 
 	if runsControlPlane {
-		// This UID is used to compute the name of the BackupEntry object. Persist the generated UID on the machine in case
-		// `gardenadm init` is retried/executed multiple times (otherwise, we'd always generate a new one).
-		uid, err := shootUID(fs)
-		if err != nil {
-			return fmt.Errorf("failed fetching shoot UID: %w", err)
+		// The Shoot UID determines the BackupBucket/BackupEntry names and thus the etcd backup location,
+		// so it must stay stable across invocations.
+		//
+		// - `gardenadm restore`: UID comes from the Shoot status exported by `gardenadm discover existing`; preserve it.
+		// - `gardenadm init`: no UID on the Shoot, so reuse the one persisted at /var/lib/gardenadm/shoot-uid,
+		//   or generate and persist a new one (keeps retries of `gardenadm init` idempotent).
+		if shoot.Status.UID == "" {
+			uid, err := shootUID(fs)
+			if err != nil {
+				return fmt.Errorf("failed fetching shoot UID: %w", err)
+			}
+			shoot.Status.UID = uid
 		}
-		shoot.Status.UID = uid
 
 		if v1beta1helper.HasManagedInfrastructure(resources.Shoot) && resources.ShootState == nil {
 			return fmt.Errorf("shoot has managed infrastructure, but ShootState is missing " +

--- a/pkg/gardenadm/botanist/botanist_test.go
+++ b/pkg/gardenadm/botanist/botanist_test.go
@@ -118,31 +118,55 @@ metadata:
 				Expect(b.Shoot.ControlPlaneNamespace).To(Equal("kube-system"))
 			})
 
-			It("should generate a UID for the shoot and write it to the host", func() {
-				fs := afero.NewMemMapFs()
-				DeferCleanup(test.WithVar(&NewFs, func() afero.Fs { return fs }))
+			When("the Shoot does not have status UID set", func() {
+				It("should generate a UID for the shoot and write it to the host", func() {
+					fs := afero.NewMemMapFs()
+					DeferCleanup(test.WithVar(&NewFs, func() afero.Fs { return fs }))
 
-				By("Generate new shoot UID and write it to the host")
-				b, err := NewGardenadmBotanistFromManifests(ctx, log, nil, configDir, true)
-				Expect(err).NotTo(HaveOccurred())
+					By("Generate new shoot UID and write it to the host")
+					b, err := NewGardenadmBotanistFromManifests(ctx, log, nil, configDir, true)
+					Expect(err).NotTo(HaveOccurred())
 
-				uid := b.Shoot.GetInfo().Status.UID
-				Expect(uid).NotTo(BeEmpty())
+					uid := b.Shoot.GetInfo().Status.UID
+					Expect(uid).NotTo(BeEmpty())
 
-				path := filepath.Join(string(filepath.Separator), "var", "lib", "gardenadm", "shoot-uid")
-				content, err := b.FS.ReadFile(path)
-				Expect(err).NotTo(HaveOccurred())
+					path := filepath.Join(string(filepath.Separator), "var", "lib", "gardenadm", "shoot-uid")
+					content, err := b.FS.ReadFile(path)
+					Expect(err).NotTo(HaveOccurred())
 
-				Expect(string(content)).To(Equal(string(uid)))
+					Expect(string(content)).To(Equal(string(uid)))
 
-				By("Do not regenerate shoot UID when file is present on host")
-				b, err = NewGardenadmBotanistFromManifests(ctx, log, nil, configDir, true)
-				Expect(err).NotTo(HaveOccurred())
+					By("Do not regenerate shoot UID when file is present on host")
+					b, err = NewGardenadmBotanistFromManifests(ctx, log, nil, configDir, true)
+					Expect(err).NotTo(HaveOccurred())
 
-				Expect(b.Shoot.GetInfo().Status.UID).To(Equal(uid))
-				content, err = b.FS.ReadFile(path)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(content)).To(Equal(string(uid)))
+					Expect(b.Shoot.GetInfo().Status.UID).To(Equal(uid))
+					content, err = b.FS.ReadFile(path)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(content)).To(Equal(string(uid)))
+				})
+			})
+
+			When("the Shoot has status UID set", func() {
+				It("should not overwrite the already set UID", func() {
+					const uid = "some-uid"
+					shootFile := fsys[configDir+"/shoot.yaml"]
+					shootFile.Data = append(shootFile.Data, []byte(`status:
+  uid: `+uid+`
+`)...)
+
+					fs := afero.NewMemMapFs()
+					DeferCleanup(test.WithVar(&NewFs, func() afero.Fs { return fs }))
+
+					By("Ensure the shoot UID is preserved")
+					b, err := NewGardenadmBotanistFromManifests(ctx, log, nil, configDir, true)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(string(b.Shoot.GetInfo().Status.UID)).To(Equal(uid))
+
+					path := filepath.Join(string(filepath.Separator), "var", "lib", "gardenadm", "shoot-uid")
+					Expect(b.FS.ReadFile(path)).Error().To(MatchError(os.IsNotExist, "IsNotExist"))
+				})
 			})
 		})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area disaster-recovery ipcei
/kind enhancement

**What this PR does / why we need it**:
Currently, on control plane Node restoration with `gardenadm restore` (to be introduced) the Shoot `.status.uid` is regenerated.
This is not expected. The Shoot `.status.uid` is being used for computing the BackupEntry and BackupBucket names. Changing the BackupEntry and BackupBucket names changes also the bucket etcd uses for its data backups.

The logic for computing the Shoot `.status.uid` is the [following](https://github.com/Kostov6/gardener/blob/088bff35f2bfe6ad520daf0cbb71af899b5b39f6/pkg/gardenadm/botanist/botanist.go#L448-L471).
If the `/var/lib/gardenadm/shoot-uid` file does not exist, a new uid is generated and later on stored in this file so that every new retry of `gardenadm init` does not regenerate a new uid.
When restoring a control plane Node the `/var/lib/gardenadm/shoot-uid` file does not exist and a new uid is generated for the existing Shoot.

With PR https://github.com/gardener/gardener/pull/15145 `gardenadm discover existing` exports the existing Shoot resource together with its `.status` (incl. `.status.uid`).

To prevent the Shoot UID to be regenerated on `gardenadm restore`, this PR adapts the gardenadm botanist to respect the provided Shoot `.status.uid` instead of generating a new one.

To fix this, this PR:
- adapts the `gardenadm discover` command to work against existing Shoot by specify the `--shoot-name` and the `--shoot-namespace` flags. `gardenadm discover <shoot-manifest>` is initially designed to be executed against a new (to be created Shoot) to collect all the referenced resources from the existing garden cluster to facilitate the `gardenadm init` execution locally. `gardenadm discover --shoot-name / --shoot--namespace` is introduced to work for existing Shoot and to fetch the required resources for restoring a control plane Node. More concretely, it fetches the Shoot with its status and fetches the BackupEntry and BackupBucket resources.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
Unfortunately, it is not possible to test this change standalone. 
We plan to introduce a new `gardenadm restore` command in follow-up PRs that is the entry point for a control plane Node restoration. (cc @vitanovs)
The command will reuse the `gardenadm init` flow.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
