### PR TITLE
Skip automatic etcdEncryptionKey rotation for hibernated shoots

### DIFF
--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -773,6 +773,7 @@ build:
             - pkg/utils/gardener/secretsrotation
             - pkg/utils/gardener/shootstate
             - pkg/utils/gardener/tokenrequest
+            - pkg/utils/hibernation
             - pkg/utils/imagevector
             - pkg/utils/istio
             - pkg/utils/kubernetes

--- a/dev-setup/skaffold-operator.yaml
+++ b/dev-setup/skaffold-operator.yaml
@@ -700,6 +700,7 @@ build:
             - pkg/utils/flow
             - pkg/utils/gardener
             - pkg/utils/gardener/gardenlet
+            - pkg/utils/hibernation
             - pkg/utils/imagevector
             - pkg/utils/kubernetes
             - pkg/utils/kubernetes/bootstraptoken

--- a/dev-setup/skaffold-seed.yaml
+++ b/dev-setup/skaffold-seed.yaml
@@ -291,6 +291,7 @@ build:
             - pkg/utils/gardener/secretsrotation
             - pkg/utils/gardener/shootstate
             - pkg/utils/gardener/tokenrequest
+            - pkg/utils/hibernation
             - pkg/utils/imagevector
             - pkg/utils/istio
             - pkg/utils/kubernetes

