### PR TITLE
[GEP-39] Set etcd `spec.memberNamePrefix` to seed name for new etcds

### DIFF
--- a/dev-setup/gardenlet/base/gardenlet.yaml
+++ b/dev-setup/gardenlet/base/gardenlet.yaml
@@ -24,7 +24,7 @@ spec:
         concurrentSyncs: 0 # we don't need the shootstate controller locally, and enabling it would even distort the results of CPM e2e tests
     etcdConfig:
       featureGates:
-        UpgradeEtcdVersion: false
+        UpgradeEtcdVersion: true
     logging:
       enabled: true
       vali:

--- a/dev-setup/skaffold-operator.yaml
+++ b/dev-setup/skaffold-operator.yaml
@@ -941,6 +941,7 @@ deploy:
           config.featureGates.PrometheusHealthChecks: true
           config.featureGates.VictoriaLogsBackend: true
           config.featureGates.DisableNginxIngressInGarden: true
+          config.controllers.garden.etcdConfig.featureGates.UpgradeEtcdVersion: true
         createNamespace: true
         wait: true
 profiles:

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -164,6 +164,7 @@ type Values struct {
 	HighAvailabilityEnabled     bool
 	TopologyAwareRoutingEnabled bool
 	StaticPodConfig             *StaticPodConfig
+	MemberNamePrefix            string
 }
 
 // BackupConfig contains information for configuring the backup-restore sidecar so that it takes regularly backups of
@@ -441,6 +442,10 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		}
 		e.etcd.Spec.StorageClass = e.values.StorageClassName
 		e.etcd.Spec.VolumeClaimTemplate = &volumeClaimTemplate
+
+		if existingEtcd == nil && e.values.MemberNamePrefix != "" {
+			e.etcd.Spec.MemberNamePrefix = new(e.values.MemberNamePrefix)
+		}
 		return nil
 	}); err != nil {
 		return err

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -967,6 +967,109 @@ var _ = Describe("Etcd", func() {
 			Entry("should update every-Three-days defrag schedule to daily", "24 3 */3 * *", defragmentationSchedule),
 		)
 
+		It("should set spec.memberNamePrefix when the Etcd resource does not yet exist", func() {
+			etcd = New(log, c, testNamespace, sm, Values{
+				Role:                    role,
+				Class:                   class,
+				Replicas:                replicas,
+				Autoscaling:             autoscalingConfig,
+				StorageCapacity:         storageCapacity,
+				StorageClassName:        &storageClassName,
+				DefragmentationSchedule: &defragmentationSchedule,
+				CARotationPhase:         caRotationPhase,
+				PriorityClassName:       priorityClassName,
+				MaintenanceTimeWindow:   maintenanceTimeWindow,
+				HighAvailabilityEnabled: highAvailabilityEnabled,
+				BackupConfig:            backupConfig,
+				StaticPodConfig:         staticPodConfig,
+				MemberNamePrefix:        "my-seed",
+			})
+
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+
+			actual := &druidcorev1alpha1.Etcd{}
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, actual)).To(Succeed())
+			Expect(actual.Spec.MemberNamePrefix).NotTo(BeNil())
+			Expect(*actual.Spec.MemberNamePrefix).To(Equal("my-seed"))
+		})
+
+		It("should not set spec.memberNamePrefix when the values are empty and the Etcd resource does not yet exist", func() {
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+
+			actual := &druidcorev1alpha1.Etcd{}
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, actual)).To(Succeed())
+			Expect(actual.Spec.MemberNamePrefix).To(BeNil())
+		})
+
+		It("should not overwrite spec.memberNamePrefix when the Etcd resource already exists (immutable field)", func() {
+			existingPrefix := "existing-prefix"
+			Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{
+				ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace},
+				Spec: druidcorev1alpha1.EtcdSpec{
+					MemberNamePrefix: &existingPrefix,
+				},
+				Status: druidcorev1alpha1.EtcdStatus{
+					Etcd: &druidcorev1alpha1.CrossVersionObjectReference{Name: etcdName},
+				},
+			})).To(Succeed())
+
+			etcd = New(log, c, testNamespace, sm, Values{
+				Role:                    role,
+				Class:                   class,
+				Replicas:                replicas,
+				Autoscaling:             autoscalingConfig,
+				StorageCapacity:         storageCapacity,
+				StorageClassName:        &storageClassName,
+				DefragmentationSchedule: &defragmentationSchedule,
+				CARotationPhase:         caRotationPhase,
+				PriorityClassName:       priorityClassName,
+				MaintenanceTimeWindow:   maintenanceTimeWindow,
+				HighAvailabilityEnabled: highAvailabilityEnabled,
+				BackupConfig:            backupConfig,
+				StaticPodConfig:         staticPodConfig,
+				MemberNamePrefix:        "different-prefix",
+			})
+
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+
+			actual := &druidcorev1alpha1.Etcd{}
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, actual)).To(Succeed())
+			Expect(actual.Spec.MemberNamePrefix).NotTo(BeNil())
+			Expect(*actual.Spec.MemberNamePrefix).To(Equal(existingPrefix))
+		})
+
+		It("should not add spec.memberNamePrefix to an existing Etcd resource that was created without one", func() {
+			Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{
+				ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace},
+				Status: druidcorev1alpha1.EtcdStatus{
+					Etcd: &druidcorev1alpha1.CrossVersionObjectReference{Name: etcdName},
+				},
+			})).To(Succeed())
+
+			etcd = New(log, c, testNamespace, sm, Values{
+				Role:                    role,
+				Class:                   class,
+				Replicas:                replicas,
+				Autoscaling:             autoscalingConfig,
+				StorageCapacity:         storageCapacity,
+				StorageClassName:        &storageClassName,
+				DefragmentationSchedule: &defragmentationSchedule,
+				CARotationPhase:         caRotationPhase,
+				PriorityClassName:       priorityClassName,
+				MaintenanceTimeWindow:   maintenanceTimeWindow,
+				HighAvailabilityEnabled: highAvailabilityEnabled,
+				BackupConfig:            backupConfig,
+				StaticPodConfig:         staticPodConfig,
+				MemberNamePrefix:        "my-seed",
+			})
+
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+
+			actual := &druidcorev1alpha1.Etcd{}
+			Expect(c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: etcdName}, actual)).To(Succeed())
+			Expect(actual.Spec.MemberNamePrefix).To(BeNil())
+		})
+
 		It("should successfully deploy (normal etcd) and not keep the existing resource request settings", func() {
 			existingResourceRequests := &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -39,6 +39,9 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 		PriorityClassName:           v1beta1constants.PriorityClassNameShootControlPlane500,
 		HighAvailabilityEnabled:     v1beta1helper.IsHAControlPlaneConfigured(b.Shoot.GetInfo()),
 		TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled,
+		// Prefix etcd member names with the seed name so that members can be distinguished across
+		// control plane migrations between seeds.
+		MemberNamePrefix: b.Seed.GetInfo().Name,
 	}
 
 	defragmentationSchedule, err := determineDefragmentationSchedule(b.Shoot.GetInfo())

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -39,9 +39,12 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 		PriorityClassName:           v1beta1constants.PriorityClassNameShootControlPlane500,
 		HighAvailabilityEnabled:     v1beta1helper.IsHAControlPlaneConfigured(b.Shoot.GetInfo()),
 		TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled,
-		// Prefix etcd member names with the seed name so that members can be distinguished across
-		// control plane migrations between seeds.
-		MemberNamePrefix: b.Seed.GetInfo().Name,
+	}
+
+	// Prefix etcd member names with the seed name so that members can be distinguished across
+	// control plane migrations between seeds. Self-hosted shoots have no Seed object.
+	if !b.Shoot.IsSelfHosted() {
+		values.MemberNamePrefix = b.Seed.GetInfo().Name
 	}
 
 	defragmentationSchedule, err := determineDefragmentationSchedule(b.Shoot.GetInfo())

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -195,6 +195,37 @@ var _ = Describe("Etcd", func() {
 			})
 		})
 
