### PR TITLE
Scrape kubelet PVC metrics in Garden Prometheus

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/garden/assets/scrapeconfigs/kubelet.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/scrapeconfigs/kubelet.yaml
@@ -22,6 +22,9 @@ relabel_configs:
   replacement: /api/v1/nodes/${1}/proxy/metrics
 
 metric_relabel_configs:
+- source_labels: [ namespace ]
+  regex: ^garden$
+  action: keep
 - source_labels: [__name__]
   action: keep
   regex: ^(kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used)$

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/scrapeconfigs/kubelet.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/scrapeconfigs/kubelet.yaml
@@ -1,0 +1,27 @@
+job_name: kubelet
+honor_labels: false
+scheme: https
+
+tls_config:
+  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+kubernetes_sd_configs:
+- role: node
+
+relabel_configs:
+- source_labels: [__meta_kubernetes_node_address_InternalIP]
+  target_label: instance
+- action: labelmap
+  regex: __meta_kubernetes_node_label_(.+)
+- target_label: __address__
+  replacement: kubernetes.default.svc
+- source_labels: [__meta_kubernetes_node_name]
+  regex: (.+)
+  target_label: __metrics_path__
+  replacement: /api/v1/nodes/${1}/proxy/metrics
+
+metric_relabel_configs:
+- source_labels: [__name__]
+  action: keep
+  regex: ^(kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used)$

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
@@ -27,9 +27,12 @@ type federationConfig struct {
 //go:embed assets/scrapeconfigs/cadvisor.yaml
 var cAdvisor string
 
+//go:embed assets/scrapeconfigs/kubelet.yaml
+var kubelet string
+
 // AdditionalScrapeConfigs returns the additional scrape configs for the garden prometheus.
 func AdditionalScrapeConfigs() []string {
-	return []string{cAdvisor}
+	return []string{cAdvisor, kubelet}
 }
 
 // CentralScrapeConfigs returns the central ScrapeConfig resources for the garden prometheus.

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
@@ -24,11 +24,12 @@ type federationConfig struct {
 	secret    *corev1.Secret
 }
 
-//go:embed assets/scrapeconfigs/cadvisor.yaml
-var cAdvisor string
-
-//go:embed assets/scrapeconfigs/kubelet.yaml
-var kubelet string
+var (
+	//go:embed assets/scrapeconfigs/cadvisor.yaml
+	cAdvisor string
+	//go:embed assets/scrapeconfigs/kubelet.yaml
+	kubelet string
+)
 
 // AdditionalScrapeConfigs returns the additional scrape configs for the garden prometheus.
 func AdditionalScrapeConfigs() []string {

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
@@ -74,6 +74,9 @@ relabel_configs:
   replacement: /api/v1/nodes/${1}/proxy/metrics
 
 metric_relabel_configs:
+- source_labels: [ namespace ]
+  regex: ^garden$
+  action: keep
 - source_labels: [__name__]
   action: keep
   regex: ^(kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used)$

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
@@ -50,6 +50,34 @@ metric_relabel_configs:
   regex: ^(container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_writes_bytes_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_last_seen|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
   action: keep
 `,
+				`job_name: kubelet
+honor_labels: false
+scheme: https
+
+tls_config:
+  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+kubernetes_sd_configs:
+- role: node
+
+relabel_configs:
+- source_labels: [__meta_kubernetes_node_address_InternalIP]
+  target_label: instance
+- action: labelmap
+  regex: __meta_kubernetes_node_label_(.+)
+- target_label: __address__
+  replacement: kubernetes.default.svc
+- source_labels: [__meta_kubernetes_node_name]
+  regex: (.+)
+  target_label: __metrics_path__
+  replacement: /api/v1/nodes/${1}/proxy/metrics
+
+metric_relabel_configs:
+- source_labels: [__name__]
+  action: keep
+  regex: ^(kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used)$
+`,
 			))
 		})
 	})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Garden Prometheus now scrapes `kubelet_volume_stats_*` metrics via a kubelet scrape config. The added metrics are:
  - `kubelet_volume_stats_available_bytes`                                                                                                                                                                                        
  - `kubelet_volume_stats_capacity_bytes`                                                                                                                                                                                       
  - `kubelet_volume_stats_used_bytes`
  - `kubelet_volume_stats_inodes`                                                                                                                                                                                                 
  - `kubelet_volume_stats_inodes_free`
  - `kubelet_volume_stats_inodes_used`

**Which issue(s) this PR fixes**:
Prerequisite for Garden part of #14383

**Special notes for your reviewer**:
@gardener/monitoring-maintainers
The scrape config is done by following the practices in the already existing cAdvisor config for the Garden Prometheus as an example.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Garden Prometheus now scrapes `kubelet_volume_stats_*` metrics, enabling PVC volume-usage monitoring, which can also be used by `pvc-autoscaler`.
```
