### PR TITLE
Clean up the backwards-compatibility logic for capping out-of-range `eventTTL` field values

### DIFF
--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -86,8 +86,6 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 	}
 
 	gardenerutils.SyncCloudProfileFields(oldShoot, newShoot)
-
-	capEventTTL(newShoot.Spec.Kubernetes.KubeAPIServer)
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
@@ -211,20 +209,6 @@ func mustIncreaseGenerationForSpecChanges(oldShoot, newShoot *core.Shoot) bool {
 	}
 
 	return !apiequality.Semantic.DeepEqual(oldShoot.Spec, newShoot.Spec)
-}
-
-// capEventTTL caps the eventTTL to 24h for already persisted Shoots with a value exceeding the allowed maximum.
-//
-// TODO(ialidzhikov): Remove this function after v1.145 has been released.
-func capEventTTL(kubeAPIServer *core.KubeAPIServerConfig) {
-	if kubeAPIServer == nil || kubeAPIServer.EventTTL == nil {
-		return
-	}
-
-	const maxEventTTL = 24 * time.Hour
-	if kubeAPIServer.EventTTL.Duration > maxEventTTL {
-		kubeAPIServer.EventTTL.Duration = maxEventTTL
-	}
 }
 
 func (shootStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -7,7 +7,6 @@ package shoot_test
 import (
 	"context"
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -246,42 +245,6 @@ var _ = Describe("Strategy", func() {
 				Expect(newShoot.Spec).To(Equal(oldShoot.Spec))
 			})
 		})
-
-		DescribeTable("should cap eventTTL to the allowed maximum",
-			func(kubeAPIServer *core.KubeAPIServerConfig, expectedKubeAPIServer *core.KubeAPIServerConfig) {
-				oldShoot = &core.Shoot{
-					Spec: core.ShootSpec{
-						Kubernetes: core.Kubernetes{
-							KubeAPIServer: kubeAPIServer,
-						},
-					},
-				}
-				newShoot = oldShoot.DeepCopy()
-
-				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
-				Expect(newShoot.Spec.Kubernetes.KubeAPIServer).To(Equal(expectedKubeAPIServer))
-			},
-			Entry("should not modify when kubeAPIServer is nil",
-				nil,
-				nil,
-			),
-			Entry("should not modify when eventTTL is nil",
-				&core.KubeAPIServerConfig{},
-				&core.KubeAPIServerConfig{},
-			),
-			Entry("should not modify when within valid range",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 12 * time.Hour}},
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 12 * time.Hour}},
-			),
-			Entry("should not modify when exactly 24h",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
-			),
-			Entry("cap to 24h when exceeding maximum",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 48 * time.Hour}},
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
-			),
-		)
 
 		Context("generation increment", func() {
 			var (

--- a/pkg/apiserver/registry/seedmanagement/managedseedset/strategy.go
+++ b/pkg/apiserver/registry/seedmanagement/managedseedset/strategy.go
@@ -7,7 +7,6 @@ package managedseedset
 import (
 	"context"
 	"fmt"
-	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/fields"
@@ -21,7 +20,6 @@ import (
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/api/seedmanagement/managedseedset"
 	"github.com/gardener/gardener/pkg/api/seedmanagement/validation"
-	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -63,8 +61,6 @@ func (s Strategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	if mustIncreaseGeneration(oldManagedSeedSet, newManagedSeedSet) {
 		newManagedSeedSet.Generation = oldManagedSeedSet.Generation + 1
 	}
-
-	capEventTTL(newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer)
 }
 
 func mustIncreaseGeneration(oldManagedSeedSet, newManagedSeedSet *seedmanagement.ManagedSeedSet) bool {
@@ -85,20 +81,6 @@ func mustIncreaseGeneration(oldManagedSeedSet, newManagedSeedSet *seedmanagement
 	}
 
 	return false
-}
-
-// capEventTTL caps the eventTTL to 24h for already persisted ManagedSeedSets with a value exceeding the allowed maximum.
-//
-// TODO(ialidzhikov): Remove this function after v1.145 has been released.
-func capEventTTL(kubeAPIServer *core.KubeAPIServerConfig) {
-	if kubeAPIServer == nil || kubeAPIServer.EventTTL == nil {
-		return
-	}
-
-	const maxEventTTL = 24 * time.Hour
-	if kubeAPIServer.EventTTL.Duration > maxEventTTL {
-		kubeAPIServer.EventTTL.Duration = maxEventTTL
-	}
 }
 
 // Validate validates the given object.

--- a/pkg/apiserver/registry/seedmanagement/managedseedset/strategy_test.go
+++ b/pkg/apiserver/registry/seedmanagement/managedseedset/strategy_test.go
@@ -6,7 +6,6 @@ package managedseedset_test
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -62,46 +61,6 @@ var _ = Describe("Strategy", func() {
 			strategy.PrepareForUpdate(ctx, newManagedSeedSet, oldManagedSeedSet)
 			Expect(newManagedSeedSet.Generation).To(Equal(oldManagedSeedSet.Generation))
 		})
-
-		DescribeTable("should cap eventTTL to the allowed maximum",
-			func(kubeAPIServer *core.KubeAPIServerConfig, expectedKubeAPIServer *core.KubeAPIServerConfig) {
-				oldManagedSeedSet = &seedmanagement.ManagedSeedSet{
-					Spec: seedmanagement.ManagedSeedSetSpec{
-						ShootTemplate: core.ShootTemplate{
-							Spec: core.ShootSpec{
-								Kubernetes: core.Kubernetes{
-									KubeAPIServer: kubeAPIServer,
-								},
-							},
-						},
-					},
-				}
-				newManagedSeedSet = oldManagedSeedSet.DeepCopy()
-
-				strategy.PrepareForUpdate(ctx, newManagedSeedSet, oldManagedSeedSet)
-				Expect(newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer).To(Equal(expectedKubeAPIServer))
-			},
-			Entry("should not modify when kubeAPIServer is nil",
-				nil,
-				nil,
-			),
-			Entry("should not modify when eventTTL is nil",
-				&core.KubeAPIServerConfig{},
-				&core.KubeAPIServerConfig{},
-			),
-			Entry("should not modify when within valid range",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 12 * time.Hour}},
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 12 * time.Hour}},
-			),
-			Entry("should not modify when exactly 24h",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
-			),
-			Entry("cap to 24h when exceeding maximum",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 48 * time.Hour}},
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
-			),
-		)
 	})
 })
 

