### PR TITLE
Use imagevector.Image directly in VictoriaLogs component

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/distribution/distribution/v3 v3.1.1
+	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.6.1+incompatible
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.7.0
@@ -106,8 +107,6 @@ exclude github.com/gardener/gardener/pkg/apis v1.143.0
 exclude github.com/gardener/gardener/pkg/apis v1.144.2
 
 tool github.com/joelanford/go-apidiff
-
-require github.com/distribution/reference v0.6.0
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,8 @@ exclude github.com/gardener/gardener/pkg/apis v1.144.2
 
 tool github.com/joelanford/go-apidiff
 
+require github.com/distribution/reference v0.6.0
+
 require (
 	cel.dev/expr v0.25.1 // indirect
 	cyphar.com/go-pathrs v0.2.1 // indirect
@@ -165,7 +167,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.5 // indirect

--- a/pkg/component/observability/logging/victorialogs/victorialogs.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	victoriametricsv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
@@ -89,6 +90,18 @@ func New(
 }
 
 func (v *victoriaLogs) Deploy(ctx context.Context) error {
+	// TODO(rrhubenov): Remove this check once https://github.com/VictoriaMetrics/operator/pull/2401 is merged
+	// and we update to the release that includes it. Until then, the VictoriaMetrics operator cannot handle a
+	// digest-only image reference, so we reject it here. A digest-only tag has the form "<algorithm>:<hex>"
+	// (e.g. "sha256:...", "sha512:...") whereas a tag+digest combined form contains a "@" separator.
+	if !strings.Contains(v.values.ImageTag, "@") {
+		for _, algorithmPrefix := range []string{"sha256:", "sha512:"} {
+			if strings.HasPrefix(v.values.ImageTag, algorithmPrefix) {
+				return fmt.Errorf("digest-only image reference %q is not supported yet", v.values.ImageRepository+"@"+v.values.ImageTag)
+			}
+		}
+	}
+
 	registry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 
 	resources := []client.Object{

--- a/pkg/component/observability/logging/victorialogs/victorialogs.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs.go
@@ -13,7 +13,6 @@ import (
 	victoriametricsv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	pvcautoscalerv1alpha1 "github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
-	"github.com/google/go-containerregistry/pkg/name"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -42,8 +41,11 @@ const (
 
 // Values is the values for VictoriaLogs configurations.
 type Values struct {
-	// Image is the VictoriaLogs image.
-	Image string
+	// ImageRepository is the VictoriaLogs image repository.
+	ImageRepository string
+	// ImageTag is the VictoriaLogs image tag. May include an appended digest
+	// in the form "<tag>@sha256:...".
+	ImageTag string
 	// Storage is the disk storage capacity of VictoriaLogs.
 	// If not set, a default of 30Gi will be used.
 	Storage *resource.Quantity
@@ -88,13 +90,9 @@ func New(
 
 func (v *victoriaLogs) Deploy(ctx context.Context) error {
 	registry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
-	imageRef, err := name.ParseReference(v.values.Image)
-	if err != nil {
-		return err
-	}
 
 	resources := []client.Object{
-		v.vlSingle(imageRef.Context().Name(), imageRef.Identifier()),
+		v.vlSingle(),
 		v.getVPA(),
 		v.getServiceMonitor(),
 		v.getPrometheusRule(),
@@ -130,7 +128,7 @@ func (v *victoriaLogs) WaitCleanup(ctx context.Context) error {
 	return managedresources.WaitUntilDeleted(timeoutCtx, v.client, v.namespace, constants.ManagedResourceNameRuntime)
 }
 
-func (v *victoriaLogs) vlSingle(imageRepo, imageTag string) *victoriametricsv1.VLSingle {
+func (v *victoriaLogs) vlSingle() *victoriametricsv1.VLSingle {
 	storage := resource.MustParse("30Gi")
 	if v.values.Storage != nil {
 		storage = *v.values.Storage
@@ -149,8 +147,8 @@ func (v *victoriaLogs) vlSingle(imageRepo, imageTag string) *victoriametricsv1.V
 				DisableSelfServiceScrape: new(true),
 				UseStrictSecurity:        new(true),
 				Image: victoriametricsv1beta1.Image{
-					Repository: imageRepo,
-					Tag:        imageTag,
+					Repository: v.values.ImageRepository,
+					Tag:        v.values.ImageTag,
 				},
 				Port: strconv.Itoa(constants.VictoriaLogsPort),
 				Resources: corev1.ResourceRequirements{

--- a/pkg/component/observability/logging/victorialogs/victorialogs_test.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs_test.go
@@ -263,7 +263,8 @@ var _ = Describe("VictoriaLogs", func() {
 		DescribeTable("should successfully deploy all resources including the PersistentVolumeClaimAutoscaler when PVC autoscaler is enabled",
 			func(maxCapacity resource.Quantity) {
 				values = Values{
-					Image: image,
+					ImageRepository: imageRepository,
+					ImageTag:        imageTag,
 					PVCAutoscaling: PVCAutoscalingConfig{
 						Enabled:     true,
 						MaxCapacity: maxCapacity,

--- a/pkg/component/observability/logging/victorialogs/victorialogs_test.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs_test.go
@@ -50,9 +50,11 @@ var _ = Describe("VictoriaLogs", func() {
 	var (
 		ctx = context.Background()
 
-		image  = "europe-docker.pkg.dev/gardener-project/releases/some-image:some-tag"
-		values = Values{
-			Image: image,
+		imageRepository = "europe-docker.pkg.dev/gardener-project/releases/some-image"
+		imageTag        = "some-tag"
+		values          = Values{
+			ImageRepository: imageRepository,
+			ImageTag:        imageTag,
 		}
 
 		c         client.Client
@@ -288,8 +290,9 @@ var _ = Describe("VictoriaLogs", func() {
 		Context("when deployed in seed cluster", func() {
 			BeforeEach(func() {
 				values = Values{
-					Image:       image,
-					ClusterType: componentpkg.ClusterTypeSeed,
+					ImageRepository: imageRepository,
+					ImageTag:        imageTag,
+					ClusterType:     componentpkg.ClusterTypeSeed,
 				}
 				component = New(c, namespace, values)
 			})
@@ -330,7 +333,8 @@ var _ = Describe("VictoriaLogs", func() {
 		Context("when deployed in garden cluster", func() {
 			BeforeEach(func() {
 				values = Values{
-					Image:           image,
+					ImageRepository: imageRepository,
+					ImageTag:        imageTag,
 					ClusterType:     componentpkg.ClusterTypeSeed,
 					IsGardenCluster: true,
 				}
@@ -371,8 +375,9 @@ var _ = Describe("VictoriaLogs", func() {
 		Context("when deployed in shoot cluster", func() {
 			BeforeEach(func() {
 				values = Values{
-					Image:       image,
-					ClusterType: componentpkg.ClusterTypeShoot,
+					ImageRepository: imageRepository,
+					ImageTag:        imageTag,
+					ClusterType:     componentpkg.ClusterTypeShoot,
 				}
 				component = New(c, namespace, values)
 			})

--- a/pkg/component/observability/logging/victorialogs/victorialogs_test.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs_test.go
@@ -218,6 +218,18 @@ var _ = Describe("VictoriaLogs", func() {
 	})
 
 	Describe("#Deploy", func() {
+		// TODO(rrhubenov): Remove this test once https://github.com/VictoriaMetrics/operator/pull/2401 is merged
+		// and we update to the release that includes it, together with the digest-only check in Deploy.
+		It("should return an error when the image reference is digest-only", func() {
+			for _, digestTag := range []string{
+				"sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+				"sha512:ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff",
+			} {
+				component = New(c, namespace, Values{ImageRepository: imageRepository, ImageTag: digestTag})
+				Expect(component.Deploy(ctx)).To(MatchError(ContainSubstring("digest-only image reference")))
+			}
+		})
+
 		It("should successfully deploy all resources for shoot cluster", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResourceSecret), customResourcesManagedResourceSecret)).To(BeNotFoundError())

--- a/pkg/component/shared/victorialogs.go
+++ b/pkg/component/shared/victorialogs.go
@@ -5,8 +5,6 @@
 package shared
 
 import (
-	// crypto/sha256 is imported for its side effect of registering the sha256 digest algorithm, which
-	// distribution/reference requires to parse image references containing a sha256 digest.
 	_ "crypto/sha256"
 	"fmt"
 

--- a/pkg/component/shared/victorialogs.go
+++ b/pkg/component/shared/victorialogs.go
@@ -35,6 +35,7 @@ func NewVictoriaLogs(
 		return nil, err
 	}
 
+	// TODO(rrhubenov): Use the Image struct directly when issue #15259 is fixed.
 	repository, tag, err := splitImageRef(victoriaLogsImage.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing image %q from imagevector: %w", imagevector.ContainerImageNameVictoriaLogs, err)

--- a/pkg/component/shared/victorialogs.go
+++ b/pkg/component/shared/victorialogs.go
@@ -5,6 +5,9 @@
 package shared
 
 import (
+	// crypto/sha256 is imported for its side effect of registering the sha256 digest algorithm, which
+	// distribution/reference requires to parse image references containing a sha256 digest.
+	_ "crypto/sha256"
 	"fmt"
 
 	"github.com/distribution/reference"
@@ -36,7 +39,7 @@ func NewVictoriaLogs(
 	}
 
 	// TODO(rrhubenov): Use the Image struct directly when issue #15259 is fixed.
-	repository, tag, err := splitImageRef(victoriaLogsImage.String())
+	repository, tag, err := SplitImageRef(victoriaLogsImage.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing image %q from imagevector: %w", imagevector.ContainerImageNameVictoriaLogs, err)
 	}
@@ -55,10 +58,10 @@ func NewVictoriaLogs(
 	return deployer, nil
 }
 
-// splitImageRef parses a fully-qualified image reference into its repository and tag components. When the reference
+// SplitImageRef parses a fully-qualified image reference into its repository and tag components. When the reference
 // contains both a tag and a digest, they are recombined into the '<tag>@sha256:...' form; a digest-only reference is
 // returned as 'sha256:...'.
-func splitImageRef(image string) (repository string, tag string, err error) {
+func SplitImageRef(image string) (repository string, tag string, err error) {
 	ref, err := reference.ParseNormalizedNamed(image)
 	if err != nil {
 		return "", "", err

--- a/pkg/component/shared/victorialogs.go
+++ b/pkg/component/shared/victorialogs.go
@@ -5,6 +5,8 @@
 package shared
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -31,9 +33,13 @@ func NewVictoriaLogs(
 	if err != nil {
 		return nil, err
 	}
+	if victoriaLogsImage.Repository == nil || victoriaLogsImage.Tag == nil {
+		return nil, fmt.Errorf("image %q from imagevector has no repository or tag set", imagevector.ContainerImageNameVictoriaLogs)
+	}
 
 	deployer := victorialogs.New(c, namespace, victorialogs.Values{
-		Image:             victoriaLogsImage.String(),
+		ImageRepository:   *victoriaLogsImage.Repository,
+		ImageTag:          *victoriaLogsImage.Tag,
 		Storage:           storage,
 		IsGardenCluster:   isGardenCluster,
 		ClusterType:       clusterType,

--- a/pkg/component/shared/victorialogs.go
+++ b/pkg/component/shared/victorialogs.go
@@ -7,6 +7,7 @@ package shared
 import (
 	"fmt"
 
+	"github.com/distribution/reference"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,13 +34,15 @@ func NewVictoriaLogs(
 	if err != nil {
 		return nil, err
 	}
-	if victoriaLogsImage.Repository == nil || victoriaLogsImage.Tag == nil {
-		return nil, fmt.Errorf("image %q from imagevector has no repository or tag set", imagevector.ContainerImageNameVictoriaLogs)
+
+	repository, tag, err := splitImageRef(victoriaLogsImage.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing image %q from imagevector: %w", imagevector.ContainerImageNameVictoriaLogs, err)
 	}
 
 	deployer := victorialogs.New(c, namespace, victorialogs.Values{
-		ImageRepository:   *victoriaLogsImage.Repository,
-		ImageTag:          *victoriaLogsImage.Tag,
+		ImageRepository:   repository,
+		ImageTag:          tag,
 		Storage:           storage,
 		IsGardenCluster:   isGardenCluster,
 		ClusterType:       clusterType,
@@ -49,4 +52,30 @@ func NewVictoriaLogs(
 	})
 
 	return deployer, nil
+}
+
+// splitImageRef parses a fully-qualified image reference into its repository and tag components. When the reference
+// contains both a tag and a digest, they are recombined into the '<tag>@sha256:...' form; a digest-only reference is
+// returned as 'sha256:...'.
+func splitImageRef(image string) (repository string, tag string, err error) {
+	ref, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return "", "", err
+	}
+
+	repository = ref.Name()
+
+	if tagged, ok := ref.(reference.Tagged); ok {
+		tag = tagged.Tag()
+	}
+	if digested, ok := ref.(reference.Digested); ok {
+		digest := digested.Digest().String()
+		if tag != "" {
+			tag += "@" + digest
+		} else {
+			tag = digest
+		}
+	}
+
+	return repository, tag, nil
 }

--- a/pkg/component/shared/victorialogs_test.go
+++ b/pkg/component/shared/victorialogs_test.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/component/shared"
+)
+
+var _ = Describe("VictoriaLogs", func() {
+	Describe("#SplitImageRef", func() {
+		const (
+			repository = "europe-docker.pkg.dev/gardener-project/releases/victoria-logs"
+			digest     = "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+		)
+
+		DescribeTable("should split the image reference into repository and tag",
+			func(image, expectedRepository, expectedTag string) {
+				gotRepository, gotTag, err := SplitImageRef(image)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(gotRepository).To(Equal(expectedRepository))
+				Expect(gotTag).To(Equal(expectedTag))
+			},
+
+			Entry("ref form (repository and tag)",
+				repository+":v1.2.3",
+				repository,
+				"v1.2.3",
+			),
+			Entry("repository and digest",
+				repository+"@"+digest,
+				repository,
+				digest,
+			),
+			Entry("tag and digest combined",
+				repository+":v1.2.3@"+digest,
+				repository,
+				"v1.2.3@"+digest,
+			),
+		)
+
+		It("should return an error for an invalid image reference", func() {
+			_, _, err := SplitImageRef("::invalid::")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**

/area logging
/kind cleanup

**What this PR does / why we need it**:

The `image` struct in the VLSingle resource expects the repository and tag to be passed separately.
However, if the image ref is passed as <repository>:<tag>@<digest>, the tag is stripped by `go-containerregistry` and only the digest is left as the "Identifier". This causes an issue when the deployment is created.

Solution just removes the `go-containerregistry` usage and relies on the imagevector.Image abstraction directly. This both simplifies the code and handles the combined `tag` + `digest` reference.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
```other operator
NONE
```