### PR TITLE
[GEP-31] extensions lib: Enhance `MachineToWorkerMapper` with predicate support

### DIFF
--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -92,7 +92,7 @@ func Add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 		if err := c.Watch(source.Kind[client.Object](
 			mgr.GetCache(),
 			&machinev1alpha1.Machine{},
-			handler.EnqueueRequestsFromMapFunc(MachineToWorkerMapper()),
+			handler.EnqueueRequestsFromMapFunc(MachineToWorkerMapper(mgr.GetClient(), predicates)),
 			MachineConditionChangedPredicate(ctx, mgr.GetLogger().WithValues("controller", ControllerName), mgr.GetClient()),
 		)); err != nil {
 			return err

--- a/extensions/pkg/controller/worker/mapper.go
+++ b/extensions/pkg/controller/worker/mapper.go
@@ -17,6 +17,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
+	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
 // ClusterToWorkerMapper returns a mapper that returns requests for Worker whose
@@ -26,8 +27,8 @@ func ClusterToWorkerMapper(reader client.Reader, predicates []predicate.Predicat
 }
 
 // MachineToWorkerMapper returns a mapper that returns requests for the Worker referenced by the machine.
-func MachineToWorkerMapper() handler.MapFunc {
-	return func(_ context.Context, obj client.Object) []reconcile.Request {
+func MachineToWorkerMapper(reader client.Reader, predicates []predicate.Predicate) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
 		machine, ok := obj.(*machinev1alpha1.Machine)
 		if !ok {
 			return nil
@@ -35,6 +36,15 @@ func MachineToWorkerMapper() handler.MapFunc {
 
 		workerName, ok := machine.Labels[v1beta1constants.LabelWorkerName]
 		if !ok {
+			return nil
+		}
+
+		worker := &extensionsv1alpha1.Worker{}
+		if err := reader.Get(ctx, types.NamespacedName{Name: workerName, Namespace: machine.Namespace}, worker); err != nil {
+			return nil
+		}
+
+		if !predicateutils.EvalGeneric(worker, predicates...) {
 			return nil
 		}
 

--- a/extensions/pkg/controller/worker/mapper_test.go
+++ b/extensions/pkg/controller/worker/mapper_test.go
@@ -13,16 +13,23 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	. "github.com/gardener/gardener/extensions/pkg/controller/worker"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
 var _ = Describe("Mapper", func() {
 	var (
 		ctx = context.TODO()
+
+		fakeClient client.Client
 
 		namespace = "some-namespace"
 
@@ -31,10 +38,17 @@ var _ = Describe("Mapper", func() {
 	)
 
 	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
 		worker = &extensionsv1alpha1.Worker{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "worker",
 				Namespace: namespace,
+			},
+			Spec: extensionsv1alpha1.WorkerSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type: "local",
+				},
 			},
 		}
 
@@ -43,7 +57,7 @@ var _ = Describe("Mapper", func() {
 				Name:      "machine",
 				Namespace: namespace,
 				Labels: map[string]string{
-					"worker.gardener.cloud/name": worker.Name,
+					v1beta1constants.LabelWorkerName: worker.Name,
 				},
 			},
 		}
@@ -53,7 +67,9 @@ var _ = Describe("Mapper", func() {
 		var mapper handler.MapFunc
 
 		BeforeEach(func() {
-			mapper = MachineToWorkerMapper()
+			mapper = MachineToWorkerMapper(fakeClient, nil)
+
+			Expect(fakeClient.Create(ctx, worker)).To(Succeed())
 		})
 
 		It("should return nil when the object is not a Machine", func() {
@@ -61,12 +77,26 @@ var _ = Describe("Mapper", func() {
 		})
 
 		It("should return nil when the machine does not have a worker label", func() {
-			delete(machine.Labels, "worker.gardener.cloud/name")
+			delete(machine.Labels, v1beta1constants.LabelWorkerName)
+
+			Expect(mapper(ctx, machine)).To(BeNil())
+		})
+
+		It("should return nil when the worker cannot be found", func() {
+			Expect(fakeClient.Delete(ctx, worker)).To(Succeed())
+
+			Expect(mapper(ctx, machine)).To(BeNil())
+		})
+
+		It("should return nil when the predicates do not match", func() {
+			mapper = MachineToWorkerMapper(fakeClient, predicateutils.AddTypeAndClassPredicates(nil, nil, "local2"))
 
 			Expect(mapper(ctx, machine)).To(BeNil())
 		})
 
 		It("should map the machine to the worker", func() {
+			mapper = MachineToWorkerMapper(fakeClient, predicateutils.AddTypeAndClassPredicates(nil, nil, "local"))
+
 			Expect(mapper(ctx, machine)).To(ConsistOf(
 				reconcile.Request{
 					NamespacedName: types.NamespacedName{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
`MachineToWorkerMapper` previously returned a mapper that only extracted the worker name from a machine label, with no  predicate filtering. This PR brings it in line with how other mappers (e.g. ClusterToWorkerMapper).
Without this (predicate filtering for Type) `provider-aws` can reconcile a `Worker` with `type: gcp` if the machine status change for a in-place machinedeployment.


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/15179

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing a provider extension to reconcile a `Worker` with a type different from its own during an in-place update is now fixed.
```
