### PR TITLE
Fix formatting of `LastMaintenance` description

### DIFF
--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -318,12 +318,8 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 			workerToKubernetesUpdate,
 			workerToMachineImageUpdate,
 			credentialsToRotationUpdate,
+			operations,
 		)
-
-		// append also other maintenance operation
-		if len(operations) > 0 {
-			description = fmt.Sprintf("%s, %s", description, strings.Join(operations, ", "))
-		}
 
 		shoot.Status.LastMaintenance = &gardencorev1beta1.LastMaintenance{
 			Description:   description,
@@ -420,7 +416,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 
 // buildMaintenanceMessages builds a combined message containing the performed maintenance operations over all worker pools. If the maintenance operation failed, the description
 // contains an indication for the failure and the reason the update was triggered. Details for failed maintenance operations are returned in the second return string.
-func buildMaintenanceMessages(kubernetesControlPlaneUpdate *updateResult, workerToKubernetesUpdate, workerToMachineImageUpdate, credentialsToRotationUpdate map[string]updateResult) (string, string) {
+func buildMaintenanceMessages(kubernetesControlPlaneUpdate *updateResult, workerToKubernetesUpdate, workerToMachineImageUpdate, credentialsToRotationUpdate map[string]updateResult, operations []string) (string, string) {
 	countSuccessfulOperations := 0
 	countFailedOperations := 0
 	description := ""
@@ -473,14 +469,18 @@ func buildMaintenanceMessages(kubernetesControlPlaneUpdate *updateResult, worker
 		failureReason = fmt.Sprintf("%s, Credentials %q: Automatic rotation failure due to: %s", failureReason, credentials, result.description)
 	}
 
+	if len(operations) > 0 {
+		description = fmt.Sprintf("%s, %s", description, strings.Join(operations, ", "))
+	}
+
 	description = strings.TrimPrefix(description, ", ")
 	failureReason = strings.TrimPrefix(failureReason, ", ")
 
 	if countFailedOperations == 0 {
-		return fmt.Sprintf("All maintenance operations successful. %s", description), failureReason
+		return strings.TrimRight(fmt.Sprintf("All maintenance operations successful. %s", description), " "), failureReason
 	}
 
-	return fmt.Sprintf("(%d/%d) maintenance operations successful. %s", countSuccessfulOperations, countSuccessfulOperations+countFailedOperations, description), failureReason
+	return strings.TrimRight(fmt.Sprintf("(%d/%d) maintenance operations successful. %s", countSuccessfulOperations, countSuccessfulOperations+countFailedOperations, description), " "), failureReason
 }
 
 // recordMaintenanceEventsForPool records dedicated events for each failed/succeeded maintenance operation per pool

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -2298,6 +2298,128 @@ var _ = Describe("Shoot Maintenance", func() {
 			Expect(quotasEqual(slice1, slice2)).To(BeTrue())
 		})
 	})
