### PR TITLE
Remove the deprecated 'authentication.gardener.cloud/public-keys' label key

### DIFF
--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
@@ -391,10 +391,10 @@ func (h *Handler) admitSecret(ctx context.Context, seedName string, request admi
 		if shootNamespace, ok = secret.Labels[v1beta1constants.LabelShootNamespace]; !ok {
 			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %q is missing", v1beta1constants.LabelShootNamespace))
 		}
-		if publicKeyType, ok := secret.Labels[v1beta1constants.LabelPublicKeys]; !ok {
-			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %q is missing", v1beta1constants.LabelPublicKeys))
+		if publicKeyType, ok := secret.Labels[v1beta1constants.LabelDiscoveryPublic]; !ok {
+			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %q is missing", v1beta1constants.LabelDiscoveryPublic))
 		} else if publicKeyType != v1beta1constants.LabelPublicKeysServiceAccount {
-			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %q value must be set to %q", v1beta1constants.LabelPublicKeys, v1beta1constants.LabelPublicKeysServiceAccount))
+			return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("label %q value must be set to %q", v1beta1constants.LabelDiscoveryPublic, v1beta1constants.LabelPublicKeysServiceAccount))
 		}
 
 		shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: shootNamespace}}

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
@@ -1244,7 +1244,7 @@ var _ = Describe("handler", func() {
 								},
 							),
 							Entry(
-								"missing authentication.gardener.cloud/public-keys label",
+								"missing discovery.gardener.cloud/public label",
 								&corev1.Secret{
 									ObjectMeta: metav1.ObjectMeta{
 										Labels: map[string]string{
@@ -1255,23 +1255,23 @@ var _ = Describe("handler", func() {
 								},
 								&metav1.Status{
 									Code:    int32(http.StatusUnprocessableEntity),
-									Message: `label "authentication.gardener.cloud/public-keys" is missing`,
+									Message: `label "discovery.gardener.cloud/public" is missing`,
 								},
 							),
 							Entry(
-								"label authentication.gardener.cloud/public-keys has wrong value",
+								"label discovery.gardener.cloud/public has wrong value",
 								&corev1.Secret{
 									ObjectMeta: metav1.ObjectMeta{
 										Labels: map[string]string{
-											"shoot.gardener.cloud/name":                 "foo",
-											"shoot.gardener.cloud/namespace":            "foo",
-											"authentication.gardener.cloud/public-keys": "foo",
+											"shoot.gardener.cloud/name":       "foo",
+											"shoot.gardener.cloud/namespace":  "foo",
+											"discovery.gardener.cloud/public": "foo",
 										},
 									},
 								},
 								&metav1.Status{
 									Code:    int32(http.StatusUnprocessableEntity),
-									Message: `label "authentication.gardener.cloud/public-keys" value must be set to "serviceaccount"`,
+									Message: `label "discovery.gardener.cloud/public" value must be set to "serviceaccount"`,
 								},
 							),
 						)
@@ -1281,9 +1281,9 @@ var _ = Describe("handler", func() {
 								secret := &corev1.Secret{
 									ObjectMeta: metav1.ObjectMeta{
 										Labels: map[string]string{
-											"shoot.gardener.cloud/name":                 name,
-											"shoot.gardener.cloud/namespace":            namespace,
-											"authentication.gardener.cloud/public-keys": "serviceaccount",
+											"shoot.gardener.cloud/name":       name,
+											"shoot.gardener.cloud/namespace":  namespace,
+											"discovery.gardener.cloud/public": "serviceaccount",
 										},
 									},
 								}

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -672,17 +672,12 @@ const (
 	// LabelShootUID is a constant for a label key that indicates a relationship to a shoot with the specified UID.
 	LabelShootUID = "shoot.gardener.cloud/uid"
 
-	// LabelPublicKeys is a constant for a label key that indicates that a resource contains public keys.
-	//
-	// Deprecated: Use LabelDiscoveryPublic instead.
-	LabelPublicKeys = "authentication.gardener.cloud/public-keys" // TODO(dimityrmirchev): Deprecate in favour of LabelDiscoveryPublic
-	// LabelPublicKeysServiceAccount is a constant for a label value that indicates that a resource contains service account public keys.
-	LabelPublicKeysServiceAccount = "serviceaccount"
-
 	// LabelDiscoveryPublic is a constant for a label key that indicates that the labeled resource is of interest to the Gardener Discovery Server.
 	LabelDiscoveryPublic = "discovery.gardener.cloud/public"
 	// DiscoveryShootCA is a constant for a label value that indicates that the labeled resource contains shoot cluster certificate authority.
 	DiscoveryShootCA = "shoot-ca"
+	// LabelPublicKeysServiceAccount is a constant for a label value that indicates that a resource contains service account public keys.
+	LabelPublicKeysServiceAccount = "serviceaccount"
 
 	// LabelExposureClassHandlerName is the label key for exposure class handler names.
 	LabelExposureClassHandlerName = "handler.exposureclass.gardener.cloud/name"

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
@@ -45,7 +45,6 @@ func (b *Botanist) SyncPublicServiceAccountKeys(ctx context.Context) error {
 			v1beta1constants.ProjectName:          b.Garden.Project.Name,
 			v1beta1constants.LabelShootName:       b.Shoot.GetInfo().Name,
 			v1beta1constants.LabelShootNamespace:  b.Shoot.GetInfo().Namespace,
-			v1beta1constants.LabelPublicKeys:      v1beta1constants.LabelPublicKeysServiceAccount, // TODO(vpnachev): Remove this label after v1.145 is released.
 			v1beta1constants.LabelDiscoveryPublic: v1beta1constants.LabelPublicKeysServiceAccount,
 		}
 		secret.Data = map[string][]byte{

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
@@ -92,11 +92,10 @@ var _ = Describe("ServiceAccountKeys", func() {
 				Namespace:       "gardener-system-shoot-issuer",
 				ResourceVersion: "1",
 				Labels: map[string]string{
-					"shoot.gardener.cloud/namespace":            "bar",
-					"authentication.gardener.cloud/public-keys": "serviceaccount", // TODO(vpnachev): Remove this label after v1.145 is released.
-					"discovery.gardener.cloud/public":           "serviceaccount",
-					"project.gardener.cloud/name":               "project-name",
-					"shoot.gardener.cloud/name":                 "foo",
+					"shoot.gardener.cloud/namespace":  "bar",
+					"discovery.gardener.cloud/public": "serviceaccount",
+					"project.gardener.cloud/name":     "project-name",
+					"shoot.gardener.cloud/name":       "foo",
 				},
 			},
 			Data: map[string][]byte{


### PR DESCRIPTION
**How to categorize this PR?**
/area security quality
/kind cleanup

**What this PR does / why we need it**:
Remove the deprecated `authentication.gardener.cloud/public-keys` label key

**Which issue(s) this PR fixes**:
Follow-up on #14670
https://github.com/gardener/gardener-discovery-server/pull/196 has adopted the new label and is released for the first time in v0.11.0

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
⚠️ Gardener is no longer compatible with `gardener-discovery-server` version `< v0.11.0`, if you are not using the default `gardener-discovery-server` managed by gardener operator, please update your `gardener-discovery-server` to version `>= v0.11.0` before updating Gardener to this version.
```


/cc @dimityrmirchev 