--- a/docs/usage/shoot-operations/shoot_credentials_rotation.md
+++ b/docs/usage/shoot-operations/shoot_credentials_rotation.md
@@ -276,7 +276,7 @@ The encryption key has no expiration date.
 **Unless automatic credentials rotation is enabled, it is the responsibility of the end-user to regularly rotate those credentials.**
 Refer to [Automatic Credentials Rotation](../shoot/shoot_maintenance.md#automatic-credentials-rotation) for instructions on enabling automatic rotation for etcd encryption key.
 
-Automatic ETCD encryption key rotation requires a running ETCD and `kube-apiserver`, so it is skipped while the Shoot is hibernated. For Shoots using the `aesgcm` encryption provider, if an overdue automatic rotation cannot run during the next maintenance window because of the hibernation schedule, Gardener reports the `AutomaticCredentialsRotationPossible` constraint in the Shoot status. Adjust the maintenance window or hibernation schedule so that maintenance runs while the Shoot is awake.
+Automatic ETCD encryption key rotation requires a running ETCD and `kube-apiserver`, so it is skipped while the Shoot is hibernated. If an overdue automatic rotation cannot run during the next maintenance window because of the hibernation schedule, Gardener reports the `AutomaticCredentialsRotationPossible` constraint in the Shoot status. Adjust the maintenance window or hibernation schedule so that maintenance runs while the Shoot is awake.
 
 The rotation happens in three stages:
 

--- a/docs/usage/shoot-operations/shoot_credentials_rotation.md
+++ b/docs/usage/shoot-operations/shoot_credentials_rotation.md
@@ -276,6 +276,8 @@ The encryption key has no expiration date.
 **Unless automatic credentials rotation is enabled, it is the responsibility of the end-user to regularly rotate those credentials.**
 Refer to [Automatic Credentials Rotation](../shoot/shoot_maintenance.md#automatic-credentials-rotation) for instructions on enabling automatic rotation for etcd encryption key.
 
+Automatic ETCD encryption key rotation requires a running ETCD and `kube-apiserver`, so it is skipped while the Shoot is hibernated. For Shoots using the `aesgcm` encryption provider, if an overdue automatic rotation cannot run during the next maintenance window because of the hibernation schedule, Gardener reports the `AutomaticCredentialsRotationPossible` constraint in the Shoot status. Adjust the maintenance window or hibernation schedule so that maintenance runs while the Shoot is awake.
+
 The rotation happens in three stages:
 
 - In stage one, a new encryption key is created and added to the bundle (together with the old encryption key).

--- a/docs/usage/shoot/shoot_maintenance.md
+++ b/docs/usage/shoot/shoot_maintenance.md
@@ -107,7 +107,7 @@ spec:
 > See [ETCD Encryption Config](../security/etcd_encryption_config.md) for more details.
 
 During the daily maintenance, the `gardener-controller-manager` starts the rotation for specific credentials if the Shoot opted-in for automatic rotation for the given credential and the set period has passed since the last rotation completion.
-Automatic ETCD encryption key rotation requires a running ETCD and `kube-apiserver`, so it is skipped while the Shoot is hibernated. This is particularly relevant for Shoots using the `aesgcm` encryption provider. If an overdue automatic rotation cannot run during the next maintenance window because of the hibernation schedule, Gardener reports the `AutomaticCredentialsRotationPossible` constraint in the Shoot status. Adjust the maintenance window or hibernation schedule so that maintenance runs while the Shoot is awake.
+Automatic ETCD encryption key rotation requires a running ETCD and `kube-apiserver`, so it is skipped while the Shoot is hibernated. If an overdue automatic rotation cannot run during the next maintenance window because of the hibernation schedule, Gardener reports the `AutomaticCredentialsRotationPossible` constraint in the Shoot status. Adjust the maintenance window or hibernation schedule so that maintenance runs while the Shoot is awake.
 Automatic rotation can be disabled for specific credential by setting the `rotationPeriod` field to `0`.
 
 ## Cluster Reconciliation

--- a/docs/usage/shoot/shoot_maintenance.md
+++ b/docs/usage/shoot/shoot_maintenance.md
@@ -107,6 +107,7 @@ spec:
 > See [ETCD Encryption Config](../security/etcd_encryption_config.md) for more details.
 
 During the daily maintenance, the `gardener-controller-manager` starts the rotation for specific credentials if the Shoot opted-in for automatic rotation for the given credential and the set period has passed since the last rotation completion.
+If the cluster is hibernated, the ETCD encryption key rotation is skipped, because it can only be completed with a running etcd and kube-apiserver.
 Automatic rotation can be disabled for specific credential by setting the `rotationPeriod` field to `0`.
 
 ## Cluster Reconciliation

--- a/docs/usage/shoot/shoot_maintenance.md
+++ b/docs/usage/shoot/shoot_maintenance.md
@@ -107,7 +107,7 @@ spec:
 > See [ETCD Encryption Config](../security/etcd_encryption_config.md) for more details.
 
 During the daily maintenance, the `gardener-controller-manager` starts the rotation for specific credentials if the Shoot opted-in for automatic rotation for the given credential and the set period has passed since the last rotation completion.
-If the cluster is hibernated, the ETCD encryption key rotation is skipped, because it can only be completed with a running etcd and kube-apiserver.
+Automatic ETCD encryption key rotation requires a running ETCD and `kube-apiserver`, so it is skipped while the Shoot is hibernated. This is particularly relevant for Shoots using the `aesgcm` encryption provider. If an overdue automatic rotation cannot run during the next maintenance window because of the hibernation schedule, Gardener reports the `AutomaticCredentialsRotationPossible` constraint in the Shoot status. Adjust the maintenance window or hibernation schedule so that maintenance runs while the Shoot is awake.
 Automatic rotation can be disabled for specific credential by setting the `rotationPeriod` field to `0`.
 
 ## Cluster Reconciliation

--- a/docs/usage/shoot/shoot_status.md
+++ b/docs/usage/shoot/shoot_status.md
@@ -131,6 +131,12 @@ If it's visible, operators should be aware that the annotated resources may dive
 This constraint indicates that one or more machines in `Failed` phase are currently being preserved (i.e., not terminated) to allow for debugging and analysis. The constraint is not added to `.status.constraints` when no failed machines are currently preserved.
 See [Machine Preservation](shoot_machine_preservation.md) for more details.
 
+**`AutomaticCredentialsRotationPossible`**:
+
+This optional constraint indicates whether an overdue automatic ETCD encryption key rotation can run during the next maintenance window. It is relevant only to Shoots that use the `aesgcm` encryption provider and have automatic ETCD encryption key rotation enabled.
+The constraint is omitted when automatic rotation is not required or can run. It is added with status `False` when the next maintenance window is affected by hibernation, because ETCD encryption key rotation requires a running ETCD and `kube-apiserver`.
+If it is present, adjust the maintenance window or hibernation schedule so that maintenance runs while the Shoot is awake. See [ETCD Encryption Key](../shoot-operations/shoot_credentials_rotation.md#etcd-encryption-key) for details.
+
 
 ### Last Operation
 

--- a/docs/usage/shoot/shoot_status.md
+++ b/docs/usage/shoot/shoot_status.md
@@ -133,7 +133,7 @@ See [Machine Preservation](shoot_machine_preservation.md) for more details.
 
 **`AutomaticCredentialsRotationPossible`**:
 
-This optional constraint indicates whether an overdue automatic ETCD encryption key rotation can run during the next maintenance window. It is relevant only to Shoots that use the `aesgcm` encryption provider and have automatic ETCD encryption key rotation enabled.
+This optional constraint indicates whether an overdue automatic ETCD encryption key rotation can run during the next maintenance window.
 The constraint is omitted when automatic rotation is not required or can run. It is added with status `False` when the next maintenance window is affected by hibernation, because ETCD encryption key rotation requires a running ETCD and `kube-apiserver`.
 If it is present, adjust the maintenance window or hibernation schedule so that maintenance runs while the Shoot is awake. See [ETCD Encryption Key](../shoot-operations/shoot_credentials_rotation.md#etcd-encryption-key) for details.
 

--- a/pkg/api/core/v1beta1/helper/shoot.go
+++ b/pkg/api/core/v1beta1/helper/shoot.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -711,6 +712,45 @@ func IsETCDEncryptionKeyAutoRotationEnabled(shoot *gardencorev1beta1.Shoot) bool
 		shoot.Spec.Maintenance.AutoRotation.Credentials.ETCDEncryptionKey != nil &&
 		shoot.Spec.Maintenance.AutoRotation.Credentials.ETCDEncryptionKey.RotationPeriod != nil &&
 		shoot.Spec.Maintenance.AutoRotation.Credentials.ETCDEncryptionKey.RotationPeriod.Duration != 0
+}
+
+// SSHKeypairRotationPassedRotationPeriod returns true if the SSH keypair rotation period has passed.
+// If the credentials have never been rotated, the shoot's creation timestamp is used as the reference point.
+func SSHKeypairRotationPassedRotationPeriod(shoot *gardencorev1beta1.Shoot, now time.Time, period metav1.Duration) bool {
+	latestRotationCompletionTime := shoot.CreationTimestamp.Time
+	if shoot.Status.Credentials != nil &&
+		shoot.Status.Credentials.Rotation != nil &&
+		shoot.Status.Credentials.Rotation.SSHKeypair != nil &&
+		shoot.Status.Credentials.Rotation.SSHKeypair.LastCompletionTime != nil {
+		latestRotationCompletionTime = shoot.Status.Credentials.Rotation.SSHKeypair.LastCompletionTime.Time
+	}
+	return latestRotationCompletionTime.Before(now.Add(-period.Duration))
+}
+
+// ObservabilityRotationPassedRotationPeriod returns true if the observability passwords rotation period has passed.
+// If the credentials have never been rotated, the shoot's creation timestamp is used as the reference point.
+func ObservabilityRotationPassedRotationPeriod(shoot *gardencorev1beta1.Shoot, now time.Time, period metav1.Duration) bool {
+	latestRotationCompletionTime := shoot.CreationTimestamp.Time
+	if shoot.Status.Credentials != nil &&
+		shoot.Status.Credentials.Rotation != nil &&
+		shoot.Status.Credentials.Rotation.Observability != nil &&
+		shoot.Status.Credentials.Rotation.Observability.LastCompletionTime != nil {
+		latestRotationCompletionTime = shoot.Status.Credentials.Rotation.Observability.LastCompletionTime.Time
+	}
+	return latestRotationCompletionTime.Before(now.Add(-period.Duration))
+}
+
+// ETCDEncryptionKeyRotationPassedRotationPeriod returns true if the ETCD encryption key rotation period has passed.
+// If the credentials have never been rotated, the shoot's creation timestamp is used as the reference point.
+func ETCDEncryptionKeyRotationPassedRotationPeriod(shoot *gardencorev1beta1.Shoot, now time.Time, period metav1.Duration) bool {
+	latestRotationCompletionTime := shoot.CreationTimestamp.Time
+	if shoot.Status.Credentials != nil &&
+		shoot.Status.Credentials.Rotation != nil &&
+		shoot.Status.Credentials.Rotation.ETCDEncryptionKey != nil &&
+		shoot.Status.Credentials.Rotation.ETCDEncryptionKey.LastCompletionTime != nil {
+		latestRotationCompletionTime = shoot.Status.Credentials.Rotation.ETCDEncryptionKey.LastCompletionTime.Time
+	}
+	return latestRotationCompletionTime.Before(now.Add(-period.Duration))
 }
 
 // GetEncryptionProviderType returns the encryption provider type.

--- a/pkg/api/core/v1beta1/helper/shoot_test.go
+++ b/pkg/api/core/v1beta1/helper/shoot_test.go
@@ -409,6 +409,74 @@ var _ = Describe("Helper", func() {
 			}, true),
 	)
 
+	Describe("rotation period passed", func() {
+		creationTimestamp := metav1.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		rotationPeriod := 2 * time.Hour
+
+		DescribeTable("#SSHKeypairRotationPassedRotationPeriod",
+			func(credentials *gardencorev1beta1.ShootCredentials, now time.Time, expectedResult bool) {
+				shoot := &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{CreationTimestamp: creationTimestamp},
+					Status:     gardencorev1beta1.ShootStatus{Credentials: credentials},
+				}
+				Expect(SSHKeypairRotationPassedRotationPeriod(shoot, now, metav1.Duration{Duration: rotationPeriod})).To(Equal(expectedResult))
+			},
+
+			Entry("should return false when the shoot age is less than rotation period", nil,
+				creationTimestamp.Add(time.Hour), false),
+			Entry("should use shoot creation time when rotation status is absent", nil,
+				creationTimestamp.Add(3*time.Hour), true),
+			Entry("should return false when the rotation period has not passed since the last completion time",
+				&gardencorev1beta1.ShootCredentials{Rotation: &gardencorev1beta1.ShootCredentialsRotation{SSHKeypair: &gardencorev1beta1.ShootSSHKeypairRotation{LastCompletionTime: new(metav1.NewTime(creationTimestamp.Add(2 * time.Hour)))}}},
+				creationTimestamp.Add(3*time.Hour), false),
+			Entry("should return true when the rotation period has passed since the last completion time",
+				&gardencorev1beta1.ShootCredentials{Rotation: &gardencorev1beta1.ShootCredentialsRotation{SSHKeypair: &gardencorev1beta1.ShootSSHKeypairRotation{LastCompletionTime: new(metav1.NewTime(creationTimestamp.Add(2 * time.Hour)))}}},
+				creationTimestamp.Add(5*time.Hour), true),
+		)
+
+		DescribeTable("#ObservabilityRotationPassedRotationPeriod",
+			func(credentials *gardencorev1beta1.ShootCredentials, now time.Time, expectedResult bool) {
+				shoot := &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{CreationTimestamp: creationTimestamp},
+					Status:     gardencorev1beta1.ShootStatus{Credentials: credentials},
+				}
+				Expect(ObservabilityRotationPassedRotationPeriod(shoot, now, metav1.Duration{Duration: rotationPeriod})).To(Equal(expectedResult))
+			},
+
+			Entry("should return false when the shoot age is less than rotation period", nil,
+				creationTimestamp.Add(time.Hour), false),
+			Entry("should use shoot creation time when rotation status is absent", nil,
+				creationTimestamp.Add(3*time.Hour), true),
+			Entry("should return false when the rotation period has not passed since the last completion time",
+				&gardencorev1beta1.ShootCredentials{Rotation: &gardencorev1beta1.ShootCredentialsRotation{Observability: &gardencorev1beta1.ObservabilityRotation{LastCompletionTime: new(metav1.NewTime(creationTimestamp.Add(2 * time.Hour)))}}},
+				creationTimestamp.Add(3*time.Hour), false),
+			Entry("should return true when the rotation period has passed since the last completion time",
+				&gardencorev1beta1.ShootCredentials{Rotation: &gardencorev1beta1.ShootCredentialsRotation{Observability: &gardencorev1beta1.ObservabilityRotation{LastCompletionTime: new(metav1.NewTime(creationTimestamp.Add(2 * time.Hour)))}}},
+				creationTimestamp.Add(5*time.Hour), true),
+		)
+
+		DescribeTable("#ETCDEncryptionKeyRotationPassedRotationPeriod",
+			func(credentials *gardencorev1beta1.ShootCredentials, now time.Time, expectedResult bool) {
+				shoot := &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{CreationTimestamp: creationTimestamp},
+					Status:     gardencorev1beta1.ShootStatus{Credentials: credentials},
+				}
+				Expect(ETCDEncryptionKeyRotationPassedRotationPeriod(shoot, now, metav1.Duration{Duration: rotationPeriod})).To(Equal(expectedResult))
+			},
+
+			Entry("should return false when the shoot age is less than rotation period", nil,
+				creationTimestamp.Add(time.Hour), false),
+			Entry("should use shoot creation time when rotation status is absent", nil,
+				creationTimestamp.Add(3*time.Hour), true),
+			Entry("should return false when the rotation period has not passed since the last completion time",
+				&gardencorev1beta1.ShootCredentials{Rotation: &gardencorev1beta1.ShootCredentialsRotation{ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{LastCompletionTime: new(metav1.NewTime(creationTimestamp.Add(2 * time.Hour)))}}},
+				creationTimestamp.Add(3*time.Hour), false),
+			Entry("should return true when the rotation period has passed since the last completion time",
+				&gardencorev1beta1.ShootCredentials{Rotation: &gardencorev1beta1.ShootCredentialsRotation{ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{LastCompletionTime: new(metav1.NewTime(creationTimestamp.Add(2 * time.Hour)))}}},
+				creationTimestamp.Add(5*time.Hour), true),
+		)
+	})
+
 	Describe("#IsMultiZonalShootControlPlane", func() {
 		var shoot *gardencorev1beta1.Shoot
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -2183,6 +2183,11 @@ const (
 	// in the Shoot's control plane namespace in the seed have been annotated with resources.gardener.cloud/ignore=true,
 	// meaning their reconciliation has been disabled. Operators should be aware of such resources as they may diverge from the desired state.
 	ShootHasIgnoredManagedResources ConditionType = "HasIgnoredManagedResources"
+	// ShootHibernationScheduleProblematic is a constant for a condition type indicating that the shoot has a
+	// hibernation schedule that may lead to problems. For example, when using AESGCM encryption for etcd and a
+	// maintenance window that is entirely within the hibernation window, the ETCD encryption key auto-rotation can
+	// never be triggered automatically during maintenance.
+	ShootHibernationScheduleProblematic ConditionType = "HibernationScheduleProblematic"
 	// ShootReadyForMigration is a constant for a condition type indicating whether the Shoot can be migrated.
 	ShootReadyForMigration ConditionType = "ReadyForMigration"
 	// ShootDualStackNodesMigrationReady is a constant for a condition type indicating whether all nodes are migrated to dual-stack .

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -2183,9 +2183,8 @@ const (
 	// in the Shoot's control plane namespace in the seed have been annotated with resources.gardener.cloud/ignore=true,
 	// meaning their reconciliation has been disabled. Operators should be aware of such resources as they may diverge from the desired state.
 	ShootHasIgnoredManagedResources ConditionType = "HasIgnoredManagedResources"
-	// ShootAutomaticCredentialsRotationPossible is a constant for a condition type indicating whether automatic
-	// credentials rotation can run. For example, an AESGCM-encrypted etcd cannot rotate its encryption key when the
-	// maintenance window is entirely within a hibernation window.
+	// ShootAutomaticCredentialsRotationPossible is a constant for a condition type indicating whether an automatic
+	// ETCD encryption key rotation can run during the next maintenance window.
 	ShootAutomaticCredentialsRotationPossible ConditionType = "AutomaticCredentialsRotationPossible"
 	// ShootReadyForMigration is a constant for a condition type indicating whether the Shoot can be migrated.
 	ShootReadyForMigration ConditionType = "ReadyForMigration"

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -2183,11 +2183,10 @@ const (
 	// in the Shoot's control plane namespace in the seed have been annotated with resources.gardener.cloud/ignore=true,
 	// meaning their reconciliation has been disabled. Operators should be aware of such resources as they may diverge from the desired state.
 	ShootHasIgnoredManagedResources ConditionType = "HasIgnoredManagedResources"
-	// ShootHibernationScheduleProblematic is a constant for a condition type indicating that the shoot has a
-	// hibernation schedule that may lead to problems. For example, when using AESGCM encryption for etcd and a
-	// maintenance window that is entirely within the hibernation window, the ETCD encryption key auto-rotation can
-	// never be triggered automatically during maintenance.
-	ShootHibernationScheduleProblematic ConditionType = "HibernationScheduleProblematic"
+	// ShootAutomaticCredentialsRotationPossible is a constant for a condition type indicating whether automatic
+	// credentials rotation can run. For example, an AESGCM-encrypted etcd cannot rotate its encryption key when the
+	// maintenance window is entirely within a hibernation window.
+	ShootAutomaticCredentialsRotationPossible ConditionType = "AutomaticCredentialsRotationPossible"
 	// ShootReadyForMigration is a constant for a condition type indicating whether the Shoot can be migrated.
 	ShootReadyForMigration ConditionType = "ReadyForMigration"
 	// ShootDualStackNodesMigrationReady is a constant for a condition type indicating whether all nodes are migrated to dual-stack .

--- a/pkg/controllermanager/controller/shoot/hibernation/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/hibernation/reconciler.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/robfig/cron"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,48 +22,13 @@ import (
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/controllermanager/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	hibernationutils "github.com/gardener/gardener/pkg/utils/hibernation"
 )
 
 const (
 	sevenDays         = 7 * 24 * time.Hour
 	nextScheduleDelta = 100 * time.Millisecond
 )
-
-type operation uint8
-
-const (
-	hibernate operation = iota
-	wakeUp
-)
-
-// parsedHibernationSchedule holds the loaded location, parsed cron schedule and information whether
-// the cluster should be hibernated or woken up.
-type parsedHibernationSchedule struct {
-	location  time.Location
-	schedule  cron.Schedule
-	operation operation
-}
-
-// next returns the time in UTC from the schedule, that is immediately after the input time 't'.
-// The input 't' is converted in the schedule's location before any calculations are done.
-func (s *parsedHibernationSchedule) next(t time.Time) time.Time {
-	return s.schedule.Next(t.In(&s.location)).UTC()
-}
-
-// previous returns the time in UTC from the schedule that is immediately before 'to' and after 'from'.
-// Nil is returned if no such time can be found.
-// The input times - 'to' and 'from' are converted in the schedule's location before any calculation is done.
-func (s *parsedHibernationSchedule) previous(from, to time.Time) *time.Time {
-	// To get the time that is immediately before `to`, iterate over every activation time in the cron schedule
-	// that is after "from" until the one that is immediately after `to` is reached.
-	var previousActivationTime *time.Time
-	for t := s.schedule.Next(from.In(&s.location)); !t.UTC().After(to.UTC()); t = s.schedule.Next(t) {
-		inUTC := t.UTC()
-		previousActivationTime = &inUTC
-	}
-
-	return previousActivationTime
-}
 
 // Reconciler reconciles Shoots and hibernates or wakes them up according to their hibernation schedules.
 type Reconciler struct {
@@ -98,7 +62,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	parsedSchedules, err := parseHibernationSchedules(schedules)
+	parsedSchedules, err := hibernationutils.Parse(schedules)
 	if err != nil {
 		log.Error(err, "Invalid hibernation schedules, stopping reconciliation")
 		return reconcile.Result{}, nil
@@ -127,13 +91,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return reconcile.Result{RequeueAfter: requeueAfter}, nil
 }
 
-func (r *Reconciler) hibernateOrWakeUpShootBasedOnSchedule(ctx context.Context, shoot *gardencorev1beta1.Shoot, schedule *parsedHibernationSchedule, now time.Time) error {
+func (r *Reconciler) hibernateOrWakeUpShootBasedOnSchedule(ctx context.Context, shoot *gardencorev1beta1.Shoot, schedule *hibernationutils.ParsedSchedule, now time.Time) error {
 	patch := client.MergeFrom(shoot.DeepCopy())
-	switch schedule.operation {
-	case hibernate:
+	switch schedule.Operation {
+	case hibernationutils.Hibernate:
 		shoot.Spec.Hibernation.Enabled = new(true)
 		r.Recorder.Eventf(shoot, nil, corev1.EventTypeNormal, gardencorev1beta1.ShootEventHibernationEnabled, gardencorev1beta1.EventActionReconcile, "Hibernating cluster due to schedule")
-	case wakeUp:
+	case hibernationutils.WakeUp:
 		shoot.Spec.Hibernation.Enabled = new(false)
 		r.Recorder.Eventf(shoot, nil, corev1.EventTypeNormal, gardencorev1beta1.ShootEventHibernationDisabled, gardencorev1beta1.EventActionReconcile, "Waking up cluster due to schedule")
 	}
@@ -146,54 +110,14 @@ func (r *Reconciler) hibernateOrWakeUpShootBasedOnSchedule(ctx context.Context, 
 	return r.Client.Status().Patch(ctx, shoot, patch)
 }
 
-// parseHibernationSchedules parses the given HibernationSchedules and returns an array of ParsedHibernationSchedules
-// If the Location of a HibernationSchedule is `nil`, it is defaulted to UTC.
-func parseHibernationSchedules(schedules []gardencorev1beta1.HibernationSchedule) ([]parsedHibernationSchedule, error) {
-	var parsedHibernationSchedules []parsedHibernationSchedule
-
-	for _, schedule := range schedules {
-		locationID := time.UTC.String()
-		if schedule.Location != nil {
-			locationID = *schedule.Location
-		}
-
-		location, err := time.LoadLocation(locationID)
-		if err != nil {
-			return nil, err
-		}
-
-		if schedule.Start != nil {
-			parsed, err := cron.ParseStandard(*schedule.Start)
-			if err != nil {
-				return nil, err
-			}
-			parsedHibernationSchedules = append(parsedHibernationSchedules,
-				parsedHibernationSchedule{location: *location, schedule: parsed, operation: hibernate},
-			)
-		}
-
-		if schedule.End != nil {
-			parsed, err := cron.ParseStandard(*schedule.End)
-			if err != nil {
-				return nil, err
-			}
-			parsedHibernationSchedules = append(parsedHibernationSchedules,
-				parsedHibernationSchedule{location: *location, schedule: parsed, operation: wakeUp},
-			)
-		}
-	}
-
-	return parsedHibernationSchedules, nil
-}
-
 // nextHibernationTimeDuration returns the time duration after which to requeue the shoot based on the hibernation schedules and current time.
 // It adds a 100ms padding to the next requeue to account for Network Time Protocol(NTP) time skews.
 // If the time drifts are adjusted which in most realistic cases would be around 100ms, scheduled hibernation
 // will still be executed without missing the schedule.
-func nextHibernationTimeDuration(schedules []parsedHibernationSchedule, now time.Time) time.Duration {
+func nextHibernationTimeDuration(schedules []hibernationutils.ParsedSchedule, now time.Time) time.Duration {
 	timeStamps := make([]time.Time, 0, len(schedules))
 	for _, schedule := range schedules {
-		timeStamps = append(timeStamps, schedule.next(now))
+		timeStamps = append(timeStamps, schedule.Next(now))
 	}
 
 	slices.SortFunc(timeStamps, func(a, b time.Time) int {
@@ -203,8 +127,8 @@ func nextHibernationTimeDuration(schedules []parsedHibernationSchedule, now time
 	return timeStamps[0].Add(nextScheduleDelta).Sub(now)
 }
 
-// getScheduleWithMostRecentTime returns the ParsedHibernationSchedule that contains the schedule with the most recent (previous) execution time.
-func getScheduleWithMostRecentTime(schedules []parsedHibernationSchedule, triggerDeadlineDuration *metav1.Duration, shoot *gardencorev1beta1.Shoot, now time.Time) *parsedHibernationSchedule {
+// getScheduleWithMostRecentTime returns the ParsedSchedule that contains the schedule with the most recent (previous) execution time.
+func getScheduleWithMostRecentTime(schedules []hibernationutils.ParsedSchedule, triggerDeadlineDuration *metav1.Duration, shoot *gardencorev1beta1.Shoot, now time.Time) *hibernationutils.ParsedSchedule {
 	// If the shoot has just been created or has never been hibernated, use the creation timestamp.
 	earliestTime := shoot.CreationTimestamp.Time
 	if shoot.Status.LastHibernationTriggerTime != nil {
@@ -225,9 +149,9 @@ func getScheduleWithMostRecentTime(schedules []parsedHibernationSchedule, trigge
 
 	// Iterate over all schedules that were parsed from the shoot specification until we find one that contains
 	// a time entry between `earliestTime` and `now`` and that time entry is the latest one (most recent) with respect to `now`
-	var scheduleWithMostRecentTime *parsedHibernationSchedule
+	var scheduleWithMostRecentTime *hibernationutils.ParsedSchedule
 	for i := range schedules {
-		cur := schedules[i].previous(earliestTime, now)
+		cur := schedules[i].Previous(earliestTime, now)
 		if cur == nil {
 			continue
 		}
@@ -235,7 +159,7 @@ func getScheduleWithMostRecentTime(schedules []parsedHibernationSchedule, trigge
 			scheduleWithMostRecentTime = &schedules[i]
 			continue
 		}
-		mostRecentTime := scheduleWithMostRecentTime.previous(earliestTime, now)
+		mostRecentTime := scheduleWithMostRecentTime.Previous(earliestTime, now)
 		if mostRecentTime == nil {
 			continue
 		}

--- a/pkg/controllermanager/controller/shoot/hibernation/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/hibernation/reconciler_test.go
@@ -46,7 +46,6 @@ var _ = Describe("Shoot Hibernation", func() {
 		locationEUSofia  = "Europe/Sofia"
 
 		weekDayAt2  = "2022-04-12T02:00:00Z"
-		weekDayAt0  = "2022-04-12T00:00:00Z"
 		weekDayAt7  = "2022-04-12T07:00:00Z"
 		weekDayAt19 = "2022-04-12T19:00:00Z"
 
@@ -87,49 +86,6 @@ var _ = Describe("Shoot Hibernation", func() {
 			}
 		}
 	)
-
-	Context("parsedHibernationSchedule", func() {
-		Describe("#next", func() {
-			It("should correctly return the next scheduling time from the parsed schedule", func() {
-				now := mustParseRFC3339Time(weekDayAt2)
-				expected := mustParseRFC3339Time(weekDayAt0).Add(24 * time.Hour)
-
-				parsedSchedule := parsedHibernationSchedule{
-					location: mustLoadLocation(locationEUBerlin),
-					schedule: mustParseStandard(everyDayAt2),
-				}
-				Expect(parsedSchedule.next(now)).To(Equal(expected))
-			})
-		})
-
-		Describe("#previous", func() {
-			It("should correctly return the previous scheduling time from the parsed schedule if it is within the specified range", func() {
-				now := mustParseRFC3339Time(weekDayAt2)
-				from := now.Add(-2 * 24 * time.Hour)
-
-				expected := mustParseRFC3339Time(weekDayAt0)
-				parsedSchedule := parsedHibernationSchedule{
-					location: mustLoadLocation(locationEUBerlin),
-					schedule: mustParseStandard(everyDayAt2),
-				}
-				prev := parsedSchedule.previous(from, now)
-				Expect(prev).NotTo(BeNil())
-				Expect(*prev).To(Equal(expected))
-			})
-
-			It("should return nil if previous scheduling time was not in specified range", func() {
-				now := mustParseRFC3339Time(weekDayAt2)
-				from := now.Add(-1 * time.Hour)
-
-				parsedSchedule := parsedHibernationSchedule{
-					location: mustLoadLocation(locationEUBerlin),
-					schedule: mustParseStandard(everyDayAt2),
-				}
-				prev := parsedSchedule.previous(from, now)
-				Expect(prev).To(BeNil())
-			})
-		})
-	})
 
 	Context("Shoot hibernation reconciliation", func() {
 		Describe("#Reconcile", func() {

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -669,7 +669,7 @@ func computeCredentialsToRotationResults(log logr.Logger, shoot *gardencorev1bet
 	)
 
 	if sshKeypairRotationEnabled && v1beta1helper.ShootEnablesSSHAccess(shoot) &&
-		sshKeypairRotationPassedRotationPeriod(shoot, now.Time, *shoot.Spec.Maintenance.AutoRotation.Credentials.SSHKeypair.RotationPeriod) {
+		v1beta1helper.SSHKeypairRotationPassedRotationPeriod(shoot, now.Time, *shoot.Spec.Maintenance.AutoRotation.Credentials.SSHKeypair.RotationPeriod) {
 		reason := "Automatic rotation of SSH keypair configured"
 		log.Info("SSH keypair for workers will be rotated", "reason", reason)
 		maintenanceResults[v1beta1constants.ShootOperationRotateSSHKeypair] = updateResult{
@@ -680,7 +680,7 @@ func computeCredentialsToRotationResults(log logr.Logger, shoot *gardencorev1bet
 	}
 
 	if observabilityPasswordsRotationEnabled &&
-		observabilityPasswordsRotationPassedRotationPeriod(shoot, now.Time, *shoot.Spec.Maintenance.AutoRotation.Credentials.Observability.RotationPeriod) {
+		v1beta1helper.ObservabilityRotationPassedRotationPeriod(shoot, now.Time, *shoot.Spec.Maintenance.AutoRotation.Credentials.Observability.RotationPeriod) {
 		reason := "Automatic rotation of observability passwords configured"
 		log.Info("Observability passwords will be rotated", "reason", reason)
 		maintenanceResults[v1beta1constants.OperationRotateObservabilityCredentials] = updateResult{
@@ -692,7 +692,7 @@ func computeCredentialsToRotationResults(log logr.Logger, shoot *gardencorev1bet
 
 	if etcdEncryptionKeyRotationEnabled &&
 		!v1beta1helper.HibernationIsEnabled(shoot) && // etcd encryption key rotation is not possible for hibernated shoots
-		etcdEncryptionKeyRotationPassedRotationPeriod(shoot, now.Time, *shoot.Spec.Maintenance.AutoRotation.Credentials.ETCDEncryptionKey.RotationPeriod) {
+		v1beta1helper.ETCDEncryptionKeyRotationPassedRotationPeriod(shoot, now.Time, *shoot.Spec.Maintenance.AutoRotation.Credentials.ETCDEncryptionKey.RotationPeriod) {
 		if len(etcdEncryptionKeyRotationPhase) == 0 || etcdEncryptionKeyRotationPhase == gardencorev1beta1.RotationCompleted {
 			reason := "Automatic rotation of etcd encryption key configured"
 			log.Info("ETCD Encryption key will be rotated", "reason", reason)
@@ -712,51 +712,6 @@ func computeCredentialsToRotationResults(log logr.Logger, shoot *gardencorev1bet
 	}
 
 	return maintenanceResults
-}
-
-// sshKeypairRotationPassedRotationPeriod checks if the rotation period for ssh keypair has passed.
-func sshKeypairRotationPassedRotationPeriod(shoot *gardencorev1beta1.Shoot, now time.Time, period metav1.Duration) bool {
-	// If the shoot has just been created or the credentials have never been rotated, use the shoot's creation timestamp to determine whether the rotation period has passed.
-	latestRotationCompletionTime := shoot.CreationTimestamp.Time
-
-	if shoot.Status.Credentials != nil &&
-		shoot.Status.Credentials.Rotation != nil &&
-		shoot.Status.Credentials.Rotation.SSHKeypair != nil &&
-		shoot.Status.Credentials.Rotation.SSHKeypair.LastCompletionTime != nil {
-		latestRotationCompletionTime = shoot.Status.Credentials.Rotation.SSHKeypair.LastCompletionTime.Time
-	}
-
-	return latestRotationCompletionTime.Before(now.Add(-period.Duration))
-}
-
-// observabilityPasswordsRotationPassedRotationPeriod checks if the rotation period for observability passwords has passed.
-func observabilityPasswordsRotationPassedRotationPeriod(shoot *gardencorev1beta1.Shoot, now time.Time, period metav1.Duration) bool {
-	// If the shoot has just been created or the credentials have never been rotated, use the shoot's creation timestamp to determine whether the rotation period has passed.
-	latestRotationCompletionTime := shoot.CreationTimestamp.Time
-
-	if shoot.Status.Credentials != nil &&
-		shoot.Status.Credentials.Rotation != nil &&
-		shoot.Status.Credentials.Rotation.Observability != nil &&
-		shoot.Status.Credentials.Rotation.Observability.LastCompletionTime != nil {
-		latestRotationCompletionTime = shoot.Status.Credentials.Rotation.Observability.LastCompletionTime.Time
-	}
-
-	return latestRotationCompletionTime.Before(now.Add(-period.Duration))
-}
-
-// etcdEncryptionKeyRotationPassedRotationPeriod checks if the rotation period for the etcd encryption key has passed.
-func etcdEncryptionKeyRotationPassedRotationPeriod(shoot *gardencorev1beta1.Shoot, now time.Time, period metav1.Duration) bool {
-	// If the shoot has just been created or the credentials have never been rotated, use the shoot's creation timestamp to determine whether the rotation period has passed.
-	latestRotationCompletionTime := shoot.CreationTimestamp.Time
-
-	if shoot.Status.Credentials != nil &&
-		shoot.Status.Credentials.Rotation != nil &&
-		shoot.Status.Credentials.Rotation.ETCDEncryptionKey != nil &&
-		shoot.Status.Credentials.Rotation.ETCDEncryptionKey.LastCompletionTime != nil {
-		latestRotationCompletionTime = shoot.Status.Credentials.Rotation.ETCDEncryptionKey.LastCompletionTime.Time
-	}
-
-	return latestRotationCompletionTime.Before(now.Add(-period.Duration))
 }
 
 func determineKubernetesVersion(kubernetesVersion string, profile *gardencorev1beta1.CloudProfile, isExpired bool) (string, error) {

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -691,6 +691,7 @@ func computeCredentialsToRotationResults(log logr.Logger, shoot *gardencorev1bet
 	}
 
 	if etcdEncryptionKeyRotationEnabled &&
+		!v1beta1helper.HibernationIsEnabled(shoot) && // etcd encryption key rotation is not possible for hibernated shoots
 		etcdEncryptionKeyRotationPassedRotationPeriod(shoot, now.Time, *shoot.Spec.Maintenance.AutoRotation.Credentials.ETCDEncryptionKey.RotationPeriod) {
 		if len(etcdEncryptionKeyRotationPhase) == 0 || etcdEncryptionKeyRotationPhase == gardencorev1beta1.RotationCompleted {
 			reason := "Automatic rotation of etcd encryption key configured"

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -133,17 +133,18 @@ var _ = Describe("Shoot Maintenance", func() {
 							MachineImageVersion: new(true),
 						},
 					},
-					Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
-						{
-							Name: "cpu-worker",
-							Machine: gardencorev1beta1.Machine{
-								Image:        shootCurrentImage,
-								Architecture: new("amd64"),
-								Type:         "someMachineType",
+					Provider: gardencorev1beta1.Provider{
+						Workers: []gardencorev1beta1.Worker{
+							{
+								Name: "cpu-worker",
+								Machine: gardencorev1beta1.Machine{
+									Image:        shootCurrentImage,
+									Architecture: new("amd64"),
+									Type:         "someMachineType",
+								},
+								UpdateStrategy: new(gardencorev1beta1.AutoRollingUpdate),
 							},
-							UpdateStrategy: new(gardencorev1beta1.AutoRollingUpdate),
 						},
-					},
 					},
 				},
 			}
@@ -1015,7 +1016,8 @@ var _ = Describe("Shoot Maintenance", func() {
 							"architecture":   []string{v1beta1constants.ArchitectureAMD64},
 							"someCapability": []string{"value2"},
 						},
-					}, {
+					},
+					{
 						Name: "anotherMachineType",
 						Capabilities: gardencorev1beta1.Capabilities{
 							"architecture":   []string{v1beta1constants.ArchitectureAMD64},
@@ -1274,7 +1276,6 @@ var _ = Describe("Shoot Maintenance", func() {
 			_, err := maintainMachineImages(log, shoot, cloudProfile)
 
 			Expect(err).To(HaveOccurred())
-
 		})
 
 		It("should return an error - cloud profile has no matching (machineImage.type) machine type defined", func() {
@@ -1656,6 +1657,17 @@ var _ = Describe("Shoot Maintenance", func() {
 			}))
 		})
 
+		It("should not attempt etcd encryption key rotation when shoot is hibernated", func() {
+			shoot.Spec.Maintenance.AutoRotation.Credentials.SSHKeypair.RotationPeriod.Duration = 0
+			shoot.Spec.Maintenance.AutoRotation.Credentials.Observability.RotationPeriod.Duration = 0
+			shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
+				Enabled: new(true),
+			}
+			results := computeCredentialsToRotationResults(log, shoot, metav1.Time{Time: now})
+
+			Expect(results).To(BeEmpty())
+		})
+
 		It("should not return results when the rotation period has not passed", func() {
 			shoot.CreationTimestamp = metav1.Time{Time: now.Add(-48 * time.Hour)}
 			shoot.Status.Credentials = &gardencorev1beta1.ShootCredentials{
@@ -1676,7 +1688,7 @@ var _ = Describe("Shoot Maintenance", func() {
 			Expect(results).To(BeEmpty())
 		})
 
-		It("should not return results when Shoow is newly created", func() {
+		It("should not return results when Shoot is newly created", func() {
 			shoot.CreationTimestamp = metav1.Time{Time: now}
 			shoot.Status.Credentials = nil
 			results := computeCredentialsToRotationResults(log, shoot, metav1.Time{Time: now})
@@ -2004,9 +2016,7 @@ var _ = Describe("Shoot Maintenance", func() {
 	})
 
 	Describe("#maintainAddons", func() {
-		var (
-			shoot *gardencorev1beta1.Shoot
-		)
+		var shoot *gardencorev1beta1.Shoot
 
 		BeforeEach(func() {
 			shoot = &gardencorev1beta1.Shoot{

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -63,6 +63,15 @@ func shootHibernatedConstraints(clock clock.Clock, conditions ...gardencorev1bet
 			}
 			continue
 		}
+		// Optional constraint computed before the hibernation guard.
+		// Only preserve it if it's non-True (i.e. the configuration is problematic).
+		// When True, drop it — consistent with filterOptionalConstraints behaviour.
+		if cond.Type == gardencorev1beta1.ShootHibernationScheduleProblematic {
+			if cond.Status != gardencorev1beta1.ConditionTrue {
+				hibernationConditions = append(hibernationConditions, cond)
+			}
+			continue
+		}
 		hibernationConditions = append(hibernationConditions, v1beta1helper.UpdatedConditionWithClock(clock, cond, gardencorev1beta1.ConditionTrue, "ConstraintNotChecked", "Shoot cluster has been hibernated."))
 	}
 	return hibernationConditions
@@ -135,6 +144,9 @@ func (c *Constraint) constraintsChecks(
 		constraints.preservedFailedMachinesAbsent = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.preservedFailedMachinesAbsent, status, reason, message)
 	}
 
+	status, reason, message = c.checkIfHibernationScheduleProblematic()
+	constraints.hibernationScheduleProblematic = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.hibernationScheduleProblematic, status, reason, message)
+
 	if c.shoot.HibernationEnabled || c.shoot.GetInfo().Status.IsHibernated {
 		return shootHibernatedConstraints(c.clock, constraints.ConvertToSlice()...)
 	}
@@ -161,14 +173,14 @@ func (c *Constraint) constraintsChecks(
 
 		return filterOptionalConstraints(
 			[]gardencorev1beta1.Condition{constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied},
-			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent},
+			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.hibernationScheduleProblematic},
 		)
 	}
 	if !apiServerRunning {
 		// don't check constraints if API server has already been deleted or has not been created yet
 		return filterOptionalConstraints(
 			shootControlPlaneNotRunningConstraints(c.clock, constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied),
-			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent},
+			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.hibernationScheduleProblematic},
 		)
 	}
 	c.shootClient = shootClient.Client()
@@ -191,7 +203,7 @@ func (c *Constraint) constraintsChecks(
 
 	return filterOptionalConstraints(
 		[]gardencorev1beta1.Condition{constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied},
-		[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.crdsWithProblematicConversionWebhooks, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent},
+		[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.crdsWithProblematicConversionWebhooks, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.hibernationScheduleProblematic},
 	)
 }
 
@@ -509,6 +521,35 @@ func wasRemediatedByGardener(annotations map[string]string) bool {
 	return annotations[v1beta1constants.GardenerWarning] != ""
 }
 
+func (c *Constraint) checkIfHibernationScheduleProblematic() (gardencorev1beta1.ConditionStatus, string, string) {
+	shoot := c.shoot.GetInfo()
+
+	if shoot.Spec.Hibernation == nil || len(shoot.Spec.Hibernation.Schedules) == 0 {
+		return gardencorev1beta1.ConditionTrue,
+			"NoProblematicHibernationSchedule",
+			"Shoot does not have a hibernation schedule."
+	}
+
+	if v1beta1helper.GetEncryptionProviderType(shoot.Spec.Kubernetes.KubeAPIServer) != gardencorev1beta1.EncryptionProviderTypeAESGCM {
+		return gardencorev1beta1.ConditionTrue,
+			"NoProblematicHibernationSchedule",
+			"Shoot does not use AESGCM encryption for etcd."
+	}
+
+	if IsShootAlwaysHibernatedDuringMaintenance(shoot) {
+		return gardencorev1beta1.ConditionFalse,
+			"MaintenanceWindowInHibernationWindow",
+			"The shoot uses AESGCM encryption for etcd and its maintenance window is entirely within the " +
+				"hibernation window. The ETCD encryption key auto-rotation will never be triggered automatically. " +
+				"Please adjust the maintenance window or the hibernation schedule so that maintenance can run " +
+				"while the cluster is awake."
+	}
+
+	return gardencorev1beta1.ConditionTrue,
+		"NoProblematicHibernationSchedule",
+		"The maintenance window is not entirely within the hibernation window."
+}
+
 func filterOptionalConstraints(required, optional []gardencorev1beta1.Condition) []gardencorev1beta1.Condition {
 	var out []gardencorev1beta1.Condition
 	out = append(out, required...)
@@ -529,6 +570,7 @@ type ShootConstraints struct {
 	caCertificateValiditiesAcceptable     gardencorev1beta1.Condition
 	crdsWithProblematicConversionWebhooks gardencorev1beta1.Condition
 	manualInPlaceWorkersUpdated           gardencorev1beta1.Condition
+	hibernationScheduleProblematic        gardencorev1beta1.Condition
 	hasIgnoredManagedResources            gardencorev1beta1.Condition
 	preservedFailedMachinesAbsent         gardencorev1beta1.Condition
 }
@@ -541,6 +583,7 @@ func (g ShootConstraints) ConvertToSlice() []gardencorev1beta1.Condition {
 		g.caCertificateValiditiesAcceptable,
 		g.crdsWithProblematicConversionWebhooks,
 		g.manualInPlaceWorkersUpdated,
+		g.hibernationScheduleProblematic,
 		g.hasIgnoredManagedResources,
 		g.preservedFailedMachinesAbsent,
 	}
@@ -554,6 +597,7 @@ func (g ShootConstraints) ConstraintTypes() []gardencorev1beta1.ConditionType {
 		g.caCertificateValiditiesAcceptable.Type,
 		g.crdsWithProblematicConversionWebhooks.Type,
 		g.manualInPlaceWorkersUpdated.Type,
+		g.hibernationScheduleProblematic.Type,
 		g.hasIgnoredManagedResources.Type,
 		g.preservedFailedMachinesAbsent.Type,
 	}
@@ -568,6 +612,7 @@ func NewShootConstraints(clock clock.Clock, shoot *gardencorev1beta1.Shoot) Shoo
 		caCertificateValiditiesAcceptable:     v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootCACertificateValiditiesAcceptable),
 		crdsWithProblematicConversionWebhooks: v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks),
 		manualInPlaceWorkersUpdated:           v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
+		hibernationScheduleProblematic:        v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootHibernationScheduleProblematic),
 		hasIgnoredManagedResources:            v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootHasIgnoredManagedResources),
 		preservedFailedMachinesAbsent:         v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootPreservedFailedMachinesAbsent),
 	}

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -524,12 +524,6 @@ func wasRemediatedByGardener(annotations map[string]string) bool {
 func (c *Constraint) checkIfAutomaticCredentialsRotationPossible() (gardencorev1beta1.ConditionStatus, string, string) {
 	shoot := c.shoot.GetInfo()
 
-	if v1beta1helper.GetEncryptionProviderType(shoot.Spec.Kubernetes.KubeAPIServer) != gardencorev1beta1.EncryptionProviderTypeAESGCM {
-		return gardencorev1beta1.ConditionTrue,
-			"AutomaticCredentialsRotationNotRequired",
-			"Shoot does not use AESGCM encryption for etcd."
-	}
-
 	if !v1beta1helper.IsETCDEncryptionKeyAutoRotationEnabled(shoot) {
 		return gardencorev1beta1.ConditionTrue,
 			"AutomaticCredentialsRotationNotRequired",
@@ -546,7 +540,7 @@ func (c *Constraint) checkIfAutomaticCredentialsRotationPossible() (gardencorev1
 	if IsShootHibernatedDuringNextMaintenanceWindow(shoot, c.clock.Now()) {
 		return gardencorev1beta1.ConditionFalse,
 			"MaintenanceWindowDuringHibernation",
-			"The shoot uses AESGCM encryption for etcd and its ETCD encryption key rotation is overdue, " +
+			"The ETCD encryption key rotation is overdue, " +
 				"but the next maintenance window falls within a hibernation interval. " +
 				"The ETCD encryption key auto-rotation cannot be triggered automatically. " +
 				"Please adjust the maintenance window or the hibernation schedule so that maintenance can run " +

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -524,30 +524,37 @@ func wasRemediatedByGardener(annotations map[string]string) bool {
 func (c *Constraint) checkIfHibernationScheduleProblematic() (gardencorev1beta1.ConditionStatus, string, string) {
 	shoot := c.shoot.GetInfo()
 
-	if shoot.Spec.Hibernation == nil || len(shoot.Spec.Hibernation.Schedules) == 0 {
-		return gardencorev1beta1.ConditionTrue,
-			"NoProblematicHibernationSchedule",
-			"Shoot does not have a hibernation schedule."
-	}
-
 	if v1beta1helper.GetEncryptionProviderType(shoot.Spec.Kubernetes.KubeAPIServer) != gardencorev1beta1.EncryptionProviderTypeAESGCM {
 		return gardencorev1beta1.ConditionTrue,
 			"NoProblematicHibernationSchedule",
 			"Shoot does not use AESGCM encryption for etcd."
 	}
 
-	if IsShootAlwaysHibernatedDuringMaintenance(shoot) {
+	if !v1beta1helper.IsETCDEncryptionKeyAutoRotationEnabled(shoot) {
+		return gardencorev1beta1.ConditionTrue,
+			"NoProblematicHibernationSchedule",
+			"Automatic ETCD encryption key rotation is not enabled."
+	}
+
+	rotationPeriod := *shoot.Spec.Maintenance.AutoRotation.Credentials.ETCDEncryptionKey.RotationPeriod
+	if !v1beta1helper.ETCDEncryptionKeyRotationPassedRotationPeriod(shoot, c.clock.Now(), rotationPeriod) {
+		return gardencorev1beta1.ConditionTrue,
+			"NoProblematicHibernationSchedule",
+			"The ETCD encryption key rotation period has not yet passed."
+	}
+
+	if IsShootHibernatedDuringNextMaintenanceWindow(shoot, c.clock.Now()) {
 		return gardencorev1beta1.ConditionFalse,
 			"MaintenanceWindowInHibernationWindow",
-			"The shoot uses AESGCM encryption for etcd and its maintenance window is entirely within the " +
-				"hibernation window. The ETCD encryption key auto-rotation will never be triggered automatically. " +
+			"The shoot uses AESGCM encryption for etcd and its ETCD encryption key rotation is overdue, " +
+				"but the next maintenance window falls within a hibernation interval. " +
+				"The ETCD encryption key auto-rotation cannot be triggered automatically. " +
 				"Please adjust the maintenance window or the hibernation schedule so that maintenance can run " +
 				"while the cluster is awake."
 	}
-
 	return gardencorev1beta1.ConditionTrue,
 		"NoProblematicHibernationSchedule",
-		"The maintenance window is not entirely within the hibernation window."
+		"The ETCD encryption key rotation is overdue but the next maintenance window is not within a hibernation interval."
 }
 
 func filterOptionalConstraints(required, optional []gardencorev1beta1.Condition) []gardencorev1beta1.Condition {

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -66,7 +66,7 @@ func shootHibernatedConstraints(clock clock.Clock, conditions ...gardencorev1bet
 		// Optional constraint computed before the hibernation guard.
 		// Only preserve it if it's non-True (i.e. the configuration is problematic).
 		// When True, drop it — consistent with filterOptionalConstraints behaviour.
-		if cond.Type == gardencorev1beta1.ShootHibernationScheduleProblematic {
+		if cond.Type == gardencorev1beta1.ShootAutomaticCredentialsRotationPossible {
 			if cond.Status != gardencorev1beta1.ConditionTrue {
 				hibernationConditions = append(hibernationConditions, cond)
 			}
@@ -144,8 +144,8 @@ func (c *Constraint) constraintsChecks(
 		constraints.preservedFailedMachinesAbsent = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.preservedFailedMachinesAbsent, status, reason, message)
 	}
 
-	status, reason, message = c.checkIfHibernationScheduleProblematic()
-	constraints.hibernationScheduleProblematic = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.hibernationScheduleProblematic, status, reason, message)
+	status, reason, message = c.checkIfAutomaticCredentialsRotationPossible()
+	constraints.automaticCredentialsRotationPossible = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.automaticCredentialsRotationPossible, status, reason, message)
 
 	if c.shoot.HibernationEnabled || c.shoot.GetInfo().Status.IsHibernated {
 		return shootHibernatedConstraints(c.clock, constraints.ConvertToSlice()...)
@@ -173,14 +173,14 @@ func (c *Constraint) constraintsChecks(
 
 		return filterOptionalConstraints(
 			[]gardencorev1beta1.Condition{constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied},
-			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.hibernationScheduleProblematic},
+			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.automaticCredentialsRotationPossible},
 		)
 	}
 	if !apiServerRunning {
 		// don't check constraints if API server has already been deleted or has not been created yet
 		return filterOptionalConstraints(
 			shootControlPlaneNotRunningConstraints(c.clock, constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied),
-			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.hibernationScheduleProblematic},
+			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.automaticCredentialsRotationPossible},
 		)
 	}
 	c.shootClient = shootClient.Client()
@@ -203,7 +203,7 @@ func (c *Constraint) constraintsChecks(
 
 	return filterOptionalConstraints(
 		[]gardencorev1beta1.Condition{constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied},
-		[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.crdsWithProblematicConversionWebhooks, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.hibernationScheduleProblematic},
+		[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.crdsWithProblematicConversionWebhooks, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.automaticCredentialsRotationPossible},
 	)
 }
 
@@ -521,31 +521,31 @@ func wasRemediatedByGardener(annotations map[string]string) bool {
 	return annotations[v1beta1constants.GardenerWarning] != ""
 }
 
-func (c *Constraint) checkIfHibernationScheduleProblematic() (gardencorev1beta1.ConditionStatus, string, string) {
+func (c *Constraint) checkIfAutomaticCredentialsRotationPossible() (gardencorev1beta1.ConditionStatus, string, string) {
 	shoot := c.shoot.GetInfo()
 
 	if v1beta1helper.GetEncryptionProviderType(shoot.Spec.Kubernetes.KubeAPIServer) != gardencorev1beta1.EncryptionProviderTypeAESGCM {
 		return gardencorev1beta1.ConditionTrue,
-			"NoProblematicHibernationSchedule",
+			"AutomaticCredentialsRotationNotRequired",
 			"Shoot does not use AESGCM encryption for etcd."
 	}
 
 	if !v1beta1helper.IsETCDEncryptionKeyAutoRotationEnabled(shoot) {
 		return gardencorev1beta1.ConditionTrue,
-			"NoProblematicHibernationSchedule",
+			"AutomaticCredentialsRotationNotRequired",
 			"Automatic ETCD encryption key rotation is not enabled."
 	}
 
 	rotationPeriod := *shoot.Spec.Maintenance.AutoRotation.Credentials.ETCDEncryptionKey.RotationPeriod
 	if !v1beta1helper.ETCDEncryptionKeyRotationPassedRotationPeriod(shoot, c.clock.Now(), rotationPeriod) {
 		return gardencorev1beta1.ConditionTrue,
-			"NoProblematicHibernationSchedule",
+			"AutomaticCredentialsRotationNotRequired",
 			"The ETCD encryption key rotation period has not yet passed."
 	}
 
 	if IsShootHibernatedDuringNextMaintenanceWindow(shoot, c.clock.Now()) {
 		return gardencorev1beta1.ConditionFalse,
-			"MaintenanceWindowInHibernationWindow",
+			"MaintenanceWindowDuringHibernation",
 			"The shoot uses AESGCM encryption for etcd and its ETCD encryption key rotation is overdue, " +
 				"but the next maintenance window falls within a hibernation interval. " +
 				"The ETCD encryption key auto-rotation cannot be triggered automatically. " +
@@ -553,7 +553,7 @@ func (c *Constraint) checkIfHibernationScheduleProblematic() (gardencorev1beta1.
 				"while the cluster is awake."
 	}
 	return gardencorev1beta1.ConditionTrue,
-		"NoProblematicHibernationSchedule",
+		"AutomaticCredentialsRotationPossible",
 		"The ETCD encryption key rotation is overdue but the next maintenance window is not within a hibernation interval."
 }
 
@@ -577,7 +577,7 @@ type ShootConstraints struct {
 	caCertificateValiditiesAcceptable     gardencorev1beta1.Condition
 	crdsWithProblematicConversionWebhooks gardencorev1beta1.Condition
 	manualInPlaceWorkersUpdated           gardencorev1beta1.Condition
-	hibernationScheduleProblematic        gardencorev1beta1.Condition
+	automaticCredentialsRotationPossible  gardencorev1beta1.Condition
 	hasIgnoredManagedResources            gardencorev1beta1.Condition
 	preservedFailedMachinesAbsent         gardencorev1beta1.Condition
 }
@@ -590,7 +590,7 @@ func (g ShootConstraints) ConvertToSlice() []gardencorev1beta1.Condition {
 		g.caCertificateValiditiesAcceptable,
 		g.crdsWithProblematicConversionWebhooks,
 		g.manualInPlaceWorkersUpdated,
-		g.hibernationScheduleProblematic,
+		g.automaticCredentialsRotationPossible,
 		g.hasIgnoredManagedResources,
 		g.preservedFailedMachinesAbsent,
 	}
@@ -604,7 +604,7 @@ func (g ShootConstraints) ConstraintTypes() []gardencorev1beta1.ConditionType {
 		g.caCertificateValiditiesAcceptable.Type,
 		g.crdsWithProblematicConversionWebhooks.Type,
 		g.manualInPlaceWorkersUpdated.Type,
-		g.hibernationScheduleProblematic.Type,
+		g.automaticCredentialsRotationPossible.Type,
 		g.hasIgnoredManagedResources.Type,
 		g.preservedFailedMachinesAbsent.Type,
 	}
@@ -619,7 +619,7 @@ func NewShootConstraints(clock clock.Clock, shoot *gardencorev1beta1.Shoot) Shoo
 		caCertificateValiditiesAcceptable:     v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootCACertificateValiditiesAcceptable),
 		crdsWithProblematicConversionWebhooks: v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks),
 		manualInPlaceWorkersUpdated:           v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
-		hibernationScheduleProblematic:        v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootHibernationScheduleProblematic),
+		automaticCredentialsRotationPossible:  v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootAutomaticCredentialsRotationPossible),
 		hasIgnoredManagedResources:            v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootHasIgnoredManagedResources),
 		preservedFailedMachinesAbsent:         v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootPreservedFailedMachinesAbsent),
 	}

--- a/pkg/gardenlet/controller/shoot/care/constraints_test.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints_test.go
@@ -709,13 +709,6 @@ var _ = Describe("Constraints", func() {
 							CreationTimestamp: metav1.NewTime(clock.Now().Add(-48 * time.Hour)),
 						},
 						Spec: gardencorev1beta1.ShootSpec{
-							Kubernetes: gardencorev1beta1.Kubernetes{
-								KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-									EncryptionConfig: &gardencorev1beta1.EncryptionConfig{
-										Provider: gardencorev1beta1.EncryptionProvider{Type: new(gardencorev1beta1.EncryptionProviderTypeAESGCM)},
-									},
-								},
-							},
 							Maintenance: &gardencorev1beta1.Maintenance{
 								AutoRotation: &gardencorev1beta1.MaintenanceAutoRotation{
 									Credentials: &gardencorev1beta1.MaintenanceCredentialsAutoRotation{
@@ -738,20 +731,13 @@ var _ = Describe("Constraints", func() {
 						}, clock)
 				})
 
-				It("should remove the constraint when shoot does not use AESGCM encryption", func() {
-					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = new(gardencorev1beta1.EncryptionProviderTypeSecretbox)
+				It("should remove the constraint when shoot has no hibernation schedule", func() {
 					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
 						OfType(gardencorev1beta1.ShootAutomaticCredentialsRotationPossible),
 					))
 				})
 
-				It("should remove the constraint when shoot uses AESGCM but has no hibernation schedule", func() {
-					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
-						OfType(gardencorev1beta1.ShootAutomaticCredentialsRotationPossible),
-					))
-				})
-
-				It("should keep the constraint when AESGCM shoot maintenance window is within the hibernation window", func() {
+				It("should keep the constraint when the maintenance window is within the hibernation window", func() {
 					shoot.Spec.Maintenance.TimeWindow = &gardencorev1beta1.MaintenanceTimeWindow{
 						Begin: "010000+0000",
 						End:   "020000+0000",
@@ -769,7 +755,7 @@ var _ = Describe("Constraints", func() {
 					))
 				})
 
-				It("should remove the constraint when AESGCM shoot maintenance window is outside the hibernation window", func() {
+				It("should remove the constraint when the maintenance window is outside the hibernation window", func() {
 					shoot.Spec.Maintenance = &gardencorev1beta1.Maintenance{
 						TimeWindow: &gardencorev1beta1.MaintenanceTimeWindow{
 							Begin: "100000+0000",

--- a/pkg/gardenlet/controller/shoot/care/constraints_test.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints_test.go
@@ -75,8 +75,8 @@ func (w *webhookTestCase) build() (
 			APIGroups:   []string{w.gvr.Group},
 			Resources:   []string{w.gvr.Resource},
 			APIVersions: []string{w.gvr.Version},
-		}},
-	}
+		},
+	}}
 
 	opType := admissionregistrationv1.OperationAll
 	if w.operationType != nil {
@@ -113,15 +113,18 @@ var _ = Describe("Constraints", func() {
 			kubeSystemNamespaceProblematic = []TableEntry{
 				Entry("namespaceSelector matching no-cleanup", webhookTestCase{
 					namespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"}},
+						MatchLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
+					},
 				}),
 				Entry("namespaceSelector matching purpose", webhookTestCase{
 					namespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
+						MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"},
+					},
 				}),
 				Entry("namespaceSelector matching name label", webhookTestCase{
 					namespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"}},
+						MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"},
+					},
 				}),
 				Entry("namespaceSelector matching all gardener labels", webhookTestCase{
 					namespaceSelector: &metav1.LabelSelector{
@@ -129,14 +132,16 @@ var _ = Describe("Constraints", func() {
 							"shoot.gardener.cloud/no-cleanup": "true",
 							"gardener.cloud/purpose":          "kube-system",
 							"kubernetes.io/metadata.name":     "kube-system",
-						}},
+						},
+					},
 				}),
 			}
 
 			kubeSystemNamespaceNotProblematic = []TableEntry{
 				Entry("not matching namespaceSelector", webhookTestCase{
 					namespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"foo": "bar"}},
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
 				}),
 				Entry("namespaceSelector excluding name label", webhookTestCase{
 					namespaceSelector: &metav1.LabelSelector{
@@ -160,7 +165,8 @@ var _ = Describe("Constraints", func() {
 						Entry("failurePolicy 'Ignore' and timeoutSeconds ok", webhookTestCase{failurePolicy: &failurePolicyIgnore, timeoutSeconds: &timeoutSecondsNotProblematic, objectSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"app.kubernetes.io/name": "test",
-							}}}),
+							},
+						}}),
 						Entry("failurePolicy 'Ignore' and timeoutSeconds ok", webhookTestCase{failurePolicy: &failurePolicyIgnore, timeoutSeconds: &timeoutSecondsNotProblematic}))
 				}
 
@@ -204,30 +210,35 @@ var _ = Describe("Constraints", func() {
 				commonTests(gvr, append(kubeSystemNamespaceProblematic,
 					Entry("objectSelector matching no-cleanup", webhookTestCase{
 						objectSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"}},
+							MatchLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
+						},
 					}),
 					Entry("objectSelector matching origin", webhookTestCase{
 						objectSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"origin": "gardener"}},
+							MatchLabels: map[string]string{"origin": "gardener"},
+						},
 					}),
 					Entry("objectSelector matching all gardener labels", webhookTestCase{
 						objectSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"shoot.gardener.cloud/no-cleanup": "true",
 								"origin":                          "gardener",
-							}},
+							},
+						},
 					}),
 					Entry("objectSelector and namespaceSelector matching all gardener labels", webhookTestCase{
 						objectSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"shoot.gardener.cloud/no-cleanup": "true",
 								"origin":                          "gardener",
-							}},
+							},
+						},
 						namespaceSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"shoot.gardener.cloud/no-cleanup": "true",
 								"gardener.cloud/purpose":          "kube-system",
-							}},
+							},
+						},
 					}),
 				), append(kubeSystemNamespaceNotProblematic,
 					Entry("matching objectSelector, not matching namespaceSelector", webhookTestCase{
@@ -235,22 +246,27 @@ var _ = Describe("Constraints", func() {
 							MatchLabels: map[string]string{
 								"origin":                          "gardener",
 								"shoot.gardener.cloud/no-cleanup": "true",
-							}},
+							},
+						},
 						namespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"foo": "bar"}},
+							MatchLabels: map[string]string{"foo": "bar"},
+						},
 					}),
 					Entry("not matching objectSelector", webhookTestCase{
 						objectSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"foo": "bar"}},
+							MatchLabels: map[string]string{"foo": "bar"},
+						},
 					}),
 					Entry("matching namespaceSelector, not matching objectSelector", webhookTestCase{
 						objectSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"foo": "bar"}},
+							MatchLabels: map[string]string{"foo": "bar"},
+						},
 						namespaceSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"shoot.gardener.cloud/no-cleanup": "true",
 								"gardener.cloud/purpose":          "kube-system",
-							}},
+							},
+						},
 					}),
 				))
 			}
@@ -260,11 +276,13 @@ var _ = Describe("Constraints", func() {
 					problematic = []TableEntry{
 						Entry("namespaceSelector matching purpose", webhookTestCase{
 							namespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
+								MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"},
+							},
 						}),
 						Entry("objectSelector matching purpose", webhookTestCase{
 							objectSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
+								MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"},
+							},
 						}),
 					}
 					notProblematic = []TableEntry{
@@ -277,7 +295,8 @@ var _ = Describe("Constraints", func() {
 						}),
 						Entry("not matching namespaceSelector", webhookTestCase{
 							namespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"foo": "bar"}},
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
 						}),
 						Entry("objectSelector not matching purpose", webhookTestCase{
 							objectSelector: &metav1.LabelSelector{
@@ -288,19 +307,24 @@ var _ = Describe("Constraints", func() {
 						}),
 						Entry("not matching objectSelector", webhookTestCase{
 							objectSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"foo": "bar"}},
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
 						}),
 						Entry("matching objectSelector, not matching namespaceSelector", webhookTestCase{
 							objectSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
+								MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"},
+							},
 							namespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"foo": "bar"}},
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
 						}),
 						Entry("matching namespaceSelector, not matching objectSelector", webhookTestCase{
 							objectSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"foo": "bar"}},
+								MatchLabels: map[string]string{"foo": "bar"},
+							},
 							namespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
+								MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"},
+							},
 						}),
 					}
 				)
@@ -495,6 +519,7 @@ var _ = Describe("Constraints", func() {
 							{Type: gardencorev1beta1.ShootMaintenancePreconditionsSatisfied},
 							{Type: gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks},
 							{Type: gardencorev1beta1.ShootManualInPlaceWorkersUpdated},
+							{Type: gardencorev1beta1.ShootHibernationScheduleProblematic},
 							{Type: gardencorev1beta1.ShootHasIgnoredManagedResources},
 							{Type: gardencorev1beta1.ShootPreservedFailedMachinesAbsent},
 						},
@@ -675,6 +700,126 @@ var _ = Describe("Constraints", func() {
 						WithReason("WorkerPoolsWithManualInPlaceUpdateStrategyPending"),
 						WithMessage("Some worker pools in your Shoot with update strategy ManualInPlaceUpdate are pending update: worker1"),
 					))
+				})
+			})
+
+			Context("#HibernationScheduleProblematic", func() {
+				BeforeEach(func() {
+					shoot = &gardencorev1beta1.Shoot{
+						Spec: gardencorev1beta1.ShootSpec{
+							Kubernetes: gardencorev1beta1.Kubernetes{
+								KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+									EncryptionConfig: &gardencorev1beta1.EncryptionConfig{
+										Provider: gardencorev1beta1.EncryptionProvider{Type: new(gardencorev1beta1.EncryptionProviderTypeAESGCM)},
+									},
+								},
+							},
+						},
+					}
+				})
+
+				JustBeforeEach(func() {
+					shootPkg := &shootpkg.Shoot{ControlPlaneNamespace: controlPlaneNamespace}
+					shootPkg.SetInfo(shoot)
+					constraint = NewConstraint(logr.Discard(), shootPkg, seedClient,
+						func() (kubernetes.Interface, bool, error) {
+							return fakekubernetes.NewClientSetBuilder().WithClient(shootClient).Build(), true, nil
+						}, clock)
+				})
+
+				It("should remove the constraint when shoot does not use AESGCM encryption", func() {
+					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = new(gardencorev1beta1.EncryptionProviderTypeSecretbox)
+					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
+						OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+					))
+				})
+
+				It("should remove the constraint when shoot uses AESGCM but has no hibernation schedule", func() {
+					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
+						OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+					))
+				})
+
+				It("should keep the constraint when AESGCM shoot maintenance window is within the hibernation window", func() {
+					shoot.Spec.Maintenance = &gardencorev1beta1.Maintenance{
+						TimeWindow: &gardencorev1beta1.MaintenanceTimeWindow{
+							Begin: "220000+0000",
+							End:   "230000+0000",
+						},
+					}
+					shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
+						Schedules: []gardencorev1beta1.HibernationSchedule{
+							{Start: new("0 20 * * *"), End: new("0 8 * * *")},
+						},
+					}
+
+					Expect(constraint.Check(ctx, constraints)).To(ContainCondition(
+						OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+						WithStatus(gardencorev1beta1.ConditionProgressing),
+						WithReason("MaintenanceWindowInHibernationWindow"),
+					))
+				})
+
+				It("should remove the constraint when AESGCM shoot maintenance window is outside the hibernation window", func() {
+					shoot.Spec.Maintenance = &gardencorev1beta1.Maintenance{
+						TimeWindow: &gardencorev1beta1.MaintenanceTimeWindow{
+							Begin: "100000+0000",
+							End:   "110000+0000",
+						},
+					}
+					shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
+						Schedules: []gardencorev1beta1.HibernationSchedule{
+							{Start: new("0 20 * * *"), End: new("0 8 * * *")},
+						},
+					}
+
+					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
+						OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+					))
+				})
+
+				Context("when shoot is hibernated", func() {
+					JustBeforeEach(func() {
+						shootPkg := &shootpkg.Shoot{
+							ControlPlaneNamespace: controlPlaneNamespace,
+							HibernationEnabled:    true,
+						}
+						shootPkg.SetInfo(shoot)
+						constraint = NewConstraint(logr.Discard(), shootPkg, seedClient,
+							func() (kubernetes.Interface, bool, error) {
+								return fakekubernetes.NewClientSetBuilder().WithClient(shootClient).Build(), true, nil
+							}, clock)
+						constraints = NewShootConstraints(testclock.NewFakeClock(time.Time{}), shootPkg.GetInfo())
+					})
+
+					It("should remove the constraint when there is no problematic schedule", func() {
+						shoot.Status.Constraints = []gardencorev1beta1.Condition{
+							{Type: gardencorev1beta1.ShootHibernationScheduleProblematic, Status: gardencorev1beta1.ConditionTrue},
+						}
+
+						Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
+							OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+						))
+					})
+
+					It("should preserve the constraint when the configuration is problematic", func() {
+						shoot.Spec.Maintenance = &gardencorev1beta1.Maintenance{
+							TimeWindow: &gardencorev1beta1.MaintenanceTimeWindow{
+								Begin: "220000+0000",
+								End:   "230000+0000",
+							},
+						}
+						shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
+							Schedules: []gardencorev1beta1.HibernationSchedule{
+								{Start: new("0 20 * * *"), End: new("0 8 * * *")},
+							},
+						}
+
+						Expect(constraint.Check(ctx, constraints)).To(ContainCondition(
+							OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+							WithReason("MaintenanceWindowInHibernationWindow"),
+						))
+					})
 				})
 			})
 