+		Context("self-hosted shoot", func() {
+			BeforeEach(func() {
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.27.2",
+						},
+						Maintenance: &gardencorev1beta1.Maintenance{
+							TimeWindow: &maintenanceTimeWindow,
+						},
+						Provider: gardencorev1beta1.Provider{
+							Workers: []gardencorev1beta1.Worker{
+								{Name: "cp-pool", ControlPlane: &gardencorev1beta1.WorkerControlPlane{}},
+							},
+						},
+					},
+				})
+				validator.expectedMemberNamePrefix = Equal("")
+			})
+
+			It("should not set MemberNamePrefix for self-hosted shoots", func() {
+				oldNewEtcd := NewEtcd
+				defer func() { NewEtcd = oldNewEtcd }()
+				NewEtcd = validator.NewEtcd
+
+				etcd, err := botanist.DefaultEtcd(role, class)
+				Expect(etcd).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
 		It("should return an error because the maintenance time window cannot be parsed", func() {
 			botanist.Shoot.GetInfo().Spec.Maintenance.TimeWindow = &gardencorev1beta1.MaintenanceTimeWindow{
 				Begin: "foobar",

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Etcd", func() {
 			botanist.Shoot = &shootpkg.Shoot{
 				ControlPlaneNamespace: namespace,
 			}
-			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{})
+			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: "test-seed"}})
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Kubernetes: gardencorev1beta1.Kubernetes{
@@ -112,6 +112,7 @@ var _ = Describe("Etcd", func() {
 				expectedDefragmentationSchedule:   Equal(new("34 12 * * *")),
 				expectedMaintenanceTimeWindow:     Equal(maintenanceTimeWindow),
 				expectedHighAvailabilityEnabled:   Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
+				expectedMemberNamePrefix:          Equal("test-seed"),
 			}
 		})
 
@@ -501,6 +502,7 @@ type newEtcdValidator struct {
 	expectedHighAvailabilityEnabled   gomegatypes.GomegaMatcher
 	expectedMaintenanceTimeWindow     gomegatypes.GomegaMatcher
 	expectedAutoscalingConfiguration  gomegatypes.GomegaMatcher
+	expectedMemberNamePrefix          gomegatypes.GomegaMatcher
 }
 
 func (v *newEtcdValidator) NewEtcd(
@@ -529,6 +531,9 @@ func (v *newEtcdValidator) NewEtcd(
 		Expect(values.Autoscaling).To(v.expectedAutoscalingConfiguration)
 	} else {
 		Expect(values.Autoscaling).To(Equal(etcd.AutoscalingConfig{}))
+	}
+	if v.expectedMemberNamePrefix != nil {
+		Expect(values.MemberNamePrefix).To(v.expectedMemberNamePrefix)
 	}
 
 	return v


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR sets the newly introduced immutable `spec.memberNamePrefix` field on the `etcd` resources deployed for shoot control planes. The prefix is set to the name of the seed hosting the control plane.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10686

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The etcd members of newly created shoot control planes are now prefixed with the seed name (`spec.memberNamePrefix` of the `Etcd` resource).
```
