### PR TITLE
[GEP-28] Always enable SSH for Self hosted Shoots

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap_test.go
@@ -110,6 +110,7 @@ var _ = Describe("controlPlaneBootstrap", func() {
 			Expect(actual.Spec.Units).To(ConsistOf(
 				HaveField("Name", "gardener-user.service"),
 				HaveField("Name", "gardener-user.path"),
+				HaveField("Name", "sshd-ensurer.service"),
 			))
 			Expect(actual.Spec.Files).To(ConsistOf(
 				HaveField("Path", "/var/lib/gardener-user/run.sh"),
@@ -117,6 +118,7 @@ var _ = Describe("controlPlaneBootstrap", func() {
 					HaveField("Path", "/var/lib/gardener-user-authorized-keys"),
 					HaveField("Content.Inline.Data", utils.EncodeBase64([]byte(sshPublicKey))),
 				),
+				HaveField("Path", "/var/lib/sshd-ensurer/run.sh"),
 				And(
 					HaveField("Path", nodeinit.GardenadmPathDownloadScript),
 					HaveField("Permissions", new(uint32(0755))),

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm.go
@@ -15,6 +15,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/gardeneruser"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -42,9 +43,22 @@ var (
 // We must not exceed the 16 KB, so be careful when extending/changing anything in here.
 // ### !CAUTION! ###
 func GardenadmConfig(sshPublicKey string) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
-	units, files, err := gardeneruser.New().Config(components.Context{SSHPublicKeys: []string{sshPublicKey}})
-	if err != nil {
-		return nil, nil, fmt.Errorf("error generating gardener user component contents: %w", err)
+	var (
+		units []extensionsv1alpha1.Unit
+		files []extensionsv1alpha1.File
+	)
+
+	for _, component := range []components.Component{
+		gardeneruser.New(),
+		sshdensurer.New(),
+	} {
+		u, f, err := component.Config(components.Context{SSHPublicKeys: []string{sshPublicKey}, SSHAccessEnabled: true})
+		if err != nil {
+			return nil, nil, fmt.Errorf("error generating gardener user component contents: %w", err)
+		}
+
+		units = append(units, u...)
+		files = append(files, f...)
 	}
 
 	downloadScript, err := generateGardenadmDownloadScript()

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
@@ -17,34 +17,13 @@ var _ = Describe("Init", func() {
 	const sshPublicKey = "ssh-rsa foobar"
 
 	Describe("#GardenadmConfig", func() {
-		It("should return the correct units and files", func() {
-			units, files, err := GardenadmConfig(sshPublicKey)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(units).To(ConsistOf(
-				And(
-					HaveField("Name", "gardener-user.service"),
-					HaveField("Enable", HaveValue(BeTrue())),
-				),
-				And(
-					HaveField("Name", "gardener-user.path"),
-					HaveField("Enable", HaveValue(BeTrue())),
-				),
-			))
-
-			Expect(files).To(ConsistOf(
-				HaveField("Path", "/var/lib/gardener-user/run.sh"),
-				And(
-					HaveField("Path", "/var/lib/gardener-user-authorized-keys"),
-					HaveField("Content.Inline.Data", utils.EncodeBase64([]byte(sshPublicKey))),
-				),
-				extensionsv1alpha1.File{
-					Path:        "/var/lib/gardenadm/download.sh",
-					Permissions: new(uint32(0755)),
-					Content: extensionsv1alpha1.FileContent{
-						Inline: &extensionsv1alpha1.FileContentInline{
-							Encoding: "b64",
-							Data: utils.EncodeBase64([]byte(`#!/usr/bin/env bash
+		downloadScriptMatcher := extensionsv1alpha1.File{
+			Path:        "/var/lib/gardenadm/download.sh",
+			Permissions: new(uint32(0755)),
+			Content: extensionsv1alpha1.FileContent{
+				Inline: &extensionsv1alpha1.FileContentInline{
+					Encoding: "b64",
+					Data: utils.EncodeBase64([]byte(`#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset
@@ -77,14 +56,48 @@ mkdir -p "/opt/bin"
 cp -f "$tmp_dir/gardenadm" "/opt/bin" || cp -f "$tmp_dir/ko-app/gardenadm" "/opt/bin"
 chmod +x "/opt/bin/gardenadm"
 `)),
-						},
-					},
 				},
+			},
+		}
+
+		machineNameFileMatcher := And(
+			HaveField("Path", "/var/lib/gardener-node-agent/machine-name"),
+			HaveField("Content.Inline.Data", "<<MACHINE_NAME>>"),
+			HaveField("Content.TransmitUnencoded", HaveValue(BeTrue())),
+		)
+
+		sshdEnsurerUnitMatcher := And(
+			HaveField("Name", "sshd-ensurer.service"),
+			HaveField("FilePaths", ConsistOf("/var/lib/sshd-ensurer/run.sh")),
+		)
+
+		sshdEnsurerFileMatcher := HaveField("Path", "/var/lib/sshd-ensurer/run.sh")
+
+		It("should return the correct units and files", func() {
+			units, files, err := GardenadmConfig(sshPublicKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(units).To(ConsistOf(
 				And(
-					HaveField("Path", "/var/lib/gardener-node-agent/machine-name"),
-					HaveField("Content.Inline.Data", "<<MACHINE_NAME>>"),
-					HaveField("Content.TransmitUnencoded", HaveValue(BeTrue())),
+					HaveField("Name", "gardener-user.service"),
+					HaveField("Enable", HaveValue(BeTrue())),
 				),
+				And(
+					HaveField("Name", "gardener-user.path"),
+					HaveField("Enable", HaveValue(BeTrue())),
+				),
+				sshdEnsurerUnitMatcher,
+			))
+
+			Expect(files).To(ConsistOf(
+				HaveField("Path", "/var/lib/gardener-user/run.sh"),
+				And(
+					HaveField("Path", "/var/lib/gardener-user-authorized-keys"),
+					HaveField("Content.Inline.Data", utils.EncodeBase64([]byte(sshPublicKey))),
+				),
+				sshdEnsurerFileMatcher,
+				downloadScriptMatcher,
+				machineNameFileMatcher,
 			))
 		})
 	})


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:

With this, `gardenadm` e.g. `bootstrap` respects ssh being explicitly enabled or not.
This is needed for OSes that do not come with SSH enabled out of the box, so gardenadm can SSH to the first controlplane node 

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`gardenadm` now enables SSH for all nodes in a self hosted shoot cluster. This is required to be able to bootstrap the control plane.
```