@@ -959,6 +1104,7 @@ var _ = Describe("Constraints", func() {
 					OfType("CACertificateValiditiesAcceptable"),
 					OfType("CRDsWithProblematicConversionWebhooks"),
 					OfType("ManualInPlaceWorkersUpdated"),
+					OfType("HibernationScheduleProblematic"),
 					OfType("HasIgnoredManagedResources"),
 					OfType("PreservedFailedMachinesAbsent"),
 				))
@@ -975,6 +1121,7 @@ var _ = Describe("Constraints", func() {
 					gardencorev1beta1.ConditionType("CACertificateValiditiesAcceptable"),
 					gardencorev1beta1.ConditionType("CRDsWithProblematicConversionWebhooks"),
 					gardencorev1beta1.ConditionType("ManualInPlaceWorkersUpdated"),
+					gardencorev1beta1.ConditionType("HibernationScheduleProblematic"),
 					gardencorev1beta1.ConditionType("HasIgnoredManagedResources"),
 					gardencorev1beta1.ConditionType("PreservedFailedMachinesAbsent"),
 				))

--- a/pkg/gardenlet/controller/shoot/care/constraints_test.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -500,7 +499,7 @@ var _ = Describe("Constraints", func() {
 			shoot.SetInfo(&gardencorev1beta1.Shoot{})
 
 			constraint = NewConstraint(
-				logr.Discard(),
+				GinkgoLogr,
 				shoot,
 				seedClient,
 				func() (kubernetes.Interface, bool, error) {
@@ -608,7 +607,7 @@ var _ = Describe("Constraints", func() {
 					shootPkg.SetInfo(shoot)
 
 					constraint = NewConstraint(
-						logr.Discard(),
+						GinkgoLogr,
 						shootPkg,
 						seedClient,
 						func() (kubernetes.Interface, bool, error) {
@@ -627,7 +626,7 @@ var _ = Describe("Constraints", func() {
 					shootPkg.SetInfo(shoot)
 
 					constraint = NewConstraint(
-						logr.Discard(),
+						GinkgoLogr,
 						shootPkg,
 						seedClient,
 						func() (kubernetes.Interface, bool, error) {
@@ -650,7 +649,7 @@ var _ = Describe("Constraints", func() {
 					shootPkg.SetInfo(shoot)
 
 					constraint = NewConstraint(
-						logr.Discard(),
+						GinkgoLogr,
 						shootPkg,
 						seedClient,
 						func() (kubernetes.Interface, bool, error) {
@@ -685,7 +684,7 @@ var _ = Describe("Constraints", func() {
 					shootPkg.SetInfo(shoot)
 
 					constraint = NewConstraint(
-						logr.Discard(),
+						GinkgoLogr,
 						shootPkg,
 						seedClient,
 						func() (kubernetes.Interface, bool, error) {
@@ -706,11 +705,23 @@ var _ = Describe("Constraints", func() {
 			Context("#HibernationScheduleProblematic", func() {
 				BeforeEach(func() {
 					shoot = &gardencorev1beta1.Shoot{
+						ObjectMeta: metav1.ObjectMeta{
+							CreationTimestamp: metav1.NewTime(clock.Now().Add(-48 * time.Hour)),
+						},
 						Spec: gardencorev1beta1.ShootSpec{
 							Kubernetes: gardencorev1beta1.Kubernetes{
 								KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
 									EncryptionConfig: &gardencorev1beta1.EncryptionConfig{
 										Provider: gardencorev1beta1.EncryptionProvider{Type: new(gardencorev1beta1.EncryptionProviderTypeAESGCM)},
+									},
+								},
+							},
+							Maintenance: &gardencorev1beta1.Maintenance{
+								AutoRotation: &gardencorev1beta1.MaintenanceAutoRotation{
+									Credentials: &gardencorev1beta1.MaintenanceCredentialsAutoRotation{
+										ETCDEncryptionKey: &gardencorev1beta1.MaintenanceRotationConfig{
+											RotationPeriod: &metav1.Duration{Duration: 24 * time.Hour},
+										},
 									},
 								},
 							},
@@ -721,7 +732,7 @@ var _ = Describe("Constraints", func() {
 				JustBeforeEach(func() {
 					shootPkg := &shootpkg.Shoot{ControlPlaneNamespace: controlPlaneNamespace}
 					shootPkg.SetInfo(shoot)
-					constraint = NewConstraint(logr.Discard(), shootPkg, seedClient,
+					constraint = NewConstraint(GinkgoLogr, shootPkg, seedClient,
 						func() (kubernetes.Interface, bool, error) {
 							return fakekubernetes.NewClientSetBuilder().WithClient(shootClient).Build(), true, nil
 						}, clock)
@@ -741,15 +752,13 @@ var _ = Describe("Constraints", func() {
 				})
 
 				It("should keep the constraint when AESGCM shoot maintenance window is within the hibernation window", func() {
-					shoot.Spec.Maintenance = &gardencorev1beta1.Maintenance{
-						TimeWindow: &gardencorev1beta1.MaintenanceTimeWindow{
-							Begin: "220000+0000",
-							End:   "230000+0000",
-						},
+					shoot.Spec.Maintenance.TimeWindow = &gardencorev1beta1.MaintenanceTimeWindow{
+						Begin: "010000+0000",
+						End:   "020000+0000",
 					}
 					shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
 						Schedules: []gardencorev1beta1.HibernationSchedule{
-							{Start: new("0 20 * * *"), End: new("0 8 * * *")},
+							{Start: new("0 0 * * *"), End: new("0 8 * * *")},
 						},
 					}
 
@@ -769,7 +778,7 @@ var _ = Describe("Constraints", func() {
 					}
 					shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
 						Schedules: []gardencorev1beta1.HibernationSchedule{
-							{Start: new("0 20 * * *"), End: new("0 8 * * *")},
+							{Start: new("0 0 * * *"), End: new("0 8 * * *")},
 						},
 					}
 
@@ -784,8 +793,9 @@ var _ = Describe("Constraints", func() {
 							ControlPlaneNamespace: controlPlaneNamespace,
 							HibernationEnabled:    true,
 						}
+						shoot.Status.IsHibernated = true
 						shootPkg.SetInfo(shoot)
-						constraint = NewConstraint(logr.Discard(), shootPkg, seedClient,
+						constraint = NewConstraint(GinkgoLogr, shootPkg, seedClient,
 							func() (kubernetes.Interface, bool, error) {
 								return fakekubernetes.NewClientSetBuilder().WithClient(shootClient).Build(), true, nil
 							}, clock)
@@ -803,15 +813,13 @@ var _ = Describe("Constraints", func() {
 					})
 
 					It("should preserve the constraint when the configuration is problematic", func() {
-						shoot.Spec.Maintenance = &gardencorev1beta1.Maintenance{
-							TimeWindow: &gardencorev1beta1.MaintenanceTimeWindow{
-								Begin: "220000+0000",
-								End:   "230000+0000",
-							},
+						shoot.Spec.Maintenance.TimeWindow = &gardencorev1beta1.MaintenanceTimeWindow{
+							Begin: "010000+0000",
+							End:   "020000+0000",
 						}
 						shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
 							Schedules: []gardencorev1beta1.HibernationSchedule{
-								{Start: new("0 20 * * *"), End: new("0 8 * * *")},
+								{Start: new("0 0 * * *"), End: new("0 8 * * *")},
 							},
 						}
 
@@ -880,7 +888,7 @@ var _ = Describe("Constraints", func() {
 						shootPkg.SetInfo(shoot)
 
 						hibernatedConstraint = NewConstraint(
-							logr.Discard(),
+							GinkgoLogr,
 							shootPkg,
 							seedClient,
 							func() (kubernetes.Interface, bool, error) {
@@ -938,7 +946,7 @@ var _ = Describe("Constraints", func() {
 							},
 						})
 						constraint = NewConstraint(
-							logr.Discard(),
+							GinkgoLogr,
 							shootPkg,
 							seedClient,
 							func() (kubernetes.Interface, bool, error) {
@@ -1068,6 +1076,7 @@ var _ = Describe("Constraints", func() {
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
+					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 				))
 			})
 
@@ -1084,6 +1093,7 @@ var _ = Describe("Constraints", func() {
 
 				Expect(constraints.ConvertToSlice()).To(ConsistOf(
 					hibernationPossibleConstraint,
+					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),

--- a/pkg/gardenlet/controller/shoot/care/constraints_test.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints_test.go
@@ -518,7 +518,7 @@ var _ = Describe("Constraints", func() {
 							{Type: gardencorev1beta1.ShootMaintenancePreconditionsSatisfied},
 							{Type: gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks},
 							{Type: gardencorev1beta1.ShootManualInPlaceWorkersUpdated},
-							{Type: gardencorev1beta1.ShootHibernationScheduleProblematic},
+							{Type: gardencorev1beta1.ShootAutomaticCredentialsRotationPossible},
 							{Type: gardencorev1beta1.ShootHasIgnoredManagedResources},
 							{Type: gardencorev1beta1.ShootPreservedFailedMachinesAbsent},
 						},
@@ -702,7 +702,7 @@ var _ = Describe("Constraints", func() {
 				})
 			})
 
-			Context("#HibernationScheduleProblematic", func() {
+			Context("#AutomaticCredentialsRotationPossible", func() {
 				BeforeEach(func() {
 					shoot = &gardencorev1beta1.Shoot{
 						ObjectMeta: metav1.ObjectMeta{
@@ -741,13 +741,13 @@ var _ = Describe("Constraints", func() {
 				It("should remove the constraint when shoot does not use AESGCM encryption", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = new(gardencorev1beta1.EncryptionProviderTypeSecretbox)
 					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
-						OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+						OfType(gardencorev1beta1.ShootAutomaticCredentialsRotationPossible),
 					))
 				})
 
 				It("should remove the constraint when shoot uses AESGCM but has no hibernation schedule", func() {
 					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
-						OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+						OfType(gardencorev1beta1.ShootAutomaticCredentialsRotationPossible),
 					))
 				})
 
@@ -763,9 +763,9 @@ var _ = Describe("Constraints", func() {
 					}
 
 					Expect(constraint.Check(ctx, constraints)).To(ContainCondition(
-						OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+						OfType(gardencorev1beta1.ShootAutomaticCredentialsRotationPossible),
 						WithStatus(gardencorev1beta1.ConditionProgressing),
-						WithReason("MaintenanceWindowInHibernationWindow"),
+						WithReason("MaintenanceWindowDuringHibernation"),
 					))
 				})
 
@@ -783,7 +783,7 @@ var _ = Describe("Constraints", func() {
 					}
 
 					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
-						OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+						OfType(gardencorev1beta1.ShootAutomaticCredentialsRotationPossible),
 					))
 				})
 
@@ -804,11 +804,11 @@ var _ = Describe("Constraints", func() {
 
 					It("should remove the constraint when there is no problematic schedule", func() {
 						shoot.Status.Constraints = []gardencorev1beta1.Condition{
-							{Type: gardencorev1beta1.ShootHibernationScheduleProblematic, Status: gardencorev1beta1.ConditionTrue},
+							{Type: gardencorev1beta1.ShootAutomaticCredentialsRotationPossible, Status: gardencorev1beta1.ConditionTrue},
 						}
 
 						Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
-							OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+							OfType(gardencorev1beta1.ShootAutomaticCredentialsRotationPossible),
 						))
 					})
 
@@ -824,8 +824,8 @@ var _ = Describe("Constraints", func() {
 						}
 
 						Expect(constraint.Check(ctx, constraints)).To(ContainCondition(
-							OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
-							WithReason("MaintenanceWindowInHibernationWindow"),
+							OfType(gardencorev1beta1.ShootAutomaticCredentialsRotationPossible),
+							WithReason("MaintenanceWindowDuringHibernation"),
 						))
 					})
 				})
@@ -1114,7 +1114,7 @@ var _ = Describe("Constraints", func() {
 					OfType("CACertificateValiditiesAcceptable"),
 					OfType("CRDsWithProblematicConversionWebhooks"),
 					OfType("ManualInPlaceWorkersUpdated"),
-					OfType("HibernationScheduleProblematic"),
+					OfType("AutomaticCredentialsRotationPossible"),
 					OfType("HasIgnoredManagedResources"),
 					OfType("PreservedFailedMachinesAbsent"),
 				))
@@ -1131,7 +1131,7 @@ var _ = Describe("Constraints", func() {
 					gardencorev1beta1.ConditionType("CACertificateValiditiesAcceptable"),
 					gardencorev1beta1.ConditionType("CRDsWithProblematicConversionWebhooks"),
 					gardencorev1beta1.ConditionType("ManualInPlaceWorkersUpdated"),
-					gardencorev1beta1.ConditionType("HibernationScheduleProblematic"),
+					gardencorev1beta1.ConditionType("AutomaticCredentialsRotationPossible"),
 					gardencorev1beta1.ConditionType("HasIgnoredManagedResources"),
 					gardencorev1beta1.ConditionType("PreservedFailedMachinesAbsent"),
 				))

--- a/pkg/gardenlet/controller/shoot/care/hibernation.go
+++ b/pkg/gardenlet/controller/shoot/care/hibernation.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package care
+
+import (
+	"slices"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	timewindowutils "github.com/gardener/gardener/pkg/apis/utils/timewindow"
+	hibernationutils "github.com/gardener/gardener/pkg/utils/hibernation"
+)
+
+// Collect all events inside [simStart, simEnd) and sort by time.
+type hibernationScheduleEvent struct {
+	at        time.Time
+	operation hibernationutils.Operation
+}
+
+// IsShootAlwaysHibernatedDuringMaintenance returns true when the hibernation schedule of the shoot is such that the shoot is
+// always hibernated during the maintenance window.
+//
+// Because the hibernation schedules are defined by cron schedules, we determine this by running a simulation of all
+// wake-up and hibernation events and checking if any awake interval fully covers the maintenance window.
+func IsShootAlwaysHibernatedDuringMaintenance(shoot *gardencorev1beta1.Shoot) bool {
+	if shoot.Spec.Maintenance == nil || shoot.Spec.Maintenance.TimeWindow == nil {
+		return false
+	}
+	if shoot.Spec.Hibernation == nil || len(shoot.Spec.Hibernation.Schedules) == 0 {
+		return false
+	}
+
+	maintenanceWindow, err := timewindowutils.ParseMaintenanceTimeWindow(
+		shoot.Spec.Maintenance.TimeWindow.Begin,
+		shoot.Spec.Maintenance.TimeWindow.End,
+	)
+	if err != nil {
+		return false
+	}
+
+	schedules, err := hibernationutils.Parse(shoot.Spec.Hibernation.Schedules)
+	if err != nil || len(schedules) == 0 {
+		return false
+	}
+
+	// If there are no wake-up events at all we assume it's never awake during maintenance and return true
+	if hasWakeEvent := slices.ContainsFunc(schedules, func(s hibernationutils.ParsedSchedule) bool {
+		return s.Operation == hibernationutils.WakeUp
+	}); !hasWakeEvent {
+		return true
+	}
+
+	events, ok := simulateHibernationSchedule(schedules)
+	if !ok {
+		return false
+	}
+
+	return isAlwaysHibernatedDuringMaintenance(maintenanceWindow, events)
+}
+
+func simulateHibernationSchedule(schedules []hibernationutils.ParsedSchedule) (events []hibernationScheduleEvent, ok bool) {
+	const (
+		maxCronIter    = 10_000
+		simulationDays = 35 // should cover most realistic scenarios.
+	)
+
+	start := time.Date(2006, time.January, 2, 0, 0, 0, 0, time.UTC) // monday
+	end := start.Add(simulationDays * 24 * time.Hour)
+
+	// make sure there is a hibernate event end of the simulation window, so that the last interval is always closed
+	events = []hibernationScheduleEvent{
+		{at: end, operation: hibernationutils.Hibernate},
+	}
+	iter := 0
+	for _, s := range schedules {
+		for t := s.Next(start); t.Before(end); t = s.Next(t) {
+			iter++
+			if iter > maxCronIter {
+				return nil, false // indicate that we reached the simulation limit
+			}
+			events = append(events, hibernationScheduleEvent{at: t, operation: s.Operation})
+		}
+	}
+	slices.SortFunc(events, func(a, b hibernationScheduleEvent) int { return a.at.Compare(b.at) })
+	events = slices.CompactFunc(events, func(e1, e2 hibernationScheduleEvent) bool {
+		return e1.operation == e2.operation
+	})
+	return events, true
+}
+
+func isAlwaysHibernatedDuringMaintenance(maintenanceWindow *timewindowutils.MaintenanceTimeWindow, events []hibernationScheduleEvent) bool {
+	maintenanceDuration := maintenanceWindow.Duration()
+
+	// iterate over all awake intervals. Since we know the simulation always contains alternating events, we can iterate
+	// with stepsize 2.
+	start := 0
+	if events[0].operation == hibernationutils.Hibernate {
+		start = 1
+	}
+	for i := start; i < len(events)-1; i += 2 {
+		awakeIntervalStart := events[i].at
+		awakeIntervalEnd := events[i+1].at
+
+		// Find the first maintenance window start on or after intervalStart.
+		maintenanceStart := maintenanceWindow.AdjustedBegin(awakeIntervalStart)
+		if maintenanceStart.Before(awakeIntervalStart) {
+			maintenanceStart = maintenanceStart.Add(24 * time.Hour)
+		}
+		// If the maintenance window ends before the end of the awake interval, then the maintenance window fits
+		// entirely inside the awake interval
+		if maintenanceStart.Add(maintenanceDuration).Before(awakeIntervalEnd) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/gardenlet/controller/shoot/care/hibernation.go
+++ b/pkg/gardenlet/controller/shoot/care/hibernation.go
@@ -22,51 +22,44 @@ func IsShootHibernatedDuringNextMaintenanceWindow(shoot *gardencorev1beta1.Shoot
 		return false
 	}
 
-	maintenanceWindow, err := timewindowutils.ParseMaintenanceTimeWindow(
-		shoot.Spec.Maintenance.TimeWindow.Begin,
-		shoot.Spec.Maintenance.TimeWindow.End,
-	)
+	maintenanceWindow, err := timewindowutils.ParseMaintenanceTimeWindow(shoot.Spec.Maintenance.TimeWindow.Begin, shoot.Spec.Maintenance.TimeWindow.End)
 	if err != nil {
 		return false
 	}
+	nextMaintenanceBegin := maintenanceWindow.AdjustedBegin(now)
+	if !nextMaintenanceBegin.After(now) {
+		nextMaintenanceBegin = nextMaintenanceBegin.AddDate(0, 0, 1)
+	}
 	nextMaintenanceEnd := maintenanceWindow.AdjustedEnd(now)
-	if !nextMaintenanceEnd.After(now) {
+	if !nextMaintenanceEnd.After(nextMaintenanceBegin) {
 		nextMaintenanceEnd = nextMaintenanceEnd.AddDate(0, 0, 1)
 	}
+
 	nextHibernateTime, nextWakeUpTime, err := parseNextHibernationEvents(shoot, now)
 	if err != nil {
 		return false
 	}
 
 	if shoot.Status.IsHibernated {
-		hasWakeUpBeforeMaintenance := nextWakeUpTime != nil && nextWakeUpTime.Before(nextMaintenanceEnd)
-
-		if !hasWakeUpBeforeMaintenance {
+		if nextWakeUpTime == nil || nextWakeUpTime.After(nextMaintenanceBegin) {
 			return true // never wakes up, or wakes up too late
 		}
 
-		reHibernatesBeforeMaintenance := nextHibernateTime != nil &&
+		return nextHibernateTime != nil &&
 			nextHibernateTime.After(*nextWakeUpTime) &&
 			nextHibernateTime.Before(nextMaintenanceEnd)
-
-		return reHibernatesBeforeMaintenance
 	}
 
-	// shoot is currently awake
-
-	hibernatesBeforeMaintenance := nextHibernateTime != nil && nextHibernateTime.Before(nextMaintenanceEnd)
-	if !hibernatesBeforeMaintenance {
+	if nextHibernateTime == nil || nextHibernateTime.After(nextMaintenanceEnd) {
 		return false // stays awake all the way to maintenance
 	}
 
-	reWakesUpBeforeMaintenance := nextWakeUpTime != nil &&
-		nextWakeUpTime.After(*nextHibernateTime) &&
-		nextWakeUpTime.Before(nextMaintenanceEnd)
-
-	return !reWakesUpBeforeMaintenance
+	return nextWakeUpTime == nil ||
+		nextWakeUpTime.Before(*nextHibernateTime) ||
+		nextWakeUpTime.After(nextMaintenanceBegin)
 }
 
-func parseNextHibernationEvents(shoot *gardencorev1beta1.Shoot, now time.Time) (*time.Time, *time.Time, error) {
+func parseNextHibernationEvents(shoot *gardencorev1beta1.Shoot, now time.Time) (nextHibernateTime *time.Time, nextWakeUpTime *time.Time, err error) {
 	if shoot.Spec.Hibernation == nil || len(shoot.Spec.Hibernation.Schedules) == 0 {
 		return nil, nil, nil
 	}
@@ -75,7 +68,6 @@ func parseNextHibernationEvents(shoot *gardencorev1beta1.Shoot, now time.Time) (
 		return nil, nil, err
 	}
 
-	var nextHibernateTime, nextWakeUpTime *time.Time
 	for _, s := range schedules {
 		t := s.Next(now)
 		switch s.Operation {

--- a/pkg/gardenlet/controller/shoot/care/hibernation.go
+++ b/pkg/gardenlet/controller/shoot/care/hibernation.go
@@ -5,7 +5,6 @@
 package care
 
 import (
-	"slices"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -13,22 +12,13 @@ import (
 	hibernationutils "github.com/gardener/gardener/pkg/utils/hibernation"
 )
 
-// Collect all events inside [simStart, simEnd) and sort by time.
-type hibernationScheduleEvent struct {
-	at        time.Time
-	operation hibernationutils.Operation
-}
-
-// IsShootAlwaysHibernatedDuringMaintenance returns true when the hibernation schedule of the shoot is such that the shoot is
-// always hibernated during the maintenance window.
-//
-// Because the hibernation schedules are defined by cron schedules, we determine this by running a simulation of all
-// wake-up and hibernation events and checking if any awake interval fully covers the maintenance window.
-func IsShootAlwaysHibernatedDuringMaintenance(shoot *gardencorev1beta1.Shoot) bool {
+// IsShootHibernatedDuringNextMaintenanceWindow reports whether the shoot could be in a hibernated state at any point
+// during its next maintenance window. Since Gardener only guarantees that maintenance starts at some point within the
+// window (not at its beginning), we compare against the end of the window — if a hibernation event falls before the
+// window closes, maintenance may never run. It only checks the very next hibernation and wake-up events, so it may
+// return false even if the shoot will be hibernated during the next maintenance window.
+func IsShootHibernatedDuringNextMaintenanceWindow(shoot *gardencorev1beta1.Shoot, now time.Time) bool {
 	if shoot.Spec.Maintenance == nil || shoot.Spec.Maintenance.TimeWindow == nil {
-		return false
-	}
-	if shoot.Spec.Hibernation == nil || len(shoot.Spec.Hibernation.Schedules) == 0 {
 		return false
 	}
 
@@ -39,81 +29,65 @@ func IsShootAlwaysHibernatedDuringMaintenance(shoot *gardencorev1beta1.Shoot) bo
 	if err != nil {
 		return false
 	}
+	nextMaintenanceEnd := maintenanceWindow.AdjustedEnd(now)
+	if !nextMaintenanceEnd.After(now) {
+		nextMaintenanceEnd = nextMaintenanceEnd.AddDate(0, 0, 1)
+	}
+	nextHibernateTime, nextWakeUpTime, err := parseNextHibernationEvents(shoot, now)
+	if err != nil {
+		return false
+	}
 
+	if shoot.Status.IsHibernated {
+		hasWakeUpBeforeMaintenance := nextWakeUpTime != nil && nextWakeUpTime.Before(nextMaintenanceEnd)
+
+		if !hasWakeUpBeforeMaintenance {
+			return true // never wakes up, or wakes up too late
+		}
+
+		reHibernatesBeforeMaintenance := nextHibernateTime != nil &&
+			nextHibernateTime.After(*nextWakeUpTime) &&
+			nextHibernateTime.Before(nextMaintenanceEnd)
+
+		return reHibernatesBeforeMaintenance
+	}
+
+	// shoot is currently awake
+
+	hibernatesBeforeMaintenance := nextHibernateTime != nil && nextHibernateTime.Before(nextMaintenanceEnd)
+	if !hibernatesBeforeMaintenance {
+		return false // stays awake all the way to maintenance
+	}
+
+	reWakesUpBeforeMaintenance := nextWakeUpTime != nil &&
+		nextWakeUpTime.After(*nextHibernateTime) &&
+		nextWakeUpTime.Before(nextMaintenanceEnd)
+
+	return !reWakesUpBeforeMaintenance
+}
+
+func parseNextHibernationEvents(shoot *gardencorev1beta1.Shoot, now time.Time) (*time.Time, *time.Time, error) {
+	if shoot.Spec.Hibernation == nil || len(shoot.Spec.Hibernation.Schedules) == 0 {
+		return nil, nil, nil
+	}
 	schedules, err := hibernationutils.Parse(shoot.Spec.Hibernation.Schedules)
-	if err != nil || len(schedules) == 0 {
-		return false
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// If there are no wake-up events at all we assume it's never awake during maintenance and return true
-	if hasWakeEvent := slices.ContainsFunc(schedules, func(s hibernationutils.ParsedSchedule) bool {
-		return s.Operation == hibernationutils.WakeUp
-	}); !hasWakeEvent {
-		return true
-	}
-
-	events, ok := simulateHibernationSchedule(schedules)
-	if !ok {
-		return false
-	}
-
-	return isAlwaysHibernatedDuringMaintenance(maintenanceWindow, events)
-}
-
-func simulateHibernationSchedule(schedules []hibernationutils.ParsedSchedule) (events []hibernationScheduleEvent, ok bool) {
-	const (
-		maxCronIter    = 10_000
-		simulationDays = 35 // should cover most realistic scenarios.
-	)
-
-	start := time.Date(2006, time.January, 2, 0, 0, 0, 0, time.UTC) // monday
-	end := start.Add(simulationDays * 24 * time.Hour)
-
-	// make sure there is a hibernate event end of the simulation window, so that the last interval is always closed
-	events = []hibernationScheduleEvent{
-		{at: end, operation: hibernationutils.Hibernate},
-	}
-	iter := 0
+	var nextHibernateTime, nextWakeUpTime *time.Time
 	for _, s := range schedules {
-		for t := s.Next(start); t.Before(end); t = s.Next(t) {
-			iter++
-			if iter > maxCronIter {
-				return nil, false // indicate that we reached the simulation limit
+		t := s.Next(now)
+		switch s.Operation {
+		case hibernationutils.Hibernate:
+			if nextHibernateTime == nil || t.Before(*nextHibernateTime) {
+				nextHibernateTime = &t
 			}
-			events = append(events, hibernationScheduleEvent{at: t, operation: s.Operation})
+		case hibernationutils.WakeUp:
+			if nextWakeUpTime == nil || t.Before(*nextWakeUpTime) {
+				nextWakeUpTime = &t
+			}
 		}
 	}
-	slices.SortFunc(events, func(a, b hibernationScheduleEvent) int { return a.at.Compare(b.at) })
-	events = slices.CompactFunc(events, func(e1, e2 hibernationScheduleEvent) bool {
-		return e1.operation == e2.operation
-	})
-	return events, true
-}
-
-func isAlwaysHibernatedDuringMaintenance(maintenanceWindow *timewindowutils.MaintenanceTimeWindow, events []hibernationScheduleEvent) bool {
-	maintenanceDuration := maintenanceWindow.Duration()
-
-	// iterate over all awake intervals. Since we know the simulation always contains alternating events, we can iterate
-	// with stepsize 2.
-	start := 0
-	if events[0].operation == hibernationutils.Hibernate {
-		start = 1
-	}
-	for i := start; i < len(events)-1; i += 2 {
-		awakeIntervalStart := events[i].at
-		awakeIntervalEnd := events[i+1].at
-
-		// Find the first maintenance window start on or after intervalStart.
-		maintenanceStart := maintenanceWindow.AdjustedBegin(awakeIntervalStart)
-		if maintenanceStart.Before(awakeIntervalStart) {
-			maintenanceStart = maintenanceStart.Add(24 * time.Hour)
-		}
-		// If the maintenance window ends before the end of the awake interval, then the maintenance window fits
-		// entirely inside the awake interval
-		if maintenanceStart.Add(maintenanceDuration).Before(awakeIntervalEnd) {
-			return false
-		}
-	}
-
-	return true
+	return nextHibernateTime, nextWakeUpTime, nil
 }

--- a/pkg/gardenlet/controller/shoot/care/hibernation_test.go
+++ b/pkg/gardenlet/controller/shoot/care/hibernation_test.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package care_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot/care"
+)
+
+var _ = Describe("#IsMaintenanceWindowInHibernationWindow", func() {
+	const (
+		maintBegin = "220000+0000"
+		maintEnd   = "230000+0000"
+	)
+
+	makeShoot := func(begin, end string, schedules ...gardencorev1beta1.HibernationSchedule) *gardencorev1beta1.Shoot {
+		return &gardencorev1beta1.Shoot{
+			Spec: gardencorev1beta1.ShootSpec{
+				Maintenance: &gardencorev1beta1.Maintenance{
+					TimeWindow: &gardencorev1beta1.MaintenanceTimeWindow{
+						Begin: begin,
+						End:   end,
+					},
+				},
+				Hibernation: &gardencorev1beta1.Hibernation{
+					Schedules: schedules,
+				},
+			},
+		}
+	}
+
+	makeShootDefault := func(schedules ...gardencorev1beta1.HibernationSchedule) *gardencorev1beta1.Shoot {
+		return makeShoot(maintBegin, maintEnd, schedules...)
+	}
+
+	DescribeTable("should return the expected result",
+		func(shoot *gardencorev1beta1.Shoot, expected bool) {
+			Expect(IsShootAlwaysHibernatedDuringMaintenance(shoot)).To(Equal(expected))
+		},
+		Entry("no maintenance time window set",
+			&gardencorev1beta1.Shoot{},
+			false,
+		),
+		Entry("no hibernation schedules",
+			makeShootDefault(),
+			false,
+		),
+		Entry("schedule has only Start, no End",
+			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * *")}),
+			true,
+		),
+		Entry("schedule has only End, no Start",
+			makeShootDefault(gardencorev1beta1.HibernationSchedule{End: new("0 8 * * *")}),
+			false,
+		),
+		Entry("maintenance window inside hibernation window",
+			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * *"), End: new("0 8 * * *")}),
+			true,
+		),
+		Entry("maintenance window inside wake window",
+			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("30 23 * * *"), End: new("0 8 * * *")}),
+			false,
+		),
+		Entry("maintenance window starts in wake window, ends in hibernation window",
+			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("30 22 * * *"), End: new("0 8 * * *")}),
+			true,
+		),
+		Entry("maintenance window starts in hibernation window, ends in wake window",
+			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("0 22 * * *"), End: new("30 22 * * *")}),
+			true,
+		),
+		Entry("weekday-only schedule: maintenance window inside weekday hibernation window, no wake on weekends",
+			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * 1-5"), End: new("0 8 * * 1-5")}),
+			true,
+		),
+		Entry("two schedules covering all seven days: maintenance always inside hibernation window",
+			makeShootDefault(
+				gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * 1-5"), End: new("0 8 * * 1-5")},
+				gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * 0,6"), End: new("0 8 * * 0,6")},
+			),
+			true,
+		),
+		Entry("weekday-only schedule: maintenance window on weekends falls outside hibernation window",
+			makeShoot("100000+0000", "110000+0000",
+				gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * 1-5"), End: new("0 8 * * 1-5")}),
+			false,
+		),
+		Entry("monthly schedule: no hibernation events in simulation window",
+			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("0 20 1 * *"), End: new("0 8 2 * *")}),
+			false,
+		),
+		Entry("two overlapping wake schedules: maintenance window inside hibernation window",
+			makeShootDefault(
+				gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * *"), End: new("0 6 * * *")},
+				gardencorev1beta1.HibernationSchedule{Start: new("0 21 * * *"), End: new("0 7 * * *")},
+			),
+			true,
+		),
+		Entry("two overlapping wake schedules: maintenance window inside wake window",
+			makeShoot("210000+0000", "220000+0000",
+				gardencorev1beta1.HibernationSchedule{Start: new("0 23 * * *"), End: new("0 6 * * *")},
+				gardencorev1beta1.HibernationSchedule{Start: new("0 0 * * *"), End: new("0 7 * * *")},
+			),
+			false,
+		),
+		Entry("cross-midnight maintenance window inside hibernation window",
+			makeShoot("230000+0000", "010000+0000",
+				gardencorev1beta1.HibernationSchedule{Start: new("0 22 * * *"), End: new("0 6 * * *")}),
+			true,
+		),
+		Entry("cross-midnight maintenance window inside wake window",
+			makeShoot("230000+0000", "010000+0000",
+				gardencorev1beta1.HibernationSchedule{Start: new("0 2 * * *"), End: new("0 21 * * *")}),
+			false,
+		),
+	)
+})

--- a/pkg/gardenlet/controller/shoot/care/hibernation_test.go
+++ b/pkg/gardenlet/controller/shoot/care/hibernation_test.go
@@ -5,6 +5,8 @@
 package care_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -12,14 +14,20 @@ import (
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot/care"
 )
 
-var _ = Describe("#IsMaintenanceWindowInHibernationWindow", func() {
+var _ = Describe("#IsShootHibernatedDuringNextMaintenanceWindow", func() {
+	now := time.Date(2024, time.January, 8, 15, 0, 0, 0, time.UTC)
+
+	// nowHibernated is inside a typical overnight hibernation window:
+	nowHibernated := time.Date(2024, time.January, 8, 21, 0, 0, 0, time.UTC)
+
 	const (
+		// maintenance window 22:00–23:00 UTC (nightly)
 		maintBegin = "220000+0000"
 		maintEnd   = "230000+0000"
 	)
 
-	makeShoot := func(begin, end string, schedules ...gardencorev1beta1.HibernationSchedule) *gardencorev1beta1.Shoot {
-		return &gardencorev1beta1.Shoot{
+	makeShoot := func(begin, end string, isHibernated bool, schedules ...gardencorev1beta1.HibernationSchedule) *gardencorev1beta1.Shoot {
+		shoot := &gardencorev1beta1.Shoot{
 			Spec: gardencorev1beta1.ShootSpec{
 				Maintenance: &gardencorev1beta1.Maintenance{
 					TimeWindow: &gardencorev1beta1.MaintenanceTimeWindow{
@@ -27,96 +35,142 @@ var _ = Describe("#IsMaintenanceWindowInHibernationWindow", func() {
 						End:   end,
 					},
 				},
-				Hibernation: &gardencorev1beta1.Hibernation{
-					Schedules: schedules,
-				},
+			},
+			Status: gardencorev1beta1.ShootStatus{
+				IsHibernated: isHibernated,
 			},
 		}
+		if len(schedules) > 0 {
+			shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
+				Schedules: schedules,
+			}
+		}
+		return shoot
 	}
 
-	makeShootDefault := func(schedules ...gardencorev1beta1.HibernationSchedule) *gardencorev1beta1.Shoot {
-		return makeShoot(maintBegin, maintEnd, schedules...)
+	makeShootDefault := func(isHibernated bool, schedules ...gardencorev1beta1.HibernationSchedule) *gardencorev1beta1.Shoot {
+		return makeShoot(maintBegin, maintEnd, isHibernated, schedules...)
 	}
+
+	nightlySchedule := gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * *"), End: new("0 8 * * *")}
+	weekdaySchedule := gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * 1-5"), End: new("0 8 * * 1-5")}
 
 	DescribeTable("should return the expected result",
-		func(shoot *gardencorev1beta1.Shoot, expected bool) {
-			Expect(IsShootAlwaysHibernatedDuringMaintenance(shoot)).To(Equal(expected))
+		func(shoot *gardencorev1beta1.Shoot, t time.Time, expected bool) {
+			Expect(IsShootHibernatedDuringNextMaintenanceWindow(shoot, t)).To(Equal(expected))
 		},
+
 		Entry("no maintenance time window set",
-			&gardencorev1beta1.Shoot{},
+			&gardencorev1beta1.Shoot{}, now,
 			false,
 		),
-		Entry("no hibernation schedules",
-			makeShootDefault(),
+		Entry("no schedules, not hibernated",
+			makeShootDefault(false), now,
 			false,
 		),
-		Entry("schedule has only Start, no End",
-			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * *")}),
+
+		Entry("hibernated with no schedules — stuck hibernated",
+			makeShootDefault(true), now,
 			true,
 		),
-		Entry("schedule has only End, no Start",
-			makeShootDefault(gardencorev1beta1.HibernationSchedule{End: new("0 8 * * *")}),
+
+		// Currently AWAKE
+
+		Entry("awake: maintenance inside nightly hibernation window",
+			makeShootDefault(false, nightlySchedule), now,
+			true,
+		),
+		Entry("awake: hibernate after maintenance window end",
+			makeShootDefault(false, gardencorev1beta1.HibernationSchedule{
+				Start: new("30 23 * * *"), End: new("0 8 * * *"),
+			}), now,
 			false,
 		),
-		Entry("maintenance window inside hibernation window",
-			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * *"), End: new("0 8 * * *")}),
+		Entry("awake: hibernate inside maintenance window",
+			makeShootDefault(false, gardencorev1beta1.HibernationSchedule{
+				Start: new("30 22 * * *"), End: new("0 8 * * *"),
+			}), now,
 			true,
 		),
-		Entry("maintenance window inside wake window",
-			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("30 23 * * *"), End: new("0 8 * * *")}),
+		Entry("awake: shoot wakes up before maintenance",
+			makeShootDefault(false, gardencorev1beta1.HibernationSchedule{
+				Start: new("0 20 * * *"), End: new("0 21 * * *"),
+			}), now,
 			false,
 		),
-		Entry("maintenance window starts in wake window, ends in hibernation window",
-			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("30 22 * * *"), End: new("0 8 * * *")}),
+		Entry("awake: hibernate-only schedule, no wake-up",
+			makeShootDefault(false, gardencorev1beta1.HibernationSchedule{
+				Start: new("0 20 * * *"),
+			}), now,
 			true,
 		),
-		Entry("maintenance window starts in hibernation window, ends in wake window",
-			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("0 22 * * *"), End: new("30 22 * * *")}),
-			true,
-		),
-		Entry("weekday-only schedule: maintenance window inside weekday hibernation window, no wake on weekends",
-			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * 1-5"), End: new("0 8 * * 1-5")}),
-			true,
-		),
-		Entry("two schedules covering all seven days: maintenance always inside hibernation window",
-			makeShootDefault(
-				gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * 1-5"), End: new("0 8 * * 1-5")},
-				gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * 0,6"), End: new("0 8 * * 0,6")},
-			),
-			true,
-		),
-		Entry("weekday-only schedule: maintenance window on weekends falls outside hibernation window",
-			makeShoot("100000+0000", "110000+0000",
-				gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * 1-5"), End: new("0 8 * * 1-5")}),
+		Entry("awake: wake-only schedule, no hibernate",
+			makeShootDefault(false, gardencorev1beta1.HibernationSchedule{
+				End: new("0 8 * * *"),
+			}), now,
 			false,
 		),
-		Entry("monthly schedule: no hibernation events in simulation window",
-			makeShootDefault(gardencorev1beta1.HibernationSchedule{Start: new("0 20 1 * *"), End: new("0 8 2 * *")}),
-			false,
-		),
-		Entry("two overlapping wake schedules: maintenance window inside hibernation window",
-			makeShootDefault(
-				gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * *"), End: new("0 6 * * *")},
-				gardencorev1beta1.HibernationSchedule{Start: new("0 21 * * *"), End: new("0 7 * * *")},
-			),
+		Entry("awake: weekday schedule, maintenance inside weeknight hibernation window",
+			makeShootDefault(false, weekdaySchedule), now,
 			true,
 		),
-		Entry("two overlapping wake schedules: maintenance window inside wake window",
-			makeShoot("210000+0000", "220000+0000",
-				gardencorev1beta1.HibernationSchedule{Start: new("0 23 * * *"), End: new("0 6 * * *")},
-				gardencorev1beta1.HibernationSchedule{Start: new("0 0 * * *"), End: new("0 7 * * *")},
-			),
-			false,
-		),
-		Entry("cross-midnight maintenance window inside hibernation window",
-			makeShoot("230000+0000", "010000+0000",
-				gardencorev1beta1.HibernationSchedule{Start: new("0 22 * * *"), End: new("0 6 * * *")}),
+		Entry("awake: cross-midnight maintenance inside hibernation window",
+			makeShoot("230000+0000", "010000+0000", false,
+				gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * *"), End: new("0 6 * * *")}), now,
 			true,
 		),
-		Entry("cross-midnight maintenance window inside wake window",
-			makeShoot("230000+0000", "010000+0000",
-				gardencorev1beta1.HibernationSchedule{Start: new("0 2 * * *"), End: new("0 21 * * *")}),
+		Entry("awake: cross-midnight maintenance before next hibernate",
+			makeShoot("230000+0000", "010000+0000", false,
+				gardencorev1beta1.HibernationSchedule{Start: new("0 2 * * *"), End: new("0 21 * * *")}), now,
 			false,
+		),
+
+		// Currently HIBERNATED
+
+		Entry("hibernated: manually hibernated, but wakes up in time",
+			makeShootDefault(true, gardencorev1beta1.HibernationSchedule{
+				End: new("0 20 * * *"),
+			}), now,
+			false,
+		),
+
+		Entry("hibernated: nightly schedule, next wake-up is after tonight's maintenance",
+			makeShootDefault(true, nightlySchedule), nowHibernated,
+			true,
+		),
+		Entry("hibernated: wake-up inside maintenance window",
+			makeShootDefault(true, gardencorev1beta1.HibernationSchedule{
+				Start: new("0 20 * * *"), End: new("30 22 * * *"),
+			}), nowHibernated,
+			false,
+		),
+		Entry("hibernated: wake-up after maintenance window end",
+			makeShootDefault(true, gardencorev1beta1.HibernationSchedule{
+				Start: new("0 20 * * *"), End: new("30 23 * * *"),
+			}), nowHibernated,
+			true,
+		),
+		Entry("hibernated: wake-up before maintenance start",
+			makeShootDefault(true, gardencorev1beta1.HibernationSchedule{
+				Start: new("0 20 * * *"), End: new("30 21 * * *"),
+			}), nowHibernated,
+			false,
+		),
+		Entry("hibernated: weekday schedule, no wake-up before tonight's maintenance",
+			makeShootDefault(true, weekdaySchedule), nowHibernated,
+			true,
+		),
+		Entry("hibernated: hibernate-only schedule, no wake-up ever",
+			makeShootDefault(true, gardencorev1beta1.HibernationSchedule{
+				Start: new("0 20 * * *"),
+			}), nowHibernated,
+			true,
+		),
+		Entry("hibernated: wakes up before maintenance but re-hibernates before it",
+			makeShootDefault(true, gardencorev1beta1.HibernationSchedule{
+				Start: new("45 21 * * *"), End: new("30 21 * * *"),
+			}), nowHibernated,
+			true,
 		),
 	)
 })

--- a/pkg/gardenlet/controller/shoot/care/hibernation_test.go
+++ b/pkg/gardenlet/controller/shoot/care/hibernation_test.go
@@ -15,10 +15,15 @@ import (
 )
 
 var _ = Describe("#IsShootHibernatedDuringNextMaintenanceWindow", func() {
-	now := time.Date(2024, time.January, 8, 15, 0, 0, 0, time.UTC)
+	var (
+		now = time.Date(2024, time.January, 8, 15, 0, 0, 0, time.UTC)
 
-	// nowHibernated is inside a typical overnight hibernation window:
-	nowHibernated := time.Date(2024, time.January, 8, 21, 0, 0, 0, time.UTC)
+		// nowHibernated is inside a typical overnight hibernation window:
+		nowHibernated = time.Date(2024, time.January, 8, 21, 0, 0, 0, time.UTC)
+
+		nightlySchedule = gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * *"), End: new("0 8 * * *")}
+		weekdaySchedule = gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * 1-5"), End: new("0 8 * * 1-5")}
+	)
 
 	const (
 		// maintenance window 22:00–23:00 UTC (nightly)
@@ -51,9 +56,6 @@ var _ = Describe("#IsShootHibernatedDuringNextMaintenanceWindow", func() {
 	makeShootDefault := func(isHibernated bool, schedules ...gardencorev1beta1.HibernationSchedule) *gardencorev1beta1.Shoot {
 		return makeShoot(maintBegin, maintEnd, isHibernated, schedules...)
 	}
-
-	nightlySchedule := gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * *"), End: new("0 8 * * *")}
-	weekdaySchedule := gardencorev1beta1.HibernationSchedule{Start: new("0 20 * * 1-5"), End: new("0 8 * * 1-5")}
 
 	DescribeTable("should return the expected result",
 		func(shoot *gardencorev1beta1.Shoot, t time.Time, expected bool) {
@@ -142,7 +144,7 @@ var _ = Describe("#IsShootHibernatedDuringNextMaintenanceWindow", func() {
 			makeShootDefault(true, gardencorev1beta1.HibernationSchedule{
 				Start: new("0 20 * * *"), End: new("30 22 * * *"),
 			}), nowHibernated,
-			false,
+			true,
 		),
 		Entry("hibernated: wake-up after maintenance window end",
 			makeShootDefault(true, gardencorev1beta1.HibernationSchedule{

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -653,7 +653,7 @@ func containConditionsInUnknownStatus(message string, isWorkerless bool) types.G
 }
 
 func containConstraintsInUnknownStatus(message string) types.GomegaMatcher {
-	var expectedLength = 8
+	var expectedLength = 9
 	matcher := And(
 		ContainCondition(
 			OfType(gardencorev1beta1.ShootHibernationPossible),

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -678,6 +678,10 @@ func containConstraintsInUnknownStatus(message string) types.GomegaMatcher {
 			WithStatus(gardencorev1beta1.ConditionUnknown),
 			WithMessage(message),
 		), ContainCondition(
+			OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+			WithStatus(gardencorev1beta1.ConditionUnknown),
+			WithMessage(message),
+		), ContainCondition(
 			OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
 			WithStatus(gardencorev1beta1.ConditionUnknown),
 			WithMessage(message),

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -678,7 +678,7 @@ func containConstraintsInUnknownStatus(message string) types.GomegaMatcher {
 			WithStatus(gardencorev1beta1.ConditionUnknown),
 			WithMessage(message),
 		), ContainCondition(
-			OfType(gardencorev1beta1.ShootHibernationScheduleProblematic),
+			OfType(gardencorev1beta1.ShootAutomaticCredentialsRotationPossible),
 			WithStatus(gardencorev1beta1.ConditionUnknown),
 			WithMessage(message),
 		), ContainCondition(

--- a/pkg/utils/hibernation/hibernationschedule.go
+++ b/pkg/utils/hibernation/hibernationschedule.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package hibernationschedule provides helpers for parsing and iterating over Shoot
+// hibernation schedules expressed as cron expressions.
+package hibernation
+
+import (
+	"time"
+
+	"github.com/robfig/cron"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+// Operation defines the type of operation that is scheduled by a hibernation schedule.
+type Operation uint8
+
+const (
+	// Hibernate indicates that the cluster should be hibernated.
+	Hibernate Operation = iota
+	// WakeUp indicates that the cluster should be woken up.
+	WakeUp
+)
+
+// ParsedSchedule holds the loaded location, parsed cron schedule and information whether
+// the cluster should be hibernated or woken up.
+type ParsedSchedule struct {
+	Schedule  cron.Schedule
+	Location  time.Location
+	Operation Operation
+}
+
+// Next returns the time in UTC from the schedule, that is immediately after the input time 't'.
+// The input 't' is converted in the schedule's location before any calculations are done.
+func (s *ParsedSchedule) Next(t time.Time) time.Time {
+	return s.Schedule.Next(t.In(&s.Location)).UTC()
+}
+
+// Previous returns the time in UTC from the schedule that is immediately before 'to' and after 'from'.
+// Nil is returned if no such time can be found.
+// The input times - 'to' and 'from' are converted in the schedule's location before any calculation is done.
+func (s *ParsedSchedule) Previous(from, to time.Time) *time.Time {
+	var last *time.Time
+	for t := s.Schedule.Next(from.In(&s.Location)); !t.UTC().After(to.UTC()); t = s.Schedule.Next(t) {
+		inUTC := t.UTC()
+		last = &inUTC
+	}
+	return last
+}
+
+// Parse parses the given HibernationSchedules and returns an array of ParsedSchedules
+// If the Location of a HibernationSchedule is `nil`, it is defaulted to UTC.
+func Parse(schedules []gardencorev1beta1.HibernationSchedule) ([]ParsedSchedule, error) {
+	var out []ParsedSchedule
+
+	for _, sched := range schedules {
+		locationID := time.UTC.String()
+		if sched.Location != nil && *sched.Location != "" {
+			locationID = *sched.Location
+		}
+
+		loc, err := time.LoadLocation(locationID)
+		if err != nil {
+			return nil, err
+		}
+
+		if sched.Start != nil {
+			parsed, err := cron.ParseStandard(*sched.Start)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, ParsedSchedule{
+				Schedule:  parsed,
+				Location:  *loc,
+				Operation: Hibernate,
+			})
+		}
+
+		if sched.End != nil {
+			parsed, err := cron.ParseStandard(*sched.End)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, ParsedSchedule{
+				Schedule:  parsed,
+				Location:  *loc,
+				Operation: WakeUp,
+			})
+		}
+	}
+
+	return out, nil
+}

--- a/pkg/utils/hibernation/hibernationschedule_test.go
+++ b/pkg/utils/hibernation/hibernationschedule_test.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hibernation_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/utils/hibernation"
+)
+
+var _ = Describe("hibernationschedule", func() {
+	Describe("#Parse", func() {
+		DescribeTable("should return the expected result",
+			func(schedules []gardencorev1beta1.HibernationSchedule, expectErr bool, wantOps []Operation) {
+				out, err := Parse(schedules)
+				if expectErr {
+					Expect(err).To(HaveOccurred())
+					return
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(HaveLen(len(wantOps)))
+				for i, op := range wantOps {
+					Expect(out[i].Operation).To(Equal(op))
+				}
+			},
+			Entry("nil input → empty slice", nil, false, nil),
+			Entry("invalid Start → error",
+				[]gardencorev1beta1.HibernationSchedule{{Start: new("not-a-cron")}}, true, nil),
+			Entry("invalid End → error",
+				[]gardencorev1beta1.HibernationSchedule{{End: new("also-invalid")}}, true, nil),
+			Entry("unknown location → error",
+				[]gardencorev1beta1.HibernationSchedule{{Start: new("0 20 * * *"), Location: new("Moon/Crater")}}, true, nil),
+			Entry("Start only → Hibernate",
+				[]gardencorev1beta1.HibernationSchedule{{Start: new("0 20 * * *")}}, false, []Operation{Hibernate}),
+			Entry("End only → WakeUp",
+				[]gardencorev1beta1.HibernationSchedule{{End: new("0 8 * * *")}}, false, []Operation{WakeUp}),
+			Entry("Start+End → Hibernate then WakeUp",
+				[]gardencorev1beta1.HibernationSchedule{{Start: new("0 20 * * *"), End: new("0 8 * * *")}},
+				false, []Operation{Hibernate, WakeUp}),
+			Entry("two schedules → four entries",
+				[]gardencorev1beta1.HibernationSchedule{
+					{Start: new("0 20 * * 1-5"), End: new("0 8 * * 1-5")},
+					{Start: new("0 22 * * 0,6"), End: new("0 10 * * 0,6")},
+				}, false, []Operation{Hibernate, WakeUp, Hibernate, WakeUp}),
+		)
+
+		It("defaults location to UTC when nil", func() {
+			out, err := Parse([]gardencorev1beta1.HibernationSchedule{{Start: new("0 20 * * *")}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out[0].Location).To(Equal(*time.UTC))
+		})
+
+		It("loads a non-UTC location", func() {
+			out, err := Parse([]gardencorev1beta1.HibernationSchedule{{Start: new("0 20 * * *"), Location: new("Europe/Berlin")}})
+			Expect(err).NotTo(HaveOccurred())
+			berlin, _ := time.LoadLocation("Europe/Berlin")
+			Expect(out[0].Location).To(Equal(*berlin))
+		})
+	})
+
+	// ref is Monday 2006-01-02 00:00:00 UTC — the same anchor used by IsMaintenanceWindowInHibernationWindow.
+	ref := time.Date(2006, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	// dailyAt20 is a UTC schedule that fires every day at 20:00.
+	mustDailyAt20 := func() ParsedSchedule {
+		out, err := Parse([]gardencorev1beta1.HibernationSchedule{{Start: new("0 20 * * *")}})
+		Expect(err).NotTo(HaveOccurred())
+		return out[0]
+	}
+
+	Describe("#Next", func() {
+		DescribeTable("should return the correct next occurrence in UTC",
+			func(spec, location string, from, want time.Time) {
+				var loc *string
+				if location != "" {
+					loc = new(location)
+				}
+				out, err := Parse([]gardencorev1beta1.HibernationSchedule{{Start: new(spec), Location: loc}})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out[0].Next(from)).To(Equal(want))
+			},
+			Entry("daily 20:00 UTC from midnight → same day 20:00",
+				"0 20 * * *", "",
+				ref,
+				time.Date(2006, 1, 2, 20, 0, 0, 0, time.UTC),
+			),
+			Entry("daily 20:00 Europe/Berlin (CET=UTC+1) from midnight UTC → 19:00 UTC",
+				"0 20 * * *", "Europe/Berlin",
+				ref,
+				time.Date(2006, 1, 2, 19, 0, 0, 0, time.UTC),
+			),
+		)
+	})
+
+	Describe("#Previous", func() {
+		DescribeTable("should return the correct last occurrence in (from, to]",
+			func(from, to time.Time, want *time.Time) {
+				s := mustDailyAt20()
+				prev := s.Previous(from, to)
+				if want == nil {
+					Expect(prev).To(BeNil())
+				} else {
+					Expect(prev).NotTo(BeNil())
+					Expect(*prev).To(Equal(*want))
+				}
+			},
+			// from=Jan2, to=Jan4 → last fire Jan3 20:00
+			Entry("last occurrence in two-day window",
+				ref, ref.Add(2*24*time.Hour),
+				func() *time.Time { t := time.Date(2006, 1, 3, 20, 0, 0, 0, time.UTC); return &t }(),
+			),
+			// from=Jan3 21:00, to=Jan4 → no fire
+			Entry("no occurrence in range",
+				time.Date(2006, 1, 3, 21, 0, 0, 0, time.UTC), ref.Add(2*24*time.Hour),
+				nil,
+			),
+			// to = Jan3 20:00 exactly → included
+			Entry("occurrence exactly at to is included",
+				time.Date(2006, 1, 2, 20, 0, 0, 0, time.UTC),
+				time.Date(2006, 1, 3, 20, 0, 0, 0, time.UTC),
+				func() *time.Time { t := time.Date(2006, 1, 3, 20, 0, 0, 0, time.UTC); return &t }(),
+			),
+			// from = Jan3 20:00 exactly → excluded (interval is open on the left)
+			Entry("occurrence exactly at from is excluded",
+				time.Date(2006, 1, 3, 20, 0, 0, 0, time.UTC),
+				ref.Add(2*24*time.Hour),
+				nil,
+			),
+		)
+	})
+})

--- a/pkg/utils/hibernation/suite_test.go
+++ b/pkg/utils/hibernation/suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hibernation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHibernation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Hibernation Suite")
+}


### PR DESCRIPTION
**How to categorize this PR?**

/area security
/kind bug

**What this PR does / why we need it**:
As described in the issue, etcdEncryptionKey rotation requires a running cluster to re-encrypt existing resources. When a cluster is hibernated we therefore just skip this step, to allow the rest of the maintenance steps to succeed.

**Which issue(s) this PR fixes**:
Fixes #15200 

**Special notes for your reviewer**:
An alternative would be to actually wake up the cluster, but that seems very complex...

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug user
Shoots with automatic `etcdEncryptionKey` rotation enabled will skip the rotation when they are hibernated, allowing the rest of the maintenance to succeed.
```
