### PR TITLE
[Flaky Test] `integration/gardenlet/seed/seed` - Wait for CRD cleanup

### DIFF
--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -704,6 +704,18 @@ var _ = Describe("Seed controller tests", func() {
 						Expect(victoriaCRD.Destroy(ctx)).To(Succeed())
 						Expect(extensionCRD.Destroy(ctx)).To(Succeed())
 						Expect(openTelemetryCRD.Destroy(ctx)).To(Succeed())
+
+						// Wait for CRDs to be fully removed before re-deploying them. Without this, a CRD still
+						// in Terminating state causes Deploy to be a no-op (content already matches desired), and
+						// the subsequent Wait races the API server's finalizer removal, observing NotFound.
+						Expect(istioCRDs.WaitCleanup(ctx)).To(Succeed())
+						Expect(vpaCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(fluentCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(prometheusCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(persesCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(victoriaCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(extensionCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(openTelemetryCRD.WaitCleanup(ctx)).To(Succeed())
 					})
 					// We need to check it after the CRDs are deployed.
 					// We cannot check it in the general case beforehand, as the VPA CRDs are needed.
@@ -1034,6 +1046,18 @@ var _ = Describe("Seed controller tests", func() {
 						Expect(victoriaCRD.Destroy(ctx)).To(Succeed())
 						Expect(extensionCRD.Destroy(ctx)).To(Succeed())
 						Expect(openTelemetryCRD.Destroy(ctx)).To(Succeed())
+
+						// Wait for CRDs to be fully removed before re-deploying them. Without this, a CRD still
+						// in Terminating state causes Deploy to be a no-op (content already matches desired), and
+						// the subsequent Wait races the API server's finalizer removal, observing NotFound.
+						Expect(istioCRDs.WaitCleanup(ctx)).To(Succeed())
+						Expect(vpaCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(fluentCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(prometheusCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(persesCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(victoriaCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(extensionCRD.WaitCleanup(ctx)).To(Succeed())
+						Expect(openTelemetryCRD.WaitCleanup(ctx)).To(Succeed())
 					})
 				})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind test

**What this PR does / why we need it**:
This PR wait for CRDs to be fully removed before re-deploying them. Without this, a CRD still in Terminating state causes Deploy to be a no-op (content already matches desired), and the subsequent Wait races the API server's finalizer removal, observing NotFound.

The issue is evident from the test logs - https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14792/pull-gardener-integration/2056276038610063360#1:build-log.txt%3A430

```
  {"level":"debug","ts":"2026-05-18T07:35:41.068Z","msg":"Skip sending empty patch","objectKey":{"name":"proxyconfigs.networking.istio.io"}}
```

This shows that CRD was already present when the test tried to create it, which shouldn't be the case.


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/14852

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
