### PR TITLE
Track dev-setup extension.yaml chart versions via Renovate github-releases manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,6 +47,21 @@
       datasourceTemplate: 'github-releases',
     },
     {
+      // Detection for Gardener extension Helm chart references in dev-setup `extension.yaml` files.
+      // The OCI chart version matches the extension's GitHub release tag, so we track it via
+      // github-releases. The docker datasource for these files is disabled below to avoid duplicate updates.
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^dev-setup/extensions/.+/extension\\.yaml$/',
+      ],
+      matchStrings: [
+        'charts/gardener/extensions/networking-(?<provider>[^:@\\s]+):(?<currentValue>[^@\\s]+)',
+        'charts/gardener/extensions/admission-(?<provider>[^-]+)-(?:runtime|application):(?<currentValue>[^@\\s]+)',
+      ],
+      depNameTemplate: 'gardener/gardener-extension-networking-{{{provider}}}',
+      datasourceTemplate: 'github-releases',
+    },
+    {
       // Generic detection for cli argument image specifications.
       customType: 'regex',
       managerFilePatterns: [


### PR DESCRIPTION
Adds a Renovate custom manager so the OCI chart refs in `dev-setup/extensions/**/extension.yaml` are kept up to date via the github-releases datasource (they were previously unmanaged and frozen).

```release-note
NONE
```