### PR TITLE
Promote `BackupEntryForGarden` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -38,7 +38,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | DisableNginxIngressInSeed      | `false` | `Alpha` | `1.142` |         |
 | DisableNginxIngressInShoot     | `false` | `Alpha` | `1.142` |         |
 | LiveControlPlaneMigration      | `false` | `Alpha` | `1.142` |         |
-| BackupEntryForGarden           | `false` | `Alpha` | `1.142` |         |
+| BackupEntryForGarden           | `false` | `Alpha` | `1.142` | `1.146` |
+| BackupEntryForGarden           | `true`  | `Beta`  | `1.147` |         |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -133,6 +133,7 @@ const (
 	// etcd-backup secret, aligning the garden with the same extension contract that shoot clusters use.
 	// owner: @rfranzke
 	// alpha: v1.142.0
+	// beta: v1.147.0
 	BackupEntryForGarden featuregate.Feature = "BackupEntryForGarden"
 )
 
@@ -178,7 +179,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DisableNginxIngressInSeed:      {Default: false, PreRelease: featuregate.Alpha},
 	DisableNginxIngressInShoot:     {Default: false, PreRelease: featuregate.Alpha},
 	LiveControlPlaneMigration:      {Default: false, PreRelease: featuregate.Alpha},
-	BackupEntryForGarden:           {Default: false, PreRelease: featuregate.Alpha},
+	BackupEntryForGarden:           {Default: true, PreRelease: featuregate.Beta},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.


### PR DESCRIPTION
**How to categorize this PR?**

/area backup
/kind enhancement

**What this PR does / why we need it**:

Follow-up to #14749. Promotes the `BackupEntryForGarden` feature gate from alpha to beta (default `true`), meaning the `BackupEntry` extension object will now be deployed by default in the garden controller alongside `BackupBucket` when etcd backup is configured.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/cc @timuthy

**Release note**:
```breaking operator
Operators must ensure that the deployed provider extensions enable their `BackupEntry` controllers before upgrading to this version. See e.g. [gardener-extension-provider-gcp#1423](https://github.com/gardener/gardener-extension-provider-gcp/pull/1423) for how to adapt an extension. If the provider extensions are not yet adapted, either upgrade them first or explicitly disable the `BackupEntryForGarden` feature gate.
```