--- a/pkg/operator/webhook/defaulting/garden/handler.go
+++ b/pkg/operator/webhook/defaulting/garden/handler.go
@@ -7,7 +7,6 @@ package garden
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -55,21 +54,5 @@ func (h *Handler) Default(_ context.Context, obj runtime.Object) error {
 		garden.Spec.VirtualCluster.Gardener.APIServer.EncryptionConfig.Provider.Type = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type
 	}
 
-	capEventTTL(garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig)
-
 	return nil
-}
-
-// capEventTTL caps the eventTTL to 24h for already persisted Gardens with a value exceeding the allowed maximum.
-//
-// TODO(ialidzhikov): Remove this function after v1.145 has been released.
-func capEventTTL(kubeAPIServer *gardencorev1beta1.KubeAPIServerConfig) {
-	if kubeAPIServer == nil || kubeAPIServer.EventTTL == nil {
-		return
-	}
-
-	const maxEventTTL = 24 * time.Hour
-	if kubeAPIServer.EventTTL.Duration > maxEventTTL {
-		kubeAPIServer.EventTTL.Duration = maxEventTTL
-	}
 }

--- a/pkg/operator/webhook/defaulting/garden/handler_test.go
+++ b/pkg/operator/webhook/defaulting/garden/handler_test.go
@@ -159,33 +159,5 @@ var _ = Describe("Handler", func() {
 			Expect(garden.Spec.RuntimeCluster.Networking.IPFamilies).To(Equal([]gardencorev1beta1.IPFamily{"foo"}))
 		})
 
-		DescribeTable("should cap eventTTL to the allowed maximum",
-			func(eventTTL *metav1.Duration, expectedEventTTL *metav1.Duration) {
-				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = &operatorv1alpha1.KubeAPIServerConfig{
-					KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{
-						EventTTL: eventTTL,
-					},
-				}
-
-				Expect(handler.Default(ctx, garden)).To(Succeed())
-				Expect(garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.EventTTL).To(Equal(expectedEventTTL))
-			},
-			Entry("should not modify when eventTTL is nil",
-				nil,
-				&metav1.Duration{Duration: 1 * time.Hour},
-			),
-			Entry("should not modify when within valid range",
-				&metav1.Duration{Duration: 12 * time.Hour},
-				&metav1.Duration{Duration: 12 * time.Hour},
-			),
-			Entry("should not modify when exactly 24h",
-				&metav1.Duration{Duration: 24 * time.Hour},
-				&metav1.Duration{Duration: 24 * time.Hour},
-			),
-			Entry("cap to 24h when exceeding maximum",
-				&metav1.Duration{Duration: 48 * time.Hour},
-				&metav1.Duration{Duration: 24 * time.Hour},
-			),
-		)
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity ops-productivity
/kind cleanup

**What this PR does / why we need it**:
This PR reverts commit https://github.com/gardener/gardener/pull/14707/changes/572bcf788b2d08cf3ea7ddcb0c1ab13a99b08a5c from PR https://github.com/gardener/gardener/pull/14707.
To mitigate the impact of the breaking change related to the newly introduced validation, with https://github.com/gardener/gardener/pull/14707 existing out-of-range Shoot, ManagedSeedSet and Garden `eventTTL` field values were capped to the max allowed value (24h).

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/14707
Part of https://github.com/gardener/gardener/issues/13825

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The existing backwards-compatibility logic in gardener-apiserver and gardener-operator for capping out-of-range `eventTTL` field values to the new maximum allowed value (24h) is now removed.
```
