### PR TITLE
Set `max_connection_duration: 86400s` in `EnvoyFilter`s created by `istio-cluster-configuration` controller

### DIFF
--- a/pkg/resourcemanager/controller/istioclusterconfiguration/reconciler.go
+++ b/pkg/resourcemanager/controller/istioclusterconfiguration/reconciler.go
@@ -271,13 +271,19 @@ func getEnvoyConfigPatch(clusterName string, httpProtocolPolicy istioutils.HTTPP
 		},
 	}
 
+	commonHTTPProtocolOptions := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"max_connection_duration": structpb.NewStringValue(fmt.Sprintf("%ds", istioutils.MaxConnectionDuration)),
+		},
+	}
+
 	var protocolOptions *structpb.Struct
 	switch httpProtocolPolicy {
 	case istioutils.HTTPProtocolPolicyExplicitHTTP2:
 		protocolOptions = &structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"@type":                        structpb.NewStringValue(httpProtocolOptionsType),
-				"common_http_protocol_options": structpb.NewStructValue(&structpb.Struct{}),
+				"common_http_protocol_options": structpb.NewStructValue(commonHTTPProtocolOptions),
 				"explicit_http_config": structpb.NewStructValue(&structpb.Struct{
 					Fields: map[string]*structpb.Value{
 						"http2_protocol_options": structpb.NewStructValue(http2Options),
@@ -289,7 +295,7 @@ func getEnvoyConfigPatch(clusterName string, httpProtocolPolicy istioutils.HTTPP
 		protocolOptions = &structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"@type":                        structpb.NewStringValue(httpProtocolOptionsType),
-				"common_http_protocol_options": structpb.NewStructValue(&structpb.Struct{}),
+				"common_http_protocol_options": structpb.NewStructValue(commonHTTPProtocolOptions),
 				"use_downstream_protocol_config": structpb.NewStructValue(&structpb.Struct{
 					Fields: map[string]*structpb.Value{
 						"http2_protocol_options": structpb.NewStructValue(http2Options),

--- a/pkg/resourcemanager/controller/istioclusterconfiguration/reconciler_test.go
+++ b/pkg/resourcemanager/controller/istioclusterconfiguration/reconciler_test.go
@@ -153,6 +153,10 @@ var _ = Describe("Reconciler", func() {
 			h2opts := explicitConfig.Fields["http2_protocol_options"].GetStructValue()
 			Expect(h2opts.Fields["initial_stream_window_size"].GetNumberValue()).To(Equal(float64(65536)))
 			Expect(h2opts.Fields["initial_connection_window_size"].GetNumberValue()).To(Equal(float64(1048576)))
+
+			commonOpts := httpOpts.Fields["common_http_protocol_options"].GetStructValue()
+			Expect(commonOpts).NotTo(BeNil())
+			Expect(commonOpts.Fields["max_connection_duration"].GetStringValue()).To(Equal("86400s"))
 		})
 
 		It("should create an EnvoyFilter with explicit HTTP/2 when port name is http2", func() {
@@ -233,6 +237,10 @@ var _ = Describe("Reconciler", func() {
 			h2opts := downstreamConfig.Fields["http2_protocol_options"].GetStructValue()
 			Expect(h2opts.Fields["initial_stream_window_size"].GetNumberValue()).To(Equal(float64(65536)))
 			Expect(h2opts.Fields["initial_connection_window_size"].GetNumberValue()).To(Equal(float64(1048576)))
+
+			commonOpts := httpOpts.Fields["common_http_protocol_options"].GetStructValue()
+			Expect(commonOpts).NotTo(BeNil())
+			Expect(commonOpts.Fields["max_connection_duration"].GetStringValue()).To(Equal("86400s"))
 		})
 
 		It("should prefer useClientProtocol over h2UpgradePolicy", func() {

--- a/pkg/utils/istio/destinationrule.go
+++ b/pkg/utils/istio/destinationrule.go
@@ -12,6 +12,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// MaxConnectionDuration is the maximum duration of a connection in seconds. It is set to 24 hours (86400 seconds) to prevent issues with expiring client certificates.
+const MaxConnectionDuration = 86400
+
 // DestinationRuleWithLocalityPreference returns a function setting the given attributes to a destination rule object.
 func DestinationRuleWithLocalityPreference(destinationRule *istionetworkingv1beta1.DestinationRule, labels map[string]string, exportTo []string, destinationHost string) func() error {
 	return DestinationRuleWithLocalityPreferenceAndTLS(destinationRule, labels, exportTo, destinationHost, &istioapinetworkingv1beta1.ClientTLSSettings{Mode: istioapinetworkingv1beta1.ClientTLSSettings_DISABLE})
@@ -82,7 +85,7 @@ func destinationRuleWithTrafficPolicy(
 			TrafficPolicy: &istioapinetworkingv1beta1.TrafficPolicy{
 				ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
 					Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
-						MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
+						MaxConnectionDuration: &durationpb.Duration{Seconds: MaxConnectionDuration},
 						TcpKeepalive: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
 							Time:     &durationpb.Duration{Seconds: 7200},
 							Interval: &durationpb.Duration{Seconds: 75},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind regression

**What this PR does / why we need it**:
`istio-cluster-configuration` controller (see PR #14690) unsets the maximum connection duration which has been introduced in PR #14061.
This could lead to HTTP 401 errors for connections to kube-apiservers which are using client-certificates when L7 load-balancing is active.
The issue occurs when the client-certificate of istio-ingressgateway is rolled but some connections between istio-ingressgateway and kube-apiserver remain open (for days) until the old certificate expires.

This PR fixes the issue. Simply removing `"common_http_protocol_options"` does not work. The value has to be set explicitly. 

**Which issue(s) this PR fixes**:
Part of #8810 

**Special notes for your reviewer**:
/cc @axel7born @marwinski @ScheererJ  

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A regression which could lead to HTTP 401 errors for clients using client-certificates to authenticate at kube-apiservers when L7 load-balancing is active has been fixed. 
```