+
+	Describe("#buildMaintenanceMessages", func() {
+		type entry struct {
+			cpUpdate        *updateResult
+			workerK8s       map[string]updateResult
+			workerImage     map[string]updateResult
+			credentials     map[string]updateResult
+			operations      []string
+			expectedDesc    string
+			expectedFailure string
+		}
+
+		DescribeTable("should build the correct description and failureReason",
+			func(e entry) {
+				description, failureReason := buildMaintenanceMessages(e.cpUpdate, e.workerK8s, e.workerImage, e.credentials, e.operations)
+				Expect(description).To(Equal(e.expectedDesc))
+				Expect(failureReason).To(Equal(e.expectedFailure))
+			},
+			Entry("no updates and no operations",
+				entry{
+					expectedDesc: "All maintenance operations successful.",
+				},
+			),
+			Entry("no updates, operations only",
+				entry{
+					operations:   []string{`Added "rotate-credentials-start;reconcile" operation annotation`},
+					expectedDesc: `All maintenance operations successful. Added "rotate-credentials-start;reconcile" operation annotation`,
+				},
+			),
+			Entry("successful control plane k8s update",
+				entry{
+					cpUpdate:     &updateResult{isSuccessful: true, description: `Updated Kubernetes version from "1.0.0" to "1.0.1"`, reason: "Kubernetes version expired - force update required"},
+					expectedDesc: `All maintenance operations successful. Control Plane: Updated Kubernetes version from "1.0.0" to "1.0.1". Reason: Kubernetes version expired - force update required`,
+				},
+			),
+			Entry("failed control plane k8s update",
+				entry{
+					cpUpdate:        &updateResult{isSuccessful: false, description: "no higher patch version available", reason: "Kubernetes version expired - force update required"},
+					expectedDesc:    "(0/1) maintenance operations successful. Control Plane: Kubernetes version update failed. Reason for update: Kubernetes version expired - force update required",
+					expectedFailure: "Control Plane: Kubernetes maintenance failure due to: no higher patch version available",
+				},
+			),
+			Entry("successful worker k8s update",
+				entry{
+					workerK8s:    map[string]updateResult{"cpu-worker": {isSuccessful: true, description: `Updated Kubernetes version from "1.0.0" to "1.0.1"`, reason: "Kubernetes version expired - force update required"}},
+					expectedDesc: `All maintenance operations successful. Worker pool "cpu-worker": Updated Kubernetes version from "1.0.0" to "1.0.1". Reason: Kubernetes version expired - force update required`,
+				},
+			),
+			Entry("failed worker k8s update",
+				entry{
+					workerK8s:       map[string]updateResult{"cpu-worker": {isSuccessful: false, description: "no higher patch version available", reason: "Kubernetes version expired - force update required"}},
+					expectedDesc:    `(0/1) maintenance operations successful. Worker pool "cpu-worker": Kubernetes version maintenance failed. Reason for update: Kubernetes version expired - force update required`,
+					expectedFailure: `Worker pool "cpu-worker": Kubernetes maintenance failure due to: no higher patch version available`,
+				},
+			),
+			Entry("successful machine image update",
+				entry{
+					workerImage:  map[string]updateResult{"cpu-worker": {isSuccessful: true, description: `Updated machine image version from "1.0.0" to "1.0.1"`, reason: "Machine image version expired - force update required"}},
+					expectedDesc: `All maintenance operations successful. Worker pool "cpu-worker": Updated machine image version from "1.0.0" to "1.0.1". Reason: Machine image version expired - force update required`,
+				},
+			),
+			Entry("failed machine image update",
+				entry{
+					workerImage:     map[string]updateResult{"cpu-worker": {isSuccessful: false, description: "no higher version available", reason: "Machine image version expired - force update required"}},
+					expectedDesc:    `(0/1) maintenance operations successful. Worker pool "cpu-worker": machine image version maintenance failed. Reason for update: Machine image version expired - force update required`,
+					expectedFailure: `Worker pool "cpu-worker": no higher version available`,
+				},
+			),
+			Entry("successful credentials rotation",
+				entry{
+					credentials:  map[string]updateResult{"ssh-keypair": {isSuccessful: true, description: "Rotated SSH keypair", reason: "Rotation period elapsed"}},
+					expectedDesc: `All maintenance operations successful. Credentials "ssh-keypair": Rotated SSH keypair. Reason: Rotation period elapsed`,
+				},
+			),
+			Entry("failed credentials rotation",
+				entry{
+					credentials:     map[string]updateResult{"ssh-keypair": {isSuccessful: false, description: "rotation prerequisites not met", reason: "Rotation period elapsed"}},
+					expectedDesc:    `(0/1) maintenance operations successful. Credentials "ssh-keypair": Automatic rotation failed. Reason for update: Rotation period elapsed`,
+					expectedFailure: `Credentials "ssh-keypair": Automatic rotation failure due to: rotation prerequisites not met`,
+				},
+			),
+			Entry("multiple operations",
+				entry{
+					operations: []string{
+						".spec.kubernetes.kubeControllerManager.podEvictionTimeout is set to nil. Reason: deprecated",
+						".spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete is set to nil. Reason: deprecated",
+						`Added "reconcile" operation annotation`,
+					},
+					expectedDesc: `All maintenance operations successful. .spec.kubernetes.kubeControllerManager.podEvictionTimeout is set to nil. Reason: deprecated, .spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete is set to nil. Reason: deprecated, Added "reconcile" operation annotation`,
+				},
+			),
+			Entry("successful cp update combined with operations",
+				entry{
+					cpUpdate:     &updateResult{isSuccessful: true, description: `Updated Kubernetes version from "1.0.0" to "1.0.1"`, reason: "Kubernetes version expired - force update required"},
+					operations:   []string{`Added "rotate-ssh-keypair;reconcile" operation annotation`},
+					expectedDesc: `All maintenance operations successful. Control Plane: Updated Kubernetes version from "1.0.0" to "1.0.1". Reason: Kubernetes version expired - force update required, Added "rotate-ssh-keypair;reconcile" operation annotation`,
+				},
+			),
+		)
+
+		It("should correctly combine typed updates, failed updates, and multiple operations", func() {
+			description, failureReason := buildMaintenanceMessages(
+				&updateResult{isSuccessful: true, description: `Updated Kubernetes version from "1.34.0" to "1.35.0"`, reason: "Kubernetes version expired - force update required"},
+				map[string]updateResult{
+					"gpu-worker": {isSuccessful: false, description: "no higher patch version available", reason: "Kubernetes version expired - force update required"},
+				},
+				nil, nil,
+				[]string{
+					".spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication was removed. Reason: not supported for 1.35+",
+					`Added "rotate-ssh-keypair;reconcile" operation annotation`,
+				},
+			)
+
+			// Uses ContainSubstring because two worker map entries have non-deterministic iteration order.
+			Expect(description).To(ContainSubstring("(1/2) maintenance operations successful."))
+			Expect(description).To(ContainSubstring("Control Plane: Updated Kubernetes version"))
+			Expect(description).To(ContainSubstring(`Worker pool "gpu-worker": Kubernetes version maintenance failed`))
+			Expect(description).To(ContainSubstring(".spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication was removed"))
+			Expect(description).To(ContainSubstring(`Added "rotate-ssh-keypair;reconcile" operation annotation`))
+			Expect(failureReason).To(Equal(`Worker pool "gpu-worker": Kubernetes maintenance failure due to: no higher patch version available`))
+		})
+	})
 })
 
 func assertWorkerMachineImageVersion(worker *gardencorev1beta1.Worker, imageName string, imageVersion string) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR fixes a small formatting issue in the Shoot's `.status.lastMaintenance.description` when there are multiple operations that were performed during maintenance. Previously the message contained an extra comma and space after the `All maintenance operations successful.` as can be seen below:

```
lastMaintenance:
    description: >-
      All maintenance operations successful. , Added
      "rotate-credentials-start;reconcile" operation annotation
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The `TrimRight(..., " ")` was added in case the `description` var is empty. 

The `operations` array is now an argument to `buildMaintenanceMessages(...)` so that the whole function and description formatting could be easily tested and also the whole formatting of the description message is in one function call.
This also fixes the actual issue of the extra comma added the call to `description = fmt.Sprintf("%s, %s", description, strings.Join(operations, ", "))` after `buildMaintenanceMessages(...)` in the old code.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed a small formatting error in the Shoot's `.status.lastMaintenance.description` description when there are other operations that took place during the maintenance.
```
