### PR TITLE
docs: Add cherry-pick eligibility criteria

### DIFF
--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -10,6 +10,7 @@ This document describes how to contribute features or hotfixes, and how new Gard
     - [TODO Statements](#todo-statements)
     - [Deprecations and Backwards-Compatibility](#deprecations-and-backwards-compatibility)
   - [Cherry Picks](#cherry-picks)
+    - [What Kind of PRs are Good for Cherry Picks](#what-kind-of-prs-are-good-for-cherry-picks)
     - [Prerequisites](#prerequisites)
     - [Initiate a Cherry Pick](#initiate-a-cherry-pick)
 
@@ -256,8 +257,30 @@ For example, the migration code for moving the Prometheus instances under manage
 
 This section explains how to initiate cherry picks on release branches within the `gardener/gardener` repository.
 
-- [Prerequisites](#prerequisites)
-- [Initiate a Cherry Pick](#initiate-a-cherry-pick)
+### What Kind of PRs are Good for Cherry Picks
+
+Patch releases must be easy and safe to consume, so security fixes and critical bug fixes can be delivered with minimal risk of regression.
+
+Good candidates for cherry picks are:
+- Security fixes
+  - Fixes that preserve the confidentiality, integrity, or availability of the system.
+- Regression fixes
+  - Fixes for functionality that used to work in an earlier release but broke.
+- Critical bug fixes
+  - Examples: failing reconciliation, failing lifecycle operation, resource leakage, outages, loss of data, memory corruption, panic, crash, hang and others.
+- Critical dependency updates
+  - Dependency updates that fix a security vulnerability or a critical bug in a dependency.
+  - Examples: Go patch version update, Go module dependency updates, container image version updates
+  - Routine dependency updates do **not** qualify.
+- Test-only changes to stabilize failing / flaky tests on release branches
+
+Changes that generally should **not** be cherry-picked:
+- New features or enhancements.
+- Refactorings, cleanups, or cosmetic changes.
+- Breaking changes.
+- Pull requests which don't have one of the `/kind bug` or `/kind regression` labels.
+
+The release responsible usually cuts new patch releases for critical fixes in a timely manner. Non-critical fixes (e.g., fixes for off-by-default alpha features, deflaking tests) may still be cherry-picked, but the release responsible is not obliged to cut a patch release for them promptly.
 
 ### Prerequisites
 

--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -11,8 +11,10 @@ This document describes how to contribute features or hotfixes, and how new Gard
     - [Deprecations and Backwards-Compatibility](#deprecations-and-backwards-compatibility)
   - [Cherry Picks](#cherry-picks)
     - [What Kind of PRs are Good for Cherry Picks](#what-kind-of-prs-are-good-for-cherry-picks)
-    - [Prerequisites](#prerequisites)
-    - [Initiate a Cherry Pick](#initiate-a-cherry-pick)
+    - [Initiate a Cherry Pick via the `cherrypicker` Plugin](#initiate-a-cherry-pick-via-the-cherrypicker-plugin)
+    - [Initiate a Cherry Pick via the Cherry Pick Script](#initiate-a-cherry-pick-via-the-cherry-pick-script)
+      - [Prerequisites](#prerequisites)
+      - [Run the Cherry Pick Script](#run-the-cherry-pick-script)
 
 ## Releases
 
@@ -282,7 +284,25 @@ Changes that generally should **not** be cherry-picked:
 
 The release responsible usually cuts new patch releases for critical fixes in a timely manner. Non-critical fixes (e.g., fixes for off-by-default alpha features, deflaking tests) may still be cherry-picked, but the release responsible is not obliged to cut a patch release for them promptly.
 
-### Prerequisites
+### Initiate a Cherry Pick via the `cherrypicker` Plugin
+
+As a first option, initiate a cherry-pick by using Prow's `cherrypicker` plugin.
+To initiate a cherry pick, comment in the pull request as follows:
+```
+/cherry-pick release-v3.14
+```
+
+The above comment will result in opening a new PR against the `release-v3.14` branch.
+
+For more details, see the [`cherrypicker` plugin documentation](https://docs.prow.k8s.io/docs/components/external-plugins/cherrypicker/).
+
+If the plugin fails to open a cherry pick PR due to merge conflicts, use the [Initiate a Cherry Pick via the Cherry Pick Script](#initiate-a-cherry-pick-via-the-cherry-pick-script) approach.
+
+### Initiate a Cherry Pick via the Cherry Pick Script
+
+Use this approach only if opening a cherry pick PR with the `cherrypicker` plugin fails (e.g., due to merge conflicts).
+
+#### Prerequisites
 
 Before you initiate a cherry pick, make sure that the following prerequisites are accomplished.
 
@@ -294,7 +314,7 @@ Before you initiate a cherry pick, make sure that the following prerequisites ar
 - Have `hub` installed. On macOS, `hub` can be installed via homebrew using the [hub formula](https://formulae.brew.sh/formula/hub). For other OS, follow the [`hub` installation instructions](https://github.com/mislav/hub?tab=readme-ov-file#installation).
 - A GitHub token which has permissions to create a PR in an upstream branch.
 
-### Initiate a Cherry Pick
+#### Run the Cherry Pick Script
 
 - Run the [cherry pick script][cherry-pick-script].
 

--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -277,10 +277,10 @@ Good candidates for cherry picks are:
 - Test-only changes to stabilize failing / flaky tests on release branches
 
 Changes that generally should **not** be cherry-picked:
-- New features or enhancements.
-- Refactorings, cleanups, or cosmetic changes.
-- Breaking changes.
-- Pull requests which don't have one of the `/kind bug` or `/kind regression` labels.
+- New features or enhancements
+- Refactorings, cleanups, or cosmetic changes
+- Breaking changes
+- Pull requests which don't have one of the `/kind bug` or `/kind regression` labels
 
 The release responsible usually cuts new patch releases for critical fixes in a timely manner. Non-critical fixes (e.g., fixes for off-by-default alpha features, deflaking tests) may still be cherry-picked, but the release responsible is not obliged to cut a patch release for them promptly.
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Until now the cherry-pick documentation only described *how* to initiate a cherry pick, but not *which* changes are appropriate to backport to `release-*` branches. This left the decision implicit and inconsistent. The new section documents the eligibility criteria — good candidates  and changes that generally should not be cherry-picked.

This PR also describes how to initiate a cherry pick via the `cherrypicker` Prow plugin. This is the preferred option to initiate a cherry-pick after the introduction of Prow.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
 The guidance is adapted from the [Kubernetes cherry-pick criteria](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-release/cherry-picks.md#what-kind-of-prs-are-good-for-cherry-picks) and adapted to the Gardener processes and conventions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The [cherry-pick documentation](https://github.com/gardener/gardener/blob/v1.148.0/docs/development/process.md#cherry-picks) now describes what kind of PRs are good candidates for cherry picks, and documents initiating cherry picks via the Prow `cherrypicker` plugin.
```
