### PR TITLE
Visualize ignored MRs for `Seed` and `Garden` resource

### DIFF
--- a/charts/gardener/operator/files/crd-gardens.yaml
+++ b/charts/gardener/operator/files/crd-gardens.yaml
@@ -2135,6 +2135,51 @@ spec:
                   - type
                   type: object
                 type: array
+              constraints:
+                description: Constraints represents conditions of a Garden's current
+                  state that constraint some operations on it.
+                items:
+                  description: Condition holds the information about the state of
+                    a resource.
+                  properties:
+                    codes:
+                      description: Well-defined error codes in case the condition
+                        reports a problem.
+                      items:
+                        description: ErrorCode is a string alias.
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: Last time the condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of the condition.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               credentials:
                 description: Credentials contains information about the virtual garden
                   cluster credentials.

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -11652,18 +11652,6 @@ string
 </tr>
 <tr>
 <td>
-<code>constraints</code></br>
-<em>
-<a href="#condition">Condition</a> array
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Constraints represents conditions of a Seed's current state that constraint some operations on it.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>lastOperation</code></br>
 <em>
 <a href="#lastoperation">LastOperation</a>
@@ -11672,6 +11660,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>LastOperation holds information about the last operation on the Seed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>constraints</code></br>
+<em>
+<a href="#condition">Condition</a> array
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Constraints represents conditions of a Seed's current state that constraint some operations on it.</p>
 </td>
 </tr>
 

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -11652,6 +11652,18 @@ string
 </tr>
 <tr>
 <td>
+<code>constraints</code></br>
+<em>
+<a href="#condition">Condition</a> array
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Constraints represents conditions of a Seed's current state that constraint some operations on it.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>lastOperation</code></br>
 <em>
 <a href="#lastoperation">LastOperation</a>

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -1942,6 +1942,18 @@ Condition array
 </tr>
 <tr>
 <td>
+<code>constraints</code></br>
+<em>
+Condition array
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Constraints represents conditions of a Garden's current state that constraint some operations on it.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>lastOperation</code></br>
 <em>
 <a href="#lastoperation">LastOperation</a>

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -398,6 +398,14 @@ The following table explains which `ManagedResource`s are considered for which c
 |-------------------------------|----------------------------------------|
 | `SeedSystemComponentsHealthy` | `.spec.class` is set                   |
 
+##### Constraints
+
+The reconciler also computes the following constraint in `.status.constraints` of the `Seed`:
+
+| Constraint Type          | Meaning when `status=True`                                        | Meaning when `status=False`                                                         |
+|--------------------------|-------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| `ManagedResourcesHonored` | No `ManagedResource` in the seed's namespaces carries the `resources.gardener.cloud/ignore=true` annotation. | At least one `ManagedResource` is annotated with `resources.gardener.cloud/ignore=true`, disabling its reconciliation. |
+
 #### ["Lease" Reconciler](../../pkg/gardenlet/controller/seed/lease)
 
 This reconciler checks whether the connection to the seed cluster's `/healthz` endpoint works.

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -403,7 +403,7 @@ The following table explains which `ManagedResource`s are considered for which c
 The reconciler also computes the following constraint in `.status.constraints` of the `Seed`:
 
 | Constraint Type           | Meaning when `status=True`                                                                                   | Meaning when `status=False`                                                                                             |
-|---------------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+|---------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | `ManagedResourcesHonored` | No `ManagedResource` in the seed's namespaces carries the `resources.gardener.cloud/ignore=true` annotation. | At least one `ManagedResource` is annotated with `resources.gardener.cloud/ignore=true`, disabling its reconciliation.  |
 
 #### ["Lease" Reconciler](../../pkg/gardenlet/controller/seed/lease)

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -402,9 +402,9 @@ The following table explains which `ManagedResource`s are considered for which c
 
 The reconciler also computes the following constraint in `.status.constraints` of the `Seed`:
 
-| Constraint Type          | Meaning when `status=True`                                        | Meaning when `status=False`                                                         |
-|--------------------------|-------------------------------------------------------------------|-------------------------------------------------------------------------------------|
-| `ManagedResourcesHonored` | No `ManagedResource` in the seed's namespaces carries the `resources.gardener.cloud/ignore=true` annotation. | At least one `ManagedResource` is annotated with `resources.gardener.cloud/ignore=true`, disabling its reconciliation. |
+| Constraint Type           | Meaning when `status=True`                                                                                   | Meaning when `status=False`                                                                                             |
+|---------------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `ManagedResourcesHonored` | No `ManagedResource` in the seed's namespaces carries the `resources.gardener.cloud/ignore=true` annotation. | At least one `ManagedResource` is annotated with `resources.gardener.cloud/ignore=true`, disabling its reconciliation.  |
 
 #### ["Lease" Reconciler](../../pkg/gardenlet/controller/seed/lease)
 

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -556,7 +556,7 @@ The reconciler also computes the following constraint in `.status.constraints` o
 
 | Constraint Type           | Meaning when `status=True`                                                                                            | Meaning when `status=False`                                                                                             |
 |---------------------------|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-| `ManagedResourcesHonored` | No `ManagedResource` in the garden's namespaces carries the `resources.gardener.cloud/ignore=true` annotation. | At least one `ManagedResource` is annotated with `resources.gardener.cloud/ignore=true`, disabling its reconciliation. |
+| `ManagedResourcesHonored` | No `ManagedResource` in the garden's namespaces carries the `resources.gardener.cloud/ignore=true` annotation.  | At least one `ManagedResource` is annotated with `resources.gardener.cloud/ignore=true`, disabling its reconciliation.  |
 
 #### [`Reference` Reconciler](../../pkg/operator/controller/garden/reference)
 

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -128,12 +128,12 @@ gardener:
     priorityClassName: gardener-garden-system-200
 ```
 
-As soon as a `Garden` object is created and `runtimeValues` are configured, the extension is deployed in the runtime cluster. 
+As soon as a `Garden` object is created and `runtimeValues` are configured, the extension is deployed in the runtime cluster.
 
 ##### Extension Registration
 
 When the virtual garden cluster is available, the `Extension` controller manages [`ControllerRegistration`/`ControllerDeployment` resources](../extensions/registration.md#controllerregistrations)
-to register extensions for shoots.  The fields of `.spec.deployment.extension` include their configuration options. 
+to register extensions for shoots.  The fields of `.spec.deployment.extension` include their configuration options.
 
 #### Configuration for Admission Deployment
 
@@ -295,7 +295,7 @@ This section highlights the most prominent fields:
   `issuerURL` is the URL of the JWT issuer.
   `sessionLifetime` is the duration after which a session is terminated (i.e., after which a user is automatically logged out).
   `additionalScopes` allows to extend the list of scopes of the JWT token that are to be recognized.
-  `certificateAuthoritySecretRef` allows you to specify a secret containing a custom CA certificate for communicating with the OIDC issuer.  
+  `certificateAuthoritySecretRef` allows you to specify a secret containing a custom CA certificate for communicating with the OIDC issuer.
   You must reference a `Secret` in the `garden` namespace containing the client and, if applicable, the client secret for the dashboard:
   ```yaml
   apiVersion: v1
@@ -554,8 +554,8 @@ The following table explains which `ManagedResource`s are considered for which c
 
 The reconciler also computes the following constraint in `.status.constraints` of the `Garden`:
 
-| Constraint Type           | Meaning when `status=True`                                                                                            | Meaning when `status=False`                                                                                             |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| Constraint Type           | Meaning when `status=True`                                                                                      | Meaning when `status=False`                                                                                             |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | `ManagedResourcesHonored` | No `ManagedResource` in the garden's namespaces carries the `resources.gardener.cloud/ignore=true` annotation.  | At least one `ManagedResource` is annotated with `resources.gardener.cloud/ignore=true`, disabling its reconciliation.  |
 
 #### [`Reference` Reconciler](../../pkg/operator/controller/garden/reference)

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -550,6 +550,14 @@ The following table explains which `ManagedResource`s are considered for which c
 | `VirtualComponentsHealthy`       | `.spec.class` unset or `care.gardener.cloud/condition-type` label set to `VirtualComponentsHealthy`                  |
 | `ObservabilityComponentsHealthy` | `care.gardener.cloud/condition-type` label set to `ObservabilityComponentsHealthy`                                   |
 
+##### Constraints
+
+The reconciler also computes the following constraint in `.status.constraints` of the `Garden`:
+
+| Constraint Type           | Meaning when `status=True`                                                                                            | Meaning when `status=False`                                                                                             |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `ManagedResourcesHonored` | No `ManagedResource` in the garden's namespaces carries the `resources.gardener.cloud/ignore=true` annotation. | At least one `ManagedResource` is annotated with `resources.gardener.cloud/ignore=true`, disabling its reconciliation. |
+
 #### [`Reference` Reconciler](../../pkg/operator/controller/garden/reference)
 
 `Garden` objects may specify references to other objects in the Garden cluster which are required for certain features.

--- a/docs/usage/shoot/shoot_status.md
+++ b/docs/usage/shoot/shoot_status.md
@@ -120,7 +120,7 @@ This constraint indicates that at least one worker pool with the update strategy
 The constraint is not added to `.status.constraints` if all such worker pools are already up-to-date.
 Once the user manually labels all the relevant nodes with `node.machine.sapcloud.io/selected-for-update` and the update process completes, the constraint will be automatically removed.
 
-**`HasIgnoredManagedResources`**:
+**`ManagedResourcesHonored`**:
 
 This constraint indicates that at least one `ManagedResource` in the Shoot's control plane namespace has been annotated with `resources.gardener.cloud/ignore=true`, meaning its reconciliation has been disabled.
 It will not be added to `.status.constraints` if no such `ManagedResource` exists.

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -2135,6 +2135,51 @@ spec:
                   - type
                   type: object
                 type: array
+              constraints:
+                description: Constraints represents conditions of a Garden's current
+                  state that constraint some operations on it.
+                items:
+                  description: Condition holds the information about the state of
+                    a resource.
+                  properties:
+                    codes:
+                      description: Well-defined error codes in case the condition
+                        reports a problem.
+                      items:
+                        description: ErrorCode is a string alias.
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: Last time the condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of the condition.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               credentials:
                 description: Credentials contains information about the virtual garden
                   cluster credentials.

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -99,6 +99,8 @@ type SeedStatus struct {
 	ClientCertificateExpirationTimestamp *metav1.Time
 	// LastOperation holds information about the last operation on the Seed.
 	LastOperation *LastOperation
+	// Constraints represents conditions of a Seed's current state that constraint some operations on it.
+	Constraints []Condition
 }
 
 // Backup contains the object store configuration for backups for shoot (currently only etcd).

--- a/pkg/apis/core/v1beta1/generated.pb.go
+++ b/pkg/apis/core/v1beta1/generated.pb.go
@@ -10931,6 +10931,20 @@ func (m *SeedStatus) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.Constraints) > 0 {
+		for iNdEx := len(m.Constraints) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Constraints[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintGenerated(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x52
+		}
+	}
 	if m.LastOperation != nil {
 		{
 			size, err := m.LastOperation.MarshalToSizedBuffer(dAtA[:i])
@@ -17547,6 +17561,12 @@ func (m *SeedStatus) Size() (n int) {
 		l = m.LastOperation.Size()
 		n += 1 + l + sovGenerated(uint64(l))
 	}
+	if len(m.Constraints) > 0 {
+		for _, e := range m.Constraints {
+			l = e.Size()
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -21218,6 +21238,11 @@ func (this *SeedStatus) String() string {
 		repeatedStringForConditions += strings.Replace(strings.Replace(f.String(), "Condition", "Condition", 1), `&`, ``, 1) + ","
 	}
 	repeatedStringForConditions += "}"
+	repeatedStringForConstraints := "[]Condition{"
+	for _, f := range this.Constraints {
+		repeatedStringForConstraints += strings.Replace(strings.Replace(f.String(), "Condition", "Condition", 1), `&`, ``, 1) + ","
+	}
+	repeatedStringForConstraints += "}"
 	keysForCapacity := make([]string, 0, len(this.Capacity))
 	for k := range this.Capacity {
 		keysForCapacity = append(keysForCapacity, string(k))
@@ -21248,6 +21273,7 @@ func (this *SeedStatus) String() string {
 		`Allocatable:` + mapStringForAllocatable + `,`,
 		`ClientCertificateExpirationTimestamp:` + strings.Replace(fmt.Sprintf("%v", this.ClientCertificateExpirationTimestamp), "Time", "v11.Time", 1) + `,`,
 		`LastOperation:` + strings.Replace(this.LastOperation.String(), "LastOperation", "LastOperation", 1) + `,`,
+		`Constraints:` + repeatedStringForConstraints + `,`,
 		`}`,
 	}, "")
 	return s
@@ -52745,6 +52771,40 @@ func (m *SeedStatus) Unmarshal(dAtA []byte) error {
 				m.LastOperation = &LastOperation{}
 			}
 			if err := m.LastOperation.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Constraints", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Constraints = append(m.Constraints, Condition{})
+			if err := m.Constraints[len(m.Constraints)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -3279,15 +3279,15 @@ message SeedStatus {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time clientCertificateExpirationTimestamp = 8;
 
+  // LastOperation holds information about the last operation on the Seed.
+  // +optional
+  optional LastOperation lastOperation = 9;
+
   // Constraints represents conditions of a Seed's current state that constraint some operations on it.
   // +patchMergeKey=type
   // +patchStrategy=merge
   // +optional
   repeated Condition constraints = 10;
-
-  // LastOperation holds information about the last operation on the Seed.
-  // +optional
-  optional LastOperation lastOperation = 9;
 }
 
 // SeedTaint describes a taint on a seed.

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -3279,6 +3279,12 @@ message SeedStatus {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time clientCertificateExpirationTimestamp = 8;
 
+  // Constraints represents conditions of a Seed's current state that constraint some operations on it.
+  // +patchMergeKey=type
+  // +patchStrategy=merge
+  // +optional
+  repeated Condition constraints = 10;
+
   // LastOperation holds information about the last operation on the Seed.
   // +optional
   optional LastOperation lastOperation = 9;

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -122,6 +122,11 @@ type SeedStatus struct {
 	// ClientCertificateExpirationTimestamp is the timestamp at which gardenlet's client certificate expires.
 	// +optional
 	ClientCertificateExpirationTimestamp *metav1.Time `json:"clientCertificateExpirationTimestamp,omitempty" protobuf:"bytes,8,opt,name=clientCertificateExpirationTimestamp"`
+	// Constraints represents conditions of a Seed's current state that constraint some operations on it.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +optional
+	Constraints []Condition `json:"constraints,omitempty" patchMergeKey:"type" patchStrategy:"merge" protobuf:"bytes,10,rep,name=constraints"`
 	// LastOperation holds information about the last operation on the Seed.
 	// +optional
 	LastOperation *LastOperation `json:"lastOperation,omitempty" protobuf:"bytes,9,opt,name=lastOperation"`
@@ -540,6 +545,9 @@ const (
 	SeedSystemComponentsHealthy ConditionType = "SeedSystemComponentsHealthy"
 	// SeedEmergencyStopShootReconciliations is a constant for a condition type indicating disabled shoot reconciliations.
 	SeedEmergencyStopShootReconciliations ConditionType = "EmergencyStopShootReconciliations"
+	// SeedManagedResourcesHonored is a constant for a constraint type indicating that no ManagedResources
+	// in the seed's namespaces have been annotated with resources.gardener.cloud/ignore=true.
+	SeedManagedResourcesHonored ConditionType = "ManagedResourcesHonored"
 )
 
 // Resource constants for Gardener object types

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -122,14 +122,14 @@ type SeedStatus struct {
 	// ClientCertificateExpirationTimestamp is the timestamp at which gardenlet's client certificate expires.
 	// +optional
 	ClientCertificateExpirationTimestamp *metav1.Time `json:"clientCertificateExpirationTimestamp,omitempty" protobuf:"bytes,8,opt,name=clientCertificateExpirationTimestamp"`
+	// LastOperation holds information about the last operation on the Seed.
+	// +optional
+	LastOperation *LastOperation `json:"lastOperation,omitempty" protobuf:"bytes,9,opt,name=lastOperation"`
 	// Constraints represents conditions of a Seed's current state that constraint some operations on it.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +optional
 	Constraints []Condition `json:"constraints,omitempty" patchMergeKey:"type" patchStrategy:"merge" protobuf:"bytes,10,rep,name=constraints"`
-	// LastOperation holds information about the last operation on the Seed.
-	// +optional
-	LastOperation *LastOperation `json:"lastOperation,omitempty" protobuf:"bytes,9,opt,name=lastOperation"`
 }
 
 // Backup contains the object store configuration for backups for shoot (currently only etcd).

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -2179,10 +2179,10 @@ const (
 	// ShootManualInPlaceWorkersUpdated is a constant for a condition type indicating that the Shoot cluster does not have
 	// any worker pools with update strategy "ManualInPlaceUpdate" and pending update.
 	ShootManualInPlaceWorkersUpdated ConditionType = "ManualInPlaceWorkersUpdated"
-	// ShootHasIgnoredManagedResources is a constant for a condition type indicating that one or more ManagedResources
-	// in the Shoot's control plane namespace in the seed have been annotated with resources.gardener.cloud/ignore=true,
-	// meaning their reconciliation has been disabled. Operators should be aware of such resources as they may diverge from the desired state.
-	ShootHasIgnoredManagedResources ConditionType = "HasIgnoredManagedResources"
+	// ShootManagedResourcesHonored is a constant for a constraint type indicating that no ManagedResources
+	// in the Shoot's control plane namespace in the seed have been annotated with resources.gardener.cloud/ignore=true.
+	// When False, at least one ManagedResource has its reconciliation disabled by the ignore annotation.
+	ShootManagedResourcesHonored ConditionType = "ManagedResourcesHonored"
 	// ShootAutomaticCredentialsRotationPossible is a constant for a condition type indicating whether an automatic
 	// ETCD encryption key rotation can run during the next maintenance window.
 	ShootAutomaticCredentialsRotationPossible ConditionType = "AutomaticCredentialsRotationPossible"

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -7067,6 +7067,7 @@ func autoConvert_v1beta1_SeedStatus_To_core_SeedStatus(in *SeedStatus, out *core
 	out.Capacity = *(*v1.ResourceList)(unsafe.Pointer(&in.Capacity))
 	out.Allocatable = *(*v1.ResourceList)(unsafe.Pointer(&in.Allocatable))
 	out.ClientCertificateExpirationTimestamp = (*metav1.Time)(unsafe.Pointer(in.ClientCertificateExpirationTimestamp))
+	out.Constraints = *(*[]core.Condition)(unsafe.Pointer(&in.Constraints))
 	out.LastOperation = (*core.LastOperation)(unsafe.Pointer(in.LastOperation))
 	return nil
 }
@@ -7086,6 +7087,7 @@ func autoConvert_core_SeedStatus_To_v1beta1_SeedStatus(in *core.SeedStatus, out 
 	out.Allocatable = *(*v1.ResourceList)(unsafe.Pointer(&in.Allocatable))
 	out.ClientCertificateExpirationTimestamp = (*metav1.Time)(unsafe.Pointer(in.ClientCertificateExpirationTimestamp))
 	out.LastOperation = (*LastOperation)(unsafe.Pointer(in.LastOperation))
+	out.Constraints = *(*[]Condition)(unsafe.Pointer(&in.Constraints))
 	return nil
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -7067,8 +7067,8 @@ func autoConvert_v1beta1_SeedStatus_To_core_SeedStatus(in *SeedStatus, out *core
 	out.Capacity = *(*v1.ResourceList)(unsafe.Pointer(&in.Capacity))
 	out.Allocatable = *(*v1.ResourceList)(unsafe.Pointer(&in.Allocatable))
 	out.ClientCertificateExpirationTimestamp = (*metav1.Time)(unsafe.Pointer(in.ClientCertificateExpirationTimestamp))
-	out.Constraints = *(*[]core.Condition)(unsafe.Pointer(&in.Constraints))
 	out.LastOperation = (*core.LastOperation)(unsafe.Pointer(in.LastOperation))
+	out.Constraints = *(*[]core.Condition)(unsafe.Pointer(&in.Constraints))
 	return nil
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -5627,17 +5627,17 @@ func (in *SeedStatus) DeepCopyInto(out *SeedStatus) {
 		in, out := &in.ClientCertificateExpirationTimestamp, &out.ClientCertificateExpirationTimestamp
 		*out = (*in).DeepCopy()
 	}
+	if in.LastOperation != nil {
+		in, out := &in.LastOperation, &out.LastOperation
+		*out = new(LastOperation)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Constraints != nil {
 		in, out := &in.Constraints, &out.Constraints
 		*out = make([]Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
-	}
-	if in.LastOperation != nil {
-		in, out := &in.LastOperation, &out.LastOperation
-		*out = new(LastOperation)
-		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -5632,6 +5632,13 @@ func (in *SeedStatus) DeepCopyInto(out *SeedStatus) {
 		*out = new(LastOperation)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Constraints != nil {
+		in, out := &in.Constraints, &out.Constraints
+		*out = make([]Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -5627,17 +5627,17 @@ func (in *SeedStatus) DeepCopyInto(out *SeedStatus) {
 		in, out := &in.ClientCertificateExpirationTimestamp, &out.ClientCertificateExpirationTimestamp
 		*out = (*in).DeepCopy()
 	}
-	if in.LastOperation != nil {
-		in, out := &in.LastOperation, &out.LastOperation
-		*out = new(LastOperation)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.Constraints != nil {
 		in, out := &in.Constraints, &out.Constraints
 		*out = make([]Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.LastOperation != nil {
+		in, out := &in.LastOperation, &out.LastOperation
+		*out = new(LastOperation)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -5637,6 +5637,13 @@ func (in *SeedStatus) DeepCopyInto(out *SeedStatus) {
 		*out = new(LastOperation)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Constraints != nil {
+		in, out := &in.Constraints, &out.Constraints
+		*out = make([]Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -838,6 +838,11 @@ type GardenStatus struct {
 	Gardener *gardencorev1beta1.Gardener `json:"gardener,omitempty"`
 	// Conditions is a list of conditions.
 	Conditions []gardencorev1beta1.Condition `json:"conditions,omitempty"`
+	// Constraints represents conditions of a Garden's current state that constraint some operations on it.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +optional
+	Constraints []gardencorev1beta1.Condition `json:"constraints,omitempty" patchMergeKey:"type" patchStrategy:"merge"`
 	// LastOperation holds information about the last operation on the Garden.
 	// +optional
 	LastOperation *gardencorev1beta1.LastOperation `json:"lastOperation,omitempty"`
@@ -935,6 +940,9 @@ const (
 	VirtualGardenAPIServerAvailable gardencorev1beta1.ConditionType = "VirtualGardenAPIServerAvailable"
 	// ObservabilityComponentsHealthy is a constant for a condition type indicating the health of observability components.
 	ObservabilityComponentsHealthy gardencorev1beta1.ConditionType = v1beta1constants.ObservabilityComponentsHealthy
+	// GardenManagedResourcesHonored is a constant for a constraint type indicating that no ManagedResources
+	// in the garden's namespaces have been annotated with resources.gardener.cloud/ignore=true.
+	GardenManagedResourcesHonored gardencorev1beta1.ConditionType = "ManagedResourcesHonored"
 )
 
 // AvailableOperationAnnotations is the set of available operation annotations for Garden resources.

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -961,6 +961,13 @@ func (in *GardenStatus) DeepCopyInto(out *GardenStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Constraints != nil {
+		in, out := &in.Constraints, &out.Constraints
+		*out = make([]v1beta1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.LastOperation != nil {
 		in, out := &in.LastOperation, &out.LastOperation
 		*out = new(v1beta1.LastOperation)

--- a/pkg/apiserver/openapi/api_violations.report
+++ b/pkg/apiserver/openapi/api_violations.report
@@ -78,6 +78,7 @@ API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,SeedSpec,Resources
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,SeedSpec,Taints
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,SeedStatus,Conditions
+API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,SeedStatus,Constraints
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,SeedVolume,Providers
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,ServiceAccountConfig,AcceptedIssuers
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,ServiceAccountKeyRotation,PendingWorkersRollouts

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -9403,6 +9403,12 @@ func schema_pkg_apis_core_v1beta1_SeedStatus(ref common.ReferenceCallback) commo
 							Ref:         ref(metav1.Time{}.OpenAPIModelName()),
 						},
 					},
+					"lastOperation": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LastOperation holds information about the last operation on the Seed.",
+							Ref:         ref(v1beta1.LastOperation{}.OpenAPIModelName()),
+						},
+					},
 					"constraints": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -9420,12 +9426,6 @@ func schema_pkg_apis_core_v1beta1_SeedStatus(ref common.ReferenceCallback) commo
 									},
 								},
 							},
-						},
-					},
-					"lastOperation": {
-						SchemaProps: spec.SchemaProps{
-							Description: "LastOperation holds information about the last operation on the Seed.",
-							Ref:         ref(v1beta1.LastOperation{}.OpenAPIModelName()),
 						},
 					},
 				},

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -9403,12 +9403,6 @@ func schema_pkg_apis_core_v1beta1_SeedStatus(ref common.ReferenceCallback) commo
 							Ref:         ref(metav1.Time{}.OpenAPIModelName()),
 						},
 					},
-					"lastOperation": {
-						SchemaProps: spec.SchemaProps{
-							Description: "LastOperation holds information about the last operation on the Seed.",
-							Ref:         ref(v1beta1.LastOperation{}.OpenAPIModelName()),
-						},
-					},
 					"constraints": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -9426,6 +9420,12 @@ func schema_pkg_apis_core_v1beta1_SeedStatus(ref common.ReferenceCallback) commo
 									},
 								},
 							},
+						},
+					},
+					"lastOperation": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LastOperation holds information about the last operation on the Seed.",
+							Ref:         ref(v1beta1.LastOperation{}.OpenAPIModelName()),
 						},
 					},
 				},

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -9409,6 +9409,25 @@ func schema_pkg_apis_core_v1beta1_SeedStatus(ref common.ReferenceCallback) commo
 							Ref:         ref(v1beta1.LastOperation{}.OpenAPIModelName()),
 						},
 					},
+					"constraints": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Constraints represents conditions of a Seed's current state that constraint some operations on it.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref(v1beta1.Condition{}.OpenAPIModelName()),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/gardenlet/controller/seed/care/health.go
+++ b/pkg/gardenlet/controller/seed/care/health.go
@@ -53,18 +53,17 @@ func NewHealth(
 func (h *health) Check(
 	ctx context.Context,
 	conditions SeedConditions,
-	constraints SeedConstraints,
-) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
+) []gardencorev1beta1.Condition {
 	managedResources, err := h.listManagedResources(ctx)
 	if err != nil {
 		conditions.systemComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.systemComponentsHealthy, nil, err)
-		return conditions.ConvertToSlice(), constraints.ConvertToSlice()
+		return conditions.ConvertToSlice()
 	}
 
 	prometheuses, err := h.listPrometheuses(ctx)
 	if err != nil {
 		conditions.systemComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.systemComponentsHealthy, nil, err)
-		return conditions.ConvertToSlice(), constraints.ConvertToSlice()
+		return conditions.ConvertToSlice()
 	}
 
 	var checkedConditions []gardencorev1beta1.Condition
@@ -73,10 +72,7 @@ func (h *health) Check(
 		checkedConditions = append(checkedConditions, v1beta1helper.NewConditionOrError(h.clock, conditions.emergencyStopShootReconciliations, newEmergencyStopShootReconciliations, nil))
 	}
 
-	status, reason, message := kuberneteshealth.CheckManagedResourcesHonored(managedResources)
-	constraints.managedResourcesHonored = v1beta1helper.UpdatedConditionWithClock(h.clock, constraints.managedResourcesHonored, status, reason, message)
-
-	return checkedConditions, constraints.ConvertToSlice()
+	return checkedConditions
 }
 
 func (h *health) listManagedResources(ctx context.Context) ([]resourcesv1alpha1.ManagedResource, error) {
@@ -191,4 +187,60 @@ func NewSeedConstraints(clock clock.Clock, status gardencorev1beta1.SeedStatus) 
 	return SeedConstraints{
 		managedResourcesHonored: v1beta1helper.GetOrInitConditionWithClock(clock, status.Constraints, gardencorev1beta1.SeedManagedResourcesHonored),
 	}
+}
+
+// constraint contains information needed to execute constraint checks for a seed.
+type constraint struct {
+	seedClient client.Client
+	clock      clock.Clock
+	namespace  *string
+}
+
+// NewConstraint returns a new constraint instance.
+func NewConstraint(seedClient client.Client, clock clock.Clock, namespace *string) ConstraintCheck {
+	return &constraint{
+		seedClient: seedClient,
+		clock:      clock,
+		namespace:  namespace,
+	}
+}
+
+// Check executes all constraint checks for the seed.
+func (c *constraint) Check(ctx context.Context, constraints SeedConstraints) []gardencorev1beta1.Condition {
+	managedResources, err := c.listManagedResources(ctx)
+	if err != nil {
+		constraints.managedResourcesHonored = v1beta1helper.UpdatedConditionUnknownErrorWithClock(c.clock, constraints.managedResourcesHonored,
+			fmt.Errorf("could not list ManagedResources to check for ignored resources: %w", err))
+		return filterOptionalSeedConstraints(constraints)
+	}
+
+	status, reason, message := kuberneteshealth.CheckManagedResourcesHonored(managedResources)
+	constraints.managedResourcesHonored = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.managedResourcesHonored, status, reason, message)
+
+	return filterOptionalSeedConstraints(constraints)
+}
+
+func (c *constraint) listManagedResources(ctx context.Context) ([]resourcesv1alpha1.ManagedResource, error) {
+	managedResourceListGarden := &resourcesv1alpha1.ManagedResourceList{}
+	if err := c.seedClient.List(ctx, managedResourceListGarden, client.InNamespace(ptr.Deref(c.namespace, v1beta1constants.GardenNamespace))); err != nil {
+		return nil, fmt.Errorf("failed listing ManagedResources in namespace %s: %w", ptr.Deref(c.namespace, v1beta1constants.GardenNamespace), err)
+	}
+
+	managedResourceListIstioSystem := &resourcesv1alpha1.ManagedResourceList{}
+	if err := c.seedClient.List(ctx, managedResourceListIstioSystem, client.InNamespace(ptr.Deref(c.namespace, v1beta1constants.IstioSystemNamespace))); err != nil {
+		return nil, fmt.Errorf("failed listing ManagedResources in namespace %s: %w", ptr.Deref(c.namespace, v1beta1constants.IstioSystemNamespace), err)
+	}
+
+	return append(managedResourceListGarden.Items, managedResourceListIstioSystem.Items...), nil
+}
+
+// filterOptionalSeedConstraints omits constraints that are True — they add no signal for operators.
+func filterOptionalSeedConstraints(constraints SeedConstraints) []gardencorev1beta1.Condition {
+	var out []gardencorev1beta1.Condition
+	for _, c := range constraints.ConvertToSlice() {
+		if c.Status != gardencorev1beta1.ConditionTrue {
+			out = append(out, c)
+		}
+	}
+	return out
 }

--- a/pkg/gardenlet/controller/seed/care/health.go
+++ b/pkg/gardenlet/controller/seed/care/health.go
@@ -19,6 +19,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	commonprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 	"github.com/gardener/gardener/pkg/features"
+	kuberneteshealth "github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	healthchecker "github.com/gardener/gardener/pkg/utils/kubernetes/health/checker"
 )
 
@@ -52,17 +53,18 @@ func NewHealth(
 func (h *health) Check(
 	ctx context.Context,
 	conditions SeedConditions,
-) []gardencorev1beta1.Condition {
+	constraints SeedConstraints,
+) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
 	managedResources, err := h.listManagedResources(ctx)
 	if err != nil {
 		conditions.systemComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.systemComponentsHealthy, nil, err)
-		return conditions.ConvertToSlice()
+		return conditions.ConvertToSlice(), constraints.ConvertToSlice()
 	}
 
 	prometheuses, err := h.listPrometheuses(ctx)
 	if err != nil {
 		conditions.systemComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.systemComponentsHealthy, nil, err)
-		return conditions.ConvertToSlice()
+		return conditions.ConvertToSlice(), constraints.ConvertToSlice()
 	}
 
 	var checkedConditions []gardencorev1beta1.Condition
@@ -70,7 +72,11 @@ func (h *health) Check(
 	if newEmergencyStopShootReconciliations := h.checkEmergencyStopShootReconciliations(conditions.emergencyStopShootReconciliations); newEmergencyStopShootReconciliations != nil {
 		checkedConditions = append(checkedConditions, v1beta1helper.NewConditionOrError(h.clock, conditions.emergencyStopShootReconciliations, newEmergencyStopShootReconciliations, nil))
 	}
-	return checkedConditions
+
+	status, reason, message := kuberneteshealth.CheckManagedResourcesHonored(managedResources)
+	constraints.managedResourcesHonored = v1beta1helper.UpdatedConditionWithClock(h.clock, constraints.managedResourcesHonored, status, reason, message)
+
+	return checkedConditions, constraints.ConvertToSlice()
 }
 
 func (h *health) listManagedResources(ctx context.Context) ([]resourcesv1alpha1.ManagedResource, error) {
@@ -157,5 +163,32 @@ func NewSeedConditions(clock clock.Clock, status gardencorev1beta1.SeedStatus) S
 	return SeedConditions{
 		systemComponentsHealthy:           v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, gardencorev1beta1.SeedSystemComponentsHealthy),
 		emergencyStopShootReconciliations: v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, gardencorev1beta1.SeedEmergencyStopShootReconciliations),
+	}
+}
+
+// SeedConstraints contains all constraints of the seed status subresource.
+type SeedConstraints struct {
+	managedResourcesHonored gardencorev1beta1.Condition
+}
+
+// ConvertToSlice returns the seed constraints as a slice.
+func (s SeedConstraints) ConvertToSlice() []gardencorev1beta1.Condition {
+	return []gardencorev1beta1.Condition{
+		s.managedResourcesHonored,
+	}
+}
+
+// ConstraintTypes returns all seed constraint types.
+func (s SeedConstraints) ConstraintTypes() []gardencorev1beta1.ConditionType {
+	return []gardencorev1beta1.ConditionType{
+		s.managedResourcesHonored.Type,
+	}
+}
+
+// NewSeedConstraints returns a new instance of SeedConstraints.
+// All constraints are retrieved from the given 'status' or newly initialized.
+func NewSeedConstraints(clock clock.Clock, status gardencorev1beta1.SeedStatus) SeedConstraints {
+	return SeedConstraints{
+		managedResourcesHonored: v1beta1helper.GetOrInitConditionWithClock(clock, status.Constraints, gardencorev1beta1.SeedManagedResourcesHonored),
 	}
 }

--- a/pkg/gardenlet/controller/seed/care/health_test.go
+++ b/pkg/gardenlet/controller/seed/care/health_test.go
@@ -42,7 +42,6 @@ var _ = Describe("Seed health", func() {
 		seed *gardencorev1beta1.Seed
 
 		seedSystemComponentsHealthyCondition gardencorev1beta1.Condition
-		seedConstraints                      SeedConstraints
 	)
 
 	BeforeEach(func() {
@@ -78,7 +77,6 @@ var _ = Describe("Seed health", func() {
 			Type:               gardencorev1beta1.SeedSystemComponentsHealthy,
 			LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
 		}
-		seedConstraints = NewSeedConstraints(fakeClock, gardencorev1beta1.SeedStatus{})
 	})
 
 	Describe("#Check", func() {
@@ -95,7 +93,7 @@ var _ = Describe("Seed health", func() {
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
 
-				updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+				updatedConditions := healthCheck.Check(ctx, conditions)
 				expectHealthySystemComponents(updatedConditions)
 			})
 		})
@@ -137,7 +135,7 @@ var _ = Describe("Seed health", func() {
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
 
-				updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+				updatedConditions := healthCheck.Check(ctx, conditions)
 
 				Expect(updatedConditions).ToNot(BeEmpty())
 				Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(
@@ -155,7 +153,7 @@ var _ = Describe("Seed health", func() {
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
 
-				updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+				updatedConditions := healthCheck.Check(ctx, conditions)
 
 				Expect(updatedConditions).ToNot(BeEmpty())
 				Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(
@@ -173,7 +171,7 @@ var _ = Describe("Seed health", func() {
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
 
-				updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+				updatedConditions := healthCheck.Check(ctx, conditions)
 				expectHealthySystemComponents(updatedConditions)
 			})
 
@@ -187,7 +185,7 @@ var _ = Describe("Seed health", func() {
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
 
-				updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+				updatedConditions := healthCheck.Check(ctx, conditions)
 				expectHealthySystemComponents(updatedConditions)
 			})
 
@@ -207,7 +205,7 @@ var _ = Describe("Seed health", func() {
 						Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 					})
 
-					updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+					updatedConditions := healthCheck.Check(ctx, conditions)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(
@@ -221,7 +219,7 @@ var _ = Describe("Seed health", func() {
 					Expect(prometheus).ToNot(BeNil())
 					prometheus.Labels = map[string]string{"health-check-by": "foo"}
 					Expect(c.Update(ctx, prometheus)).To(Succeed())
-					updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+					updatedConditions := healthCheck.Check(ctx, conditions)
 					expectHealthySystemComponents(updatedConditions)
 				})
 			})
@@ -236,7 +234,7 @@ var _ = Describe("Seed health", func() {
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
 
-						updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+						updatedConditions := healthCheck.Check(ctx, conditions)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedSystemComponentsHealthy, gardencorev1beta1.ConditionFalse, reason, message))
@@ -256,7 +254,7 @@ var _ = Describe("Seed health", func() {
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
 
-						updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+						updatedConditions := healthCheck.Check(ctx, conditions)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedSystemComponentsHealthy, gardencorev1beta1.ConditionProgressing, reason, message))
@@ -276,7 +274,7 @@ var _ = Describe("Seed health", func() {
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
 
-						updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+						updatedConditions := healthCheck.Check(ctx, conditions)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedSystemComponentsHealthy, gardencorev1beta1.ConditionProgressing, reason, message))
@@ -296,7 +294,7 @@ var _ = Describe("Seed health", func() {
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
 
-						updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+						updatedConditions := healthCheck.Check(ctx, conditions)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedSystemComponentsHealthy, gardencorev1beta1.ConditionProgressing, reason, message))
@@ -316,7 +314,7 @@ var _ = Describe("Seed health", func() {
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
 
-						updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+						updatedConditions := healthCheck.Check(ctx, conditions)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedSystemComponentsHealthy, gardencorev1beta1.ConditionFalse, reason, message))
@@ -456,20 +454,13 @@ var _ = Describe("Seed health", func() {
 		})
 
 		Context("ManagedResourcesHonored constraint check", func() {
-			It("should set ManagedResourcesHonored to True if no ManagedResources are ignored", func() {
+			It("should not include ManagedResourcesHonored constraint when no ManagedResources are ignored", func() {
 				Expect(c.Create(ctx, healthyManagedResource("foo"))).To(Succeed())
 
-				healthCheck := NewHealth(seed, c, fakeClock, nil, checker.NewHealthChecker(log, c, fakeClock))
-				conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
-					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
-				})
 				constraints := NewSeedConstraints(fakeClock, gardencorev1beta1.SeedStatus{})
+				updatedConstraints := NewConstraint(c, fakeClock, nil).Check(ctx, constraints)
 
-				_, updatedConstraints := healthCheck.Check(ctx, conditions, constraints)
-
-				Expect(updatedConstraints).To(ContainElements(
-					beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedManagedResourcesHonored, gardencorev1beta1.ConditionTrue, "AllManagedResourcesActive", "No ManagedResources are annotated to be ignored."),
-				))
+				Expect(updatedConstraints).NotTo(ContainCondition(OfType(gardencorev1beta1.SeedManagedResourcesHonored)))
 			})
 
 			It("should set ManagedResourcesHonored to False if a ManagedResource is ignored", func() {
@@ -477,13 +468,8 @@ var _ = Describe("Seed health", func() {
 				mr.Annotations = map[string]string{"resources.gardener.cloud/ignore": "true"}
 				Expect(c.Create(ctx, mr)).To(Succeed())
 
-				healthCheck := NewHealth(seed, c, fakeClock, nil, checker.NewHealthChecker(log, c, fakeClock))
-				conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
-					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
-				})
 				constraints := NewSeedConstraints(fakeClock, gardencorev1beta1.SeedStatus{})
-
-				_, updatedConstraints := healthCheck.Check(ctx, conditions, constraints)
+				updatedConstraints := NewConstraint(c, fakeClock, nil).Check(ctx, constraints)
 
 				Expect(updatedConstraints).To(ContainElements(
 					And(OfType(gardencorev1beta1.SeedManagedResourcesHonored), WithStatus(gardencorev1beta1.ConditionFalse), WithReason("ManagedResourcesIgnored"), WithMessageSubstrings("foo")),

--- a/pkg/gardenlet/controller/seed/care/health_test.go
+++ b/pkg/gardenlet/controller/seed/care/health_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Seed health", func() {
 		seed *gardencorev1beta1.Seed
 
 		seedSystemComponentsHealthyCondition gardencorev1beta1.Condition
+	seedConstraints                       SeedConstraints
 	)
 
 	BeforeEach(func() {
@@ -77,6 +78,7 @@ var _ = Describe("Seed health", func() {
 			Type:               gardencorev1beta1.SeedSystemComponentsHealthy,
 			LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
 		}
+		seedConstraints = NewSeedConstraints(fakeClock, gardencorev1beta1.SeedStatus{})
 	})
 
 	Describe("#Check", func() {
@@ -93,7 +95,8 @@ var _ = Describe("Seed health", func() {
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
 
-				expectHealthySystemComponents(healthCheck.Check(ctx, conditions))
+				updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+				expectHealthySystemComponents(updatedConditions)
 			})
 		})
 
@@ -134,7 +137,7 @@ var _ = Describe("Seed health", func() {
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
 
-				updatedConditions := healthCheck.Check(ctx, conditions)
+				updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
 
 				Expect(updatedConditions).ToNot(BeEmpty())
 				Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(
@@ -152,7 +155,7 @@ var _ = Describe("Seed health", func() {
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
 
-				updatedConditions := healthCheck.Check(ctx, conditions)
+				updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
 
 				Expect(updatedConditions).ToNot(BeEmpty())
 				Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(
@@ -170,7 +173,8 @@ var _ = Describe("Seed health", func() {
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
 
-				expectHealthySystemComponents(healthCheck.Check(ctx, conditions))
+				updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+				expectHealthySystemComponents(updatedConditions)
 			})
 
 			It("should set SeedSystemComponentsHealthy condition to true if Prometheus health check is down but the PrometheusHealthChecks feature gate is disabled", func() {
@@ -183,7 +187,7 @@ var _ = Describe("Seed health", func() {
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
 
-				updatedConditions := healthCheck.Check(ctx, conditions)
+				updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
 				expectHealthySystemComponents(updatedConditions)
 			})
 
@@ -203,7 +207,7 @@ var _ = Describe("Seed health", func() {
 						Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 					})
 
-					updatedConditions := healthCheck.Check(ctx, conditions)
+					updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(
@@ -217,7 +221,8 @@ var _ = Describe("Seed health", func() {
 					Expect(prometheus).ToNot(BeNil())
 					prometheus.Labels = map[string]string{"health-check-by": "foo"}
 					Expect(c.Update(ctx, prometheus)).To(Succeed())
-					expectHealthySystemComponents(healthCheck.Check(ctx, conditions))
+					updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
+				expectHealthySystemComponents(updatedConditions)
 				})
 			})
 		})
@@ -231,7 +236,7 @@ var _ = Describe("Seed health", func() {
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
 
-						updatedConditions := healthCheck.Check(ctx, conditions)
+						updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedSystemComponentsHealthy, gardencorev1beta1.ConditionFalse, reason, message))
@@ -251,7 +256,7 @@ var _ = Describe("Seed health", func() {
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
 
-						updatedConditions := healthCheck.Check(ctx, conditions)
+						updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedSystemComponentsHealthy, gardencorev1beta1.ConditionProgressing, reason, message))
@@ -271,7 +276,7 @@ var _ = Describe("Seed health", func() {
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
 
-						updatedConditions := healthCheck.Check(ctx, conditions)
+						updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedSystemComponentsHealthy, gardencorev1beta1.ConditionProgressing, reason, message))
@@ -291,7 +296,7 @@ var _ = Describe("Seed health", func() {
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
 
-						updatedConditions := healthCheck.Check(ctx, conditions)
+						updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedSystemComponentsHealthy, gardencorev1beta1.ConditionProgressing, reason, message))
@@ -311,7 +316,7 @@ var _ = Describe("Seed health", func() {
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
 
-						updatedConditions := healthCheck.Check(ctx, conditions)
+						updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions[0]).To(beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedSystemComponentsHealthy, gardencorev1beta1.ConditionFalse, reason, message))
@@ -401,6 +406,87 @@ var _ = Describe("Seed health", func() {
 				Expect(conditions.ConditionTypes()).To(HaveExactElements(
 					gardencorev1beta1.ConditionType("SeedSystemComponentsHealthy"),
 					gardencorev1beta1.ConditionType("EmergencyStopShootReconciliations"),
+				))
+			})
+		})
+	})
+
+	Describe("SeedConstraints", func() {
+		Describe("#NewSeedConstraints", func() {
+			It("should initialize all constraints", func() {
+				constraints := NewSeedConstraints(fakeClock, gardencorev1beta1.SeedStatus{})
+
+				Expect(constraints.ConvertToSlice()).To(ConsistOf(
+					beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedManagedResourcesHonored, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
+				))
+			})
+
+			It("should only initialize missing constraints", func() {
+				constraints := NewSeedConstraints(fakeClock, gardencorev1beta1.SeedStatus{
+					Constraints: []gardencorev1beta1.Condition{
+						{Type: "ManagedResourcesHonored"},
+						{Type: "Foo"},
+					},
+				})
+
+				Expect(constraints.ConvertToSlice()).To(HaveExactElements(
+					OfType("ManagedResourcesHonored"),
+				))
+			})
+		})
+
+		Describe("#ConvertToSlice", func() {
+			It("should return the expected constraints", func() {
+				constraints := NewSeedConstraints(fakeClock, gardencorev1beta1.SeedStatus{})
+
+				Expect(constraints.ConvertToSlice()).To(HaveExactElements(
+					OfType("ManagedResourcesHonored"),
+				))
+			})
+		})
+
+		Describe("#ConstraintTypes", func() {
+			It("should return the expected constraint types", func() {
+				constraints := NewSeedConstraints(fakeClock, gardencorev1beta1.SeedStatus{})
+
+				Expect(constraints.ConstraintTypes()).To(HaveExactElements(
+					gardencorev1beta1.ConditionType("ManagedResourcesHonored"),
+				))
+			})
+		})
+
+		Context("ManagedResourcesHonored constraint check", func() {
+			It("should set ManagedResourcesHonored to True if no ManagedResources are ignored", func() {
+				Expect(c.Create(ctx, healthyManagedResource("foo"))).To(Succeed())
+
+				healthCheck := NewHealth(seed, c, fakeClock, nil, checker.NewHealthChecker(log, c, fakeClock))
+				conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
+				})
+				constraints := NewSeedConstraints(fakeClock, gardencorev1beta1.SeedStatus{})
+
+				_, updatedConstraints := healthCheck.Check(ctx, conditions, constraints)
+
+				Expect(updatedConstraints).To(ContainElements(
+					beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedManagedResourcesHonored, gardencorev1beta1.ConditionTrue, "AllManagedResourcesActive", "No ManagedResources are annotated to be ignored."),
+				))
+			})
+
+			It("should set ManagedResourcesHonored to False if a ManagedResource is ignored", func() {
+				mr := healthyManagedResource("foo")
+				mr.Annotations = map[string]string{"resources.gardener.cloud/ignore": "true"}
+				Expect(c.Create(ctx, mr)).To(Succeed())
+
+				healthCheck := NewHealth(seed, c, fakeClock, nil, checker.NewHealthChecker(log, c, fakeClock))
+				conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
+				})
+				constraints := NewSeedConstraints(fakeClock, gardencorev1beta1.SeedStatus{})
+
+				_, updatedConstraints := healthCheck.Check(ctx, conditions, constraints)
+
+				Expect(updatedConstraints).To(ContainElements(
+					And(OfType(gardencorev1beta1.SeedManagedResourcesHonored), WithStatus(gardencorev1beta1.ConditionFalse), WithReason("ManagedResourcesIgnored"), WithMessageSubstrings("foo")),
 				))
 			})
 		})

--- a/pkg/gardenlet/controller/seed/care/health_test.go
+++ b/pkg/gardenlet/controller/seed/care/health_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Seed health", func() {
 		seed *gardencorev1beta1.Seed
 
 		seedSystemComponentsHealthyCondition gardencorev1beta1.Condition
-	seedConstraints                       SeedConstraints
+		seedConstraints                      SeedConstraints
 	)
 
 	BeforeEach(func() {
@@ -222,7 +222,7 @@ var _ = Describe("Seed health", func() {
 					prometheus.Labels = map[string]string{"health-check-by": "foo"}
 					Expect(c.Update(ctx, prometheus)).To(Succeed())
 					updatedConditions, _ := healthCheck.Check(ctx, conditions, seedConstraints)
-				expectHealthySystemComponents(updatedConditions)
+					expectHealthySystemComponents(updatedConditions)
 				})
 			})
 		})

--- a/pkg/gardenlet/controller/seed/care/reconciler.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler.go
@@ -60,9 +60,10 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 
 	// Initialize conditions based on the current status.
 	seedConditions := NewSeedConditions(r.Clock, seed.Status)
+	seedConstraints := NewSeedConstraints(r.Clock, seed.Status)
 
 	// Trigger health check
-	updatedConditions := NewHealthCheck(
+	updatedConditions, updatedConstraints := NewHealthCheck(
 		seed,
 		r.SeedClient,
 		r.Clock,
@@ -75,17 +76,24 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 	).Check(
 		ctx,
 		seedConditions,
+		seedConstraints,
 	)
 
-	// Update Seed status conditions if necessary
-	if v1beta1helper.ConditionsNeedUpdate(seedConditions.ConvertToSlice(), updatedConditions) {
-		// Rebuild seed conditions to ensure that only the conditions with the
-		// correct types will be updated, and any other conditions will remain intact
-		conditions := v1beta1helper.BuildConditions(seed.Status.Conditions, updatedConditions, seedConditions.ConditionTypes())
+	conditionsNeedUpdate := v1beta1helper.ConditionsNeedUpdate(seedConditions.ConvertToSlice(), updatedConditions)
+	constraintsNeedUpdate := v1beta1helper.ConditionsNeedUpdate(seedConstraints.ConvertToSlice(), updatedConstraints)
 
-		log.Info("Updating seed status conditions")
+	if conditionsNeedUpdate || constraintsNeedUpdate {
+		// Rebuild seed conditions/constraints to ensure that only the entries with the
+		// correct types will be updated, and any other entries will remain intact
 		patch := client.StrategicMergeFrom(seed.DeepCopy())
-		seed.Status.Conditions = conditions
+		if conditionsNeedUpdate {
+			seed.Status.Conditions = v1beta1helper.BuildConditions(seed.Status.Conditions, updatedConditions, seedConditions.ConditionTypes())
+		}
+		if constraintsNeedUpdate {
+			seed.Status.Constraints = v1beta1helper.BuildConditions(seed.Status.Constraints, updatedConstraints, seedConstraints.ConstraintTypes())
+		}
+
+		log.Info("Updating seed status conditions and constraints")
 		if err := r.GardenClient.Status().Patch(ctx, seed, patch); err != nil {
 			log.Error(err, "Could not update Seed status")
 			return reconcile.Result{}, err

--- a/pkg/gardenlet/controller/seed/care/reconciler.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler.go
@@ -23,6 +23,7 @@ import (
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health/checker"
 )
@@ -62,22 +63,29 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 	seedConditions := NewSeedConditions(r.Clock, seed.Status)
 	seedConstraints := NewSeedConstraints(r.Clock, seed.Status)
 
-	// Trigger health check
-	updatedConditions, updatedConstraints := NewHealthCheck(
-		seed,
-		r.SeedClient,
-		r.Clock,
-		r.Namespace,
-		checker.NewHealthChecker(
-			log,
-			r.SeedClient,
-			r.Clock,
-			checker.WithConditionThresholds(r.conditionThresholdsToProgressingMapping())),
-	).Check(
-		ctx,
-		seedConditions,
-		seedConstraints,
-	)
+	var updatedConditions, updatedConstraints []gardencorev1beta1.Condition
+	_ = flow.Parallel(
+		// Trigger health check
+		func(ctx context.Context) error {
+			updatedConditions = NewHealthCheck(
+				seed,
+				r.SeedClient,
+				r.Clock,
+				r.Namespace,
+				checker.NewHealthChecker(
+					log,
+					r.SeedClient,
+					r.Clock,
+					checker.WithConditionThresholds(r.conditionThresholdsToProgressingMapping())),
+			).Check(ctx, seedConditions)
+			return nil
+		},
+		// Trigger constraint check
+		func(ctx context.Context) error {
+			updatedConstraints = NewConstraintCheck(r.SeedClient, r.Clock, r.Namespace).Check(ctx, seedConstraints)
+			return nil
+		},
+	)(ctx)
 
 	conditionsNeedUpdate := v1beta1helper.ConditionsNeedUpdate(seedConditions.ConvertToSlice(), updatedConditions)
 	constraintsNeedUpdate := v1beta1helper.ConditionsNeedUpdate(seedConstraints.ConvertToSlice(), updatedConstraints)

--- a/pkg/gardenlet/controller/seed/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler_test.go
@@ -253,8 +253,8 @@ var _ = Describe("Seed Care Control", func() {
 
 type resultingConditionFunc func(conditions SeedConditions) []gardencorev1beta1.Condition
 
-func (c resultingConditionFunc) Check(_ context.Context, conditions SeedConditions, _ SeedConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
-	return c(conditions), nil
+func (c resultingConditionFunc) Check(_ context.Context, conditions SeedConditions) []gardencorev1beta1.Condition {
+	return c(conditions)
 }
 
 func healthCheckFunc(fn resultingConditionFunc) NewHealthCheckFunc {

--- a/pkg/gardenlet/controller/seed/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler_test.go
@@ -253,8 +253,8 @@ var _ = Describe("Seed Care Control", func() {
 
 type resultingConditionFunc func(conditions SeedConditions) []gardencorev1beta1.Condition
 
-func (c resultingConditionFunc) Check(_ context.Context, conditions SeedConditions) []gardencorev1beta1.Condition {
-	return c(conditions)
+func (c resultingConditionFunc) Check(_ context.Context, conditions SeedConditions, _ SeedConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
+	return c(conditions), nil
 }
 
 func healthCheckFunc(fn resultingConditionFunc) NewHealthCheckFunc {

--- a/pkg/gardenlet/controller/seed/care/types.go
+++ b/pkg/gardenlet/controller/seed/care/types.go
@@ -22,5 +22,21 @@ var defaultNewHealthCheck NewHealthCheckFunc = NewHealth
 
 // HealthCheck is an interface used to perform health checks.
 type HealthCheck interface {
-	Check(ctx context.Context, conditions SeedConditions, constraints SeedConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition)
+	Check(ctx context.Context, conditions SeedConditions) []gardencorev1beta1.Condition
 }
+
+// ConstraintCheck is an interface used to perform constraint checks.
+type ConstraintCheck interface {
+	Check(ctx context.Context, constraints SeedConstraints) []gardencorev1beta1.Condition
+}
+
+// NewConstraintCheckFunc is a function used to create a new instance for performing constraint checks.
+type NewConstraintCheckFunc func(client.Client, clock.Clock, *string) ConstraintCheck
+
+// defaultNewConstraintCheck is the default function to create a new instance for performing constraint checks.
+var defaultNewConstraintCheck NewConstraintCheckFunc = func(seedClient client.Client, clock clock.Clock, namespace *string) ConstraintCheck {
+	return NewConstraint(seedClient, clock, namespace)
+}
+
+// NewConstraintCheck is used to create a new Constraint check instance.
+var NewConstraintCheck = defaultNewConstraintCheck

--- a/pkg/gardenlet/controller/seed/care/types.go
+++ b/pkg/gardenlet/controller/seed/care/types.go
@@ -22,5 +22,5 @@ var defaultNewHealthCheck NewHealthCheckFunc = NewHealth
 
 // HealthCheck is an interface used to perform health checks.
 type HealthCheck interface {
-	Check(ctx context.Context, condition SeedConditions) []gardencorev1beta1.Condition
+	Check(ctx context.Context, conditions SeedConditions, constraints SeedConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition)
 }

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	kuberneteshealth "github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
 const (
@@ -57,7 +58,7 @@ func shootHibernatedConstraints(clock clock.Clock, conditions ...gardencorev1bet
 		// Optional constraint computed before the hibernation guard.
 		// Only preserve it if it's non-True (i.e. there are ignored MRs worth showing).
 		// When True, drop it — consistent with filterOptionalConstraints behaviour.
-		if cond.Type == gardencorev1beta1.ShootHasIgnoredManagedResources {
+		if cond.Type == gardencorev1beta1.ShootManagedResourcesHonored {
 			if cond.Status != gardencorev1beta1.ConditionTrue {
 				hibernationConditions = append(hibernationConditions, cond)
 			}
@@ -131,13 +132,15 @@ func (c *Constraint) constraintsChecks(
 ) []gardencorev1beta1.Condition {
 	// Check whether any ManagedResources in the shoot's control plane namespace have been annotated with
 	// resources.gardener.cloud/ignore=true, which disables their reconciliation.
-	status, reason, message, err := c.checkIfManagedResourcesAreIgnored(ctx)
-	if err != nil {
-		constraints.hasIgnoredManagedResources = v1beta1helper.UpdatedConditionUnknownErrorWithClock(c.clock, constraints.hasIgnoredManagedResources, err)
+	managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
+	if err := c.seedClient.List(ctx, managedResourceList, client.InNamespace(c.shoot.ControlPlaneNamespace)); err != nil {
+		constraints.managedResourcesHonored = v1beta1helper.UpdatedConditionUnknownErrorWithClock(c.clock, constraints.managedResourcesHonored,
+			fmt.Errorf("could not list ManagedResources in shoot namespace in seed to check for ignored resources: %w", err))
 	} else {
-		constraints.hasIgnoredManagedResources = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.hasIgnoredManagedResources, status, reason, message)
+		status, reason, message := kuberneteshealth.CheckManagedResourcesHonored(managedResourceList.Items)
+		constraints.managedResourcesHonored = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.managedResourcesHonored, status, reason, message)
 	}
-	status, reason, message, err = c.checkPreservation(ctx)
+	status, reason, message, err := c.checkPreservation(ctx)
 	if err != nil {
 		constraints.preservedFailedMachinesAbsent = v1beta1helper.UpdatedConditionUnknownErrorWithClock(c.clock, constraints.preservedFailedMachinesAbsent, err)
 	} else {
@@ -173,14 +176,14 @@ func (c *Constraint) constraintsChecks(
 
 		return filterOptionalConstraints(
 			[]gardencorev1beta1.Condition{constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied},
-			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.automaticCredentialsRotationPossible},
+			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.managedResourcesHonored, constraints.preservedFailedMachinesAbsent, constraints.automaticCredentialsRotationPossible},
 		)
 	}
 	if !apiServerRunning {
 		// don't check constraints if API server has already been deleted or has not been created yet
 		return filterOptionalConstraints(
 			shootControlPlaneNotRunningConstraints(c.clock, constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied),
-			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.automaticCredentialsRotationPossible},
+			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.managedResourcesHonored, constraints.preservedFailedMachinesAbsent, constraints.automaticCredentialsRotationPossible},
 		)
 	}
 	c.shootClient = shootClient.Client()
@@ -203,7 +206,7 @@ func (c *Constraint) constraintsChecks(
 
 	return filterOptionalConstraints(
 		[]gardencorev1beta1.Condition{constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied},
-		[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.crdsWithProblematicConversionWebhooks, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources, constraints.preservedFailedMachinesAbsent, constraints.automaticCredentialsRotationPossible},
+		[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.crdsWithProblematicConversionWebhooks, constraints.manualInPlaceWorkersUpdated, constraints.managedResourcesHonored, constraints.preservedFailedMachinesAbsent, constraints.automaticCredentialsRotationPossible},
 	)
 }
 
@@ -300,37 +303,6 @@ func (c *Constraint) checkIfManualInPlaceWorkersUpdated() (gardencorev1beta1.Con
 		"WorkerPoolsWithManualInPlaceUpdateStrategyPending",
 		fmt.Sprintf("Some worker pools in your Shoot with update strategy ManualInPlaceUpdate are pending update: %s",
 			strings.Join(c.shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate, ", "))
-}
-
-// checkIfManagedResourcesAreIgnored lists all ManagedResources in the shoot's control plane namespace and checks
-// whether any of them have the resources.gardener.cloud/ignore=true annotation set, which disables their reconciliation.
-func (c *Constraint) checkIfManagedResourcesAreIgnored(ctx context.Context) (gardencorev1beta1.ConditionStatus, string, string, error) {
-	managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
-	if err := c.seedClient.List(ctx, managedResourceList, client.InNamespace(c.shoot.ControlPlaneNamespace)); err != nil {
-		return "", "", "", fmt.Errorf("could not list ManagedResources in shoot namespace in seed to check for ignored resources: %w", err)
-	}
-
-	ignoredNames := sets.New[string]()
-	for _, mr := range managedResourceList.Items {
-		if value, ok := mr.GetAnnotations()[resourcesv1alpha1.Ignore]; ok {
-			if truthy, _ := strconv.ParseBool(value); truthy {
-				ignoredNames.Insert(mr.Name)
-			}
-		}
-	}
-
-	if ignoredNames.Len() > 0 {
-		return gardencorev1beta1.ConditionFalse,
-			"ManagedResourcesIgnored",
-			fmt.Sprintf("Some ManagedResources have been annotated with %s=true, meaning their reconciliation is disabled: %s",
-				resourcesv1alpha1.Ignore, strings.Join(sets.List(ignoredNames), ", ")),
-			nil
-	}
-
-	return gardencorev1beta1.ConditionTrue,
-		"NoManagedResourcesIgnored",
-		"No ManagedResources are annotated to be ignored.",
-		nil
 }
 
 // checkIfCRDsWithProblematicConversionWebhooksPresent checks whether there are CRDs with multiple stored versions and
@@ -572,7 +544,7 @@ type ShootConstraints struct {
 	crdsWithProblematicConversionWebhooks gardencorev1beta1.Condition
 	manualInPlaceWorkersUpdated           gardencorev1beta1.Condition
 	automaticCredentialsRotationPossible  gardencorev1beta1.Condition
-	hasIgnoredManagedResources            gardencorev1beta1.Condition
+	managedResourcesHonored               gardencorev1beta1.Condition
 	preservedFailedMachinesAbsent         gardencorev1beta1.Condition
 }
 
@@ -585,7 +557,7 @@ func (g ShootConstraints) ConvertToSlice() []gardencorev1beta1.Condition {
 		g.crdsWithProblematicConversionWebhooks,
 		g.manualInPlaceWorkersUpdated,
 		g.automaticCredentialsRotationPossible,
-		g.hasIgnoredManagedResources,
+		g.managedResourcesHonored,
 		g.preservedFailedMachinesAbsent,
 	}
 }
@@ -599,7 +571,7 @@ func (g ShootConstraints) ConstraintTypes() []gardencorev1beta1.ConditionType {
 		g.crdsWithProblematicConversionWebhooks.Type,
 		g.manualInPlaceWorkersUpdated.Type,
 		g.automaticCredentialsRotationPossible.Type,
-		g.hasIgnoredManagedResources.Type,
+		g.managedResourcesHonored.Type,
 		g.preservedFailedMachinesAbsent.Type,
 	}
 }
@@ -614,7 +586,7 @@ func NewShootConstraints(clock clock.Clock, shoot *gardencorev1beta1.Shoot) Shoo
 		crdsWithProblematicConversionWebhooks: v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks),
 		manualInPlaceWorkersUpdated:           v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
 		automaticCredentialsRotationPossible:  v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootAutomaticCredentialsRotationPossible),
-		hasIgnoredManagedResources:            v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootHasIgnoredManagedResources),
+		managedResourcesHonored:               v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootManagedResourcesHonored),
 		preservedFailedMachinesAbsent:         v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootPreservedFailedMachinesAbsent),
 	}
 }

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -31,9 +31,9 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/operation/botanist/matchers"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils"
+	kuberneteshealth "github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
-	kuberneteshealth "github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
 const (

--- a/pkg/gardenlet/controller/shoot/care/constraints_test.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints_test.go
@@ -519,7 +519,7 @@ var _ = Describe("Constraints", func() {
 							{Type: gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks},
 							{Type: gardencorev1beta1.ShootManualInPlaceWorkersUpdated},
 							{Type: gardencorev1beta1.ShootAutomaticCredentialsRotationPossible},
-							{Type: gardencorev1beta1.ShootHasIgnoredManagedResources},
+							{Type: gardencorev1beta1.ShootManagedResourcesHonored},
 							{Type: gardencorev1beta1.ShootPreservedFailedMachinesAbsent},
 						},
 					},
@@ -820,7 +820,7 @@ var _ = Describe("Constraints", func() {
 			Context("#HasIgnoredManagedResources", func() {
 				It("should remove the constraint when no ManagedResources exist", func() {
 					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
-						OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+						OfType(gardencorev1beta1.ShootManagedResourcesHonored),
 					))
 				})
 
@@ -837,7 +837,7 @@ var _ = Describe("Constraints", func() {
 					Expect(seedClient.Create(ctx, mr)).To(Succeed())
 
 					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
-						OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+						OfType(gardencorev1beta1.ShootManagedResourcesHonored),
 					))
 				})
 
@@ -856,7 +856,7 @@ var _ = Describe("Constraints", func() {
 					}
 
 					Expect(constraint.Check(ctx, constraints)).To(ContainCondition(
-						OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+						OfType(gardencorev1beta1.ShootManagedResourcesHonored),
 						WithStatus(gardencorev1beta1.ConditionProgressing),
 						WithReason("ManagedResourcesIgnored"),
 						WithMessageSubstrings("bar, baz, foo"),
@@ -888,14 +888,14 @@ var _ = Describe("Constraints", func() {
 						hibernatedShoot := &gardencorev1beta1.Shoot{
 							Status: gardencorev1beta1.ShootStatus{
 								Constraints: []gardencorev1beta1.Condition{
-									{Type: gardencorev1beta1.ShootHasIgnoredManagedResources, Status: gardencorev1beta1.ConditionTrue},
+									{Type: gardencorev1beta1.ShootManagedResourcesHonored, Status: gardencorev1beta1.ConditionTrue},
 								},
 							},
 						}
 						hibernatedConstraints := NewShootConstraints(testclock.NewFakeClock(time.Time{}), hibernatedShoot)
 
 						Expect(hibernatedConstraint.Check(ctx, hibernatedConstraints)).NotTo(ContainCondition(
-							OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+							OfType(gardencorev1beta1.ShootManagedResourcesHonored),
 						))
 					})
 
@@ -912,7 +912,7 @@ var _ = Describe("Constraints", func() {
 						Expect(seedClient.Create(ctx, mr)).To(Succeed())
 
 						Expect(hibernatedConstraint.Check(ctx, constraints)).To(ContainCondition(
-							OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+							OfType(gardencorev1beta1.ShootManagedResourcesHonored),
 							WithReason("ManagedResourcesIgnored"),
 							WithMessageSubstrings("foo"),
 						))
@@ -1101,7 +1101,7 @@ var _ = Describe("Constraints", func() {
 					OfType("CRDsWithProblematicConversionWebhooks"),
 					OfType("ManualInPlaceWorkersUpdated"),
 					OfType("AutomaticCredentialsRotationPossible"),
-					OfType("HasIgnoredManagedResources"),
+					OfType("ManagedResourcesHonored"),
 					OfType("PreservedFailedMachinesAbsent"),
 				))
 			})
@@ -1118,7 +1118,7 @@ var _ = Describe("Constraints", func() {
 					gardencorev1beta1.ConditionType("CRDsWithProblematicConversionWebhooks"),
 					gardencorev1beta1.ConditionType("ManualInPlaceWorkersUpdated"),
 					gardencorev1beta1.ConditionType("AutomaticCredentialsRotationPossible"),
-					gardencorev1beta1.ConditionType("HasIgnoredManagedResources"),
+					gardencorev1beta1.ConditionType("ManagedResourcesHonored"),
 					gardencorev1beta1.ConditionType("PreservedFailedMachinesAbsent"),
 				))
 			})

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -682,7 +682,7 @@ func containConstraintsInUnknownStatus(message string) types.GomegaMatcher {
 			WithStatus(gardencorev1beta1.ConditionUnknown),
 			WithMessage(message),
 		), ContainCondition(
-			OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+			OfType(gardencorev1beta1.ShootManagedResourcesHonored),
 			WithStatus(gardencorev1beta1.ConditionUnknown),
 			WithMessage(message),
 		), ContainCondition(

--- a/pkg/operator/controller/garden/care/health.go
+++ b/pkg/operator/controller/garden/care/health.go
@@ -61,14 +61,14 @@ func NewHealth(
 }
 
 // Check conducts the health checks on all the given conditions.
-func (h *health) Check(ctx context.Context, conditions GardenConditions, constraints GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
+func (h *health) Check(ctx context.Context, conditions GardenConditions) []gardencorev1beta1.Condition {
 	managedResources, err := h.listManagedResources(ctx)
 	if err != nil {
 		conditions.virtualGardenAPIServerAvailable = v1beta1helper.NewConditionOrError(h.clock, conditions.virtualGardenAPIServerAvailable, nil, err)
 		conditions.runtimeComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.runtimeComponentsHealthy, nil, err)
 		conditions.virtualComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.virtualComponentsHealthy, nil, err)
 		conditions.observabilityComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.observabilityComponentsHealthy, nil, err)
-		return conditions.ConvertToSlice(), constraints.ConvertToSlice()
+		return conditions.ConvertToSlice()
 	}
 
 	taskFns := []flow.TaskFn{
@@ -101,10 +101,7 @@ func (h *health) Check(ctx context.Context, conditions GardenConditions, constra
 
 	_ = flow.Parallel(taskFns...)(ctx)
 
-	status, reason, message := kuberneteshealth.CheckManagedResourcesHonored(managedResources)
-	constraints.managedResourcesHonored = v1beta1helper.UpdatedConditionWithClock(h.clock, constraints.managedResourcesHonored, status, reason, message)
-
-	return conditions.ConvertToSlice(), constraints.ConvertToSlice()
+	return conditions.ConvertToSlice()
 }
 
 func (h *health) listManagedResources(ctx context.Context) ([]resourcesv1alpha1.ManagedResource, error) {
@@ -258,4 +255,60 @@ func NewGardenConstraints(clock clock.Clock, status operatorv1alpha1.GardenStatu
 	return GardenConstraints{
 		managedResourcesHonored: v1beta1helper.GetOrInitConditionWithClock(clock, status.Constraints, operatorv1alpha1.GardenManagedResourcesHonored),
 	}
+}
+
+// constraint contains information needed to execute constraint checks for a garden.
+type constraint struct {
+	runtimeClient   client.Client
+	clock           clock.Clock
+	gardenNamespace string
+}
+
+// NewConstraint returns a new constraint instance.
+func NewConstraint(runtimeClient client.Client, clock clock.Clock, gardenNamespace string) ConstraintCheck {
+	return &constraint{
+		runtimeClient:   runtimeClient,
+		clock:           clock,
+		gardenNamespace: gardenNamespace,
+	}
+}
+
+// Check executes all constraint checks for the garden.
+func (c *constraint) Check(ctx context.Context, constraints GardenConstraints) []gardencorev1beta1.Condition {
+	managedResources, err := c.listManagedResources(ctx)
+	if err != nil {
+		constraints.managedResourcesHonored = v1beta1helper.UpdatedConditionUnknownErrorWithClock(c.clock, constraints.managedResourcesHonored,
+			fmt.Errorf("could not list ManagedResources to check for ignored resources: %w", err))
+		return filterOptionalGardenConstraints(constraints)
+	}
+
+	status, reason, message := kuberneteshealth.CheckManagedResourcesHonored(managedResources)
+	constraints.managedResourcesHonored = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.managedResourcesHonored, status, reason, message)
+
+	return filterOptionalGardenConstraints(constraints)
+}
+
+func (c *constraint) listManagedResources(ctx context.Context) ([]resourcesv1alpha1.ManagedResource, error) {
+	managedResourceListGarden := &resourcesv1alpha1.ManagedResourceList{}
+	if err := c.runtimeClient.List(ctx, managedResourceListGarden, client.InNamespace(c.gardenNamespace)); err != nil {
+		return nil, fmt.Errorf("failed listing ManagedResources in namespace %s: %w", c.gardenNamespace, err)
+	}
+
+	managedResourceListIstioSystem := &resourcesv1alpha1.ManagedResourceList{}
+	if err := c.runtimeClient.List(ctx, managedResourceListIstioSystem, client.InNamespace(v1beta1constants.IstioSystemNamespace)); err != nil {
+		return nil, fmt.Errorf("failed listing ManagedResources in namespace %s: %w", v1beta1constants.IstioSystemNamespace, err)
+	}
+
+	return append(managedResourceListGarden.Items, managedResourceListIstioSystem.Items...), nil
+}
+
+// filterOptionalGardenConstraints omits constraints that are True — they add no signal for operators.
+func filterOptionalGardenConstraints(constraints GardenConstraints) []gardencorev1beta1.Condition {
+	var out []gardencorev1beta1.Condition
+	for _, c := range constraints.ConvertToSlice() {
+		if c.Status != gardencorev1beta1.ConditionTrue {
+			out = append(out, c)
+		}
+	}
+	return out
 }

--- a/pkg/operator/controller/garden/care/health.go
+++ b/pkg/operator/controller/garden/care/health.go
@@ -61,14 +61,14 @@ func NewHealth(
 }
 
 // Check conducts the health checks on all the given conditions.
-func (h *health) Check(ctx context.Context, conditions GardenConditions) []gardencorev1beta1.Condition {
+func (h *health) Check(ctx context.Context, conditions GardenConditions, constraints GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
 	managedResources, err := h.listManagedResources(ctx)
 	if err != nil {
 		conditions.virtualGardenAPIServerAvailable = v1beta1helper.NewConditionOrError(h.clock, conditions.virtualGardenAPIServerAvailable, nil, err)
 		conditions.runtimeComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.runtimeComponentsHealthy, nil, err)
 		conditions.virtualComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.virtualComponentsHealthy, nil, err)
 		conditions.observabilityComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.observabilityComponentsHealthy, nil, err)
-		return conditions.ConvertToSlice()
+		return conditions.ConvertToSlice(), constraints.ConvertToSlice()
 	}
 
 	taskFns := []flow.TaskFn{
@@ -101,7 +101,10 @@ func (h *health) Check(ctx context.Context, conditions GardenConditions) []garde
 
 	_ = flow.Parallel(taskFns...)(ctx)
 
-	return conditions.ConvertToSlice()
+	status, reason, message := kuberneteshealth.CheckManagedResourcesHonored(managedResources)
+	constraints.managedResourcesHonored = v1beta1helper.UpdatedConditionWithClock(h.clock, constraints.managedResourcesHonored, status, reason, message)
+
+	return conditions.ConvertToSlice(), constraints.ConvertToSlice()
 }
 
 func (h *health) listManagedResources(ctx context.Context) ([]resourcesv1alpha1.ManagedResource, error) {
@@ -227,5 +230,32 @@ func NewGardenConditions(clock clock.Clock, status operatorv1alpha1.GardenStatus
 		runtimeComponentsHealthy:        v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.RuntimeComponentsHealthy),
 		virtualComponentsHealthy:        v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.VirtualComponentsHealthy),
 		observabilityComponentsHealthy:  v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.ObservabilityComponentsHealthy),
+	}
+}
+
+// GardenConstraints contains all constraints of the garden status subresource.
+type GardenConstraints struct {
+	managedResourcesHonored gardencorev1beta1.Condition
+}
+
+// ConvertToSlice returns the garden constraints as a slice.
+func (g GardenConstraints) ConvertToSlice() []gardencorev1beta1.Condition {
+	return []gardencorev1beta1.Condition{
+		g.managedResourcesHonored,
+	}
+}
+
+// ConstraintTypes returns all garden constraint types.
+func (g GardenConstraints) ConstraintTypes() []gardencorev1beta1.ConditionType {
+	return []gardencorev1beta1.ConditionType{
+		g.managedResourcesHonored.Type,
+	}
+}
+
+// NewGardenConstraints returns a new instance of GardenConstraints.
+// All constraints are retrieved from the given 'status' or newly initialized.
+func NewGardenConstraints(clock clock.Clock, status operatorv1alpha1.GardenStatus) GardenConstraints {
+	return GardenConstraints{
+		managedResourcesHonored: v1beta1helper.GetOrInitConditionWithClock(clock, status.Constraints, operatorv1alpha1.GardenManagedResourcesHonored),
 	}
 }

--- a/pkg/operator/controller/garden/care/health_test.go
+++ b/pkg/operator/controller/garden/care/health_test.go
@@ -58,9 +58,9 @@ var _ = Describe("Garden health", func() {
 		gardenClientSet kubernetes.Interface
 		fakeClock       *testclock.FakeClock
 
-		garden           *operatorv1alpha1.Garden
-		gardenNamespace  string
-		gardenConditions GardenConditions
+		garden            *operatorv1alpha1.Garden
+		gardenNamespace   string
+		gardenConditions  GardenConditions
 		gardenConstraints GardenConstraints
 
 		apiserverAvailabilityCondition          gardencorev1beta1.Condition

--- a/pkg/operator/controller/garden/care/health_test.go
+++ b/pkg/operator/controller/garden/care/health_test.go
@@ -58,10 +58,9 @@ var _ = Describe("Garden health", func() {
 		gardenClientSet kubernetes.Interface
 		fakeClock       *testclock.FakeClock
 
-		garden            *operatorv1alpha1.Garden
-		gardenNamespace   string
-		gardenConditions  GardenConditions
-		gardenConstraints GardenConstraints
+		garden           *operatorv1alpha1.Garden
+		gardenNamespace  string
+		gardenConditions GardenConditions
 
 		apiserverAvailabilityCondition          gardencorev1beta1.Condition
 		runtimeComponentsHealthyCondition       gardencorev1beta1.Condition
@@ -111,7 +110,6 @@ var _ = Describe("Garden health", func() {
 		}
 
 		gardenConditions = NewGardenConditions(fakeClock, garden.Status)
-		gardenConstraints = NewGardenConstraints(fakeClock, garden.Status)
 	})
 
 	Describe("#Check", func() {
@@ -130,7 +128,7 @@ var _ = Describe("Garden health", func() {
 			})
 
 			It("should set RuntimeComponentsHealthy and VirtualComponentsHealthy conditions to true", func() {
-				updatedConditions, _ := NewHealth(
+				updatedConditions := NewHealth(
 					garden,
 					runtimeClient,
 					gardenClientSet,
@@ -138,7 +136,7 @@ var _ = Describe("Garden health", func() {
 					nil,
 					gardenNamespace,
 					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-				).Check(ctx, gardenConditions, gardenConstraints)
+				).Check(ctx, gardenConditions)
 
 				Expect(updatedConditions).ToNot(BeEmpty())
 				Expect(updatedConditions).To(ContainElements(
@@ -153,7 +151,7 @@ var _ = Describe("Garden health", func() {
 			var (
 				tests = func(reason, message string) {
 					It("should set RuntimeComponentsHealthy and VirtualComponentsHealthy conditions to False if there is no Progressing threshold duration mapping", func() {
-						updatedConditions, _ := NewHealth(
+						updatedConditions := NewHealth(
 							garden,
 							runtimeClient,
 							gardenClientSet,
@@ -161,7 +159,7 @@ var _ = Describe("Garden health", func() {
 							nil,
 							gardenNamespace,
 							healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-						).Check(ctx, gardenConditions, gardenConstraints)
+						).Check(ctx, gardenConditions)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions).To(ContainElements(
@@ -183,7 +181,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							}
-							updatedConditions, _ := NewHealth(
+							updatedConditions := NewHealth(
 								garden,
 								runtimeClient,
 								gardenClientSet,
@@ -196,7 +194,7 @@ var _ = Describe("Garden health", func() {
 									fakeClock,
 									healthchecker.WithConditionThresholds(conditionThresholds),
 									healthchecker.WithLastOperation(garden.Status.LastOperation)),
-							).Check(ctx, gardenConditions, gardenConstraints)
+							).Check(ctx, gardenConditions)
 
 							Expect(updatedConditions).ToNot(BeEmpty())
 							Expect(updatedConditions).To(ContainElements(
@@ -219,7 +217,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							}
-							updatedConditions, _ := NewHealth(
+							updatedConditions := NewHealth(
 								garden,
 								runtimeClient,
 								gardenClientSet,
@@ -232,7 +230,7 @@ var _ = Describe("Garden health", func() {
 									fakeClock,
 									healthchecker.WithConditionThresholds(conditionThresholds),
 									healthchecker.WithLastOperation(garden.Status.LastOperation)),
-							).Check(ctx, gardenConditions, gardenConstraints)
+							).Check(ctx, gardenConditions)
 
 							Expect(updatedConditions).ToNot(BeEmpty())
 							Expect(updatedConditions).To(ContainElements(
@@ -255,7 +253,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							}
-							updatedConditions, _ := NewHealth(
+							updatedConditions := NewHealth(
 								garden,
 								runtimeClient,
 								gardenClientSet,
@@ -268,7 +266,7 @@ var _ = Describe("Garden health", func() {
 									fakeClock,
 									healthchecker.WithConditionThresholds(conditionThresholds),
 									healthchecker.WithLastOperation(garden.Status.LastOperation)),
-							).Check(ctx, gardenConditions, gardenConstraints)
+							).Check(ctx, gardenConditions)
 
 							Expect(updatedConditions).ToNot(BeEmpty())
 							Expect(updatedConditions).To(ContainElements(
@@ -284,7 +282,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							}
-							updatedConditions, _ := NewHealth(
+							updatedConditions := NewHealth(
 								garden,
 								runtimeClient,
 								gardenClientSet,
@@ -297,7 +295,7 @@ var _ = Describe("Garden health", func() {
 									fakeClock,
 									healthchecker.WithConditionThresholds(conditionThresholds),
 									healthchecker.WithLastOperation(garden.Status.LastOperation)),
-							).Check(ctx, gardenConditions, gardenConstraints)
+							).Check(ctx, gardenConditions)
 
 							Expect(updatedConditions).ToNot(BeEmpty())
 							Expect(updatedConditions).To(ContainElements(
@@ -385,7 +383,7 @@ var _ = Describe("Garden health", func() {
 						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
 					}
 
-					updatedConditions, _ := NewHealth(
+					updatedConditions := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -393,7 +391,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions, gardenConstraints)
+					).Check(ctx, gardenConditions)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainElements(
@@ -413,7 +411,7 @@ var _ = Describe("Garden health", func() {
 						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, false))).To(Succeed())
 					}
 
-					updatedConditions, _ := NewHealth(
+					updatedConditions := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -421,7 +419,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions, gardenConstraints)
+					).Check(ctx, gardenConditions)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainElements(
@@ -438,7 +436,7 @@ var _ = Describe("Garden health", func() {
 				})
 
 				It("should set VirtualComponentsHealthy conditions to false when the ETCDs are missing", func() {
-					updatedConditions, _ := NewHealth(
+					updatedConditions := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -446,7 +444,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions, gardenConstraints)
+					).Check(ctx, gardenConditions)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainElements(
@@ -463,7 +461,7 @@ var _ = Describe("Garden health", func() {
 						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, false))).To(Succeed())
 					}
 
-					updatedConditions, _ := NewHealth(
+					updatedConditions := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -471,7 +469,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions, gardenConstraints)
+					).Check(ctx, gardenConditions)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainElements(
@@ -488,7 +486,7 @@ var _ = Describe("Garden health", func() {
 				It("should set ObservabilityComponentsHealthy conditions to false when ManagedResources are unhealthy", func() {
 					Expect(runtimeClient.Create(ctx, unhealthyManagedResource("baz", "ObservabilityComponentsHealthy"))).To(Succeed())
 
-					updatedConditions, _ := NewHealth(
+					updatedConditions := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -496,7 +494,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions, gardenConstraints)
+					).Check(ctx, gardenConditions)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainCondition(OfType(operatorv1alpha1.ObservabilityComponentsHealthy), WithReason("NotHealthy")))
@@ -505,7 +503,7 @@ var _ = Describe("Garden health", func() {
 				It("should set ObservabilityComponentsHealthy conditions to false when ManagedResources are not applied", func() {
 					Expect(runtimeClient.Create(ctx, unappliedManagedResource("baz", "ObservabilityComponentsHealthy"))).To(Succeed())
 
-					updatedConditions, _ := NewHealth(
+					updatedConditions := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -513,7 +511,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions, gardenConstraints)
+					).Check(ctx, gardenConditions)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainCondition(OfType(operatorv1alpha1.ObservabilityComponentsHealthy), WithReason("NotApplied")))
@@ -522,7 +520,7 @@ var _ = Describe("Garden health", func() {
 				It("should set ObservabilityComponentsHealthy conditions to false when ManagedResources are progressing", func() {
 					Expect(runtimeClient.Create(ctx, progressingManagedResource("baz", "ObservabilityComponentsHealthy"))).To(Succeed())
 
-					updatedConditions, _ := NewHealth(
+					updatedConditions := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -530,7 +528,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions, gardenConstraints)
+					).Check(ctx, gardenConditions)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainCondition(OfType(operatorv1alpha1.ObservabilityComponentsHealthy), WithReason("ResourcesProgressing")))
@@ -542,7 +540,7 @@ var _ = Describe("Garden health", func() {
 						Status: gardencorev1beta1.ConditionTrue}},
 					))).To(Succeed())
 
-					updatedConditions, _ := NewHealth(
+					updatedConditions := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -550,7 +548,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions, gardenConstraints)
+					).Check(ctx, gardenConditions)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainCondition(OfType(operatorv1alpha1.ObservabilityComponentsHealthy), WithReason("MissingManagedResourceCondition")))
@@ -588,7 +586,7 @@ var _ = Describe("Garden health", func() {
 			})
 
 			It("should set ObservabilityComponentsHealthy condition to false if Prometheus health check is down", func() {
-				updatedConditions, _ := NewHealth(
+				updatedConditions := NewHealth(
 					garden,
 					runtimeClient,
 					gardenClientSet,
@@ -596,7 +594,7 @@ var _ = Describe("Garden health", func() {
 					nil,
 					gardenNamespace,
 					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithPrometheusHealthChecker(unhealthy)),
-				).Check(ctx, gardenConditions, gardenConstraints)
+				).Check(ctx, gardenConditions)
 
 				Expect(updatedConditions).To(ContainElements(
 					beConditionOfTypeWithStatusReasonAndMessage(
@@ -607,7 +605,7 @@ var _ = Describe("Garden health", func() {
 			})
 
 			It("should set ObservabilityComponentsHealthy condition to false if Prometheus health check is erroring", func() {
-				updatedConditions, _ := NewHealth(
+				updatedConditions := NewHealth(
 					garden,
 					runtimeClient,
 					gardenClientSet,
@@ -615,7 +613,7 @@ var _ = Describe("Garden health", func() {
 					nil,
 					gardenNamespace,
 					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithPrometheusHealthChecker(erroring)),
-				).Check(ctx, gardenConditions, gardenConstraints)
+				).Check(ctx, gardenConditions)
 
 				Expect(updatedConditions).To(ContainElements(
 					beConditionOfTypeWithStatusReasonAndMessage(
@@ -626,7 +624,7 @@ var _ = Describe("Garden health", func() {
 			})
 
 			It("should set ObservabilityComponentsHealthy condition to true if Prometheus is healthy", func() {
-				updatedConditions, _ := NewHealth(
+				updatedConditions := NewHealth(
 					garden,
 					runtimeClient,
 					gardenClientSet,
@@ -634,7 +632,7 @@ var _ = Describe("Garden health", func() {
 					nil,
 					gardenNamespace,
 					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithPrometheusHealthChecker(healthy)),
-				).Check(ctx, gardenConditions, gardenConstraints)
+				).Check(ctx, gardenConditions)
 
 				expectHealthyObservabilityComponents(updatedConditions)
 			})
@@ -642,7 +640,7 @@ var _ = Describe("Garden health", func() {
 			It("should set ObservabilityComponentsHealthy condition to true if Prometheus health check is down but the PrometheusHealthChecks feature gate is disabled", func() {
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.PrometheusHealthChecks, false))
 
-				updatedConditions, _ := NewHealth(
+				updatedConditions := NewHealth(
 					garden,
 					runtimeClient,
 					gardenClientSet,
@@ -650,7 +648,7 @@ var _ = Describe("Garden health", func() {
 					nil,
 					gardenNamespace,
 					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithPrometheusHealthChecker(unhealthy)),
-				).Check(ctx, gardenConditions, gardenConstraints)
+				).Check(ctx, gardenConditions)
 
 				expectHealthyObservabilityComponents(updatedConditions)
 			})
@@ -665,7 +663,7 @@ var _ = Describe("Garden health", func() {
 				// is set to healthy if the Prometheus resource is filtered out.
 				BeforeEach(func() {
 					healthChecker = healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithPrometheusHealthChecker(unhealthy))
-					conditions, _ = NewHealth(
+					conditions = NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -673,7 +671,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthChecker,
-					).Check(ctx, gardenConditions, gardenConstraints)
+					).Check(ctx, gardenConditions)
 
 					Expect(conditions).To(ContainElements(
 						beConditionOfTypeWithStatusReasonAndMessage(
@@ -687,7 +685,7 @@ var _ = Describe("Garden health", func() {
 					prometheus.Labels = map[string]string{"health-check-by": "foo"}
 					Expect(runtimeClient.Update(ctx, prometheus)).To(Succeed())
 
-					conditions, _ = NewHealth(
+					conditions = NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -695,7 +693,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthChecker,
-					).Check(ctx, gardenConditions, gardenConstraints)
+					).Check(ctx, gardenConditions)
 
 					expectHealthyObservabilityComponents(conditions)
 				})
@@ -814,22 +812,13 @@ var _ = Describe("Garden health", func() {
 				}
 			})
 
-			It("should set ManagedResourcesHonored to True if no ManagedResources are ignored", func() {
+			It("should not include ManagedResourcesHonored constraint when no ManagedResources are ignored", func() {
 				Expect(runtimeClient.Create(ctx, healthyManagedResource("foo", "RuntimeComponentsHealthy"))).To(Succeed())
 
-				_, updatedConstraints := NewHealth(
-					garden,
-					runtimeClient,
-					gardenClientSet,
-					fakeClock,
-					nil,
-					gardenNamespace,
-					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-				).Check(ctx, gardenConditions, gardenConstraints)
+				constraints := NewGardenConstraints(fakeClock, garden.Status)
+				updatedConstraints := NewConstraint(runtimeClient, fakeClock, gardenNamespace).Check(ctx, constraints)
 
-				Expect(updatedConstraints).To(ContainElements(
-					beConditionOfTypeWithStatusReasonAndMessage(operatorv1alpha1.GardenManagedResourcesHonored, gardencorev1beta1.ConditionTrue, "AllManagedResourcesActive", "No ManagedResources are annotated to be ignored."),
-				))
+				Expect(updatedConstraints).NotTo(ContainCondition(OfType(operatorv1alpha1.GardenManagedResourcesHonored)))
 			})
 
 			It("should set ManagedResourcesHonored to False if a ManagedResource is ignored", func() {
@@ -837,15 +826,8 @@ var _ = Describe("Garden health", func() {
 				mr.Annotations = map[string]string{"resources.gardener.cloud/ignore": "true"}
 				Expect(runtimeClient.Create(ctx, mr)).To(Succeed())
 
-				_, updatedConstraints := NewHealth(
-					garden,
-					runtimeClient,
-					gardenClientSet,
-					fakeClock,
-					nil,
-					gardenNamespace,
-					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-				).Check(ctx, gardenConditions, gardenConstraints)
+				constraints := NewGardenConstraints(fakeClock, garden.Status)
+				updatedConstraints := NewConstraint(runtimeClient, fakeClock, gardenNamespace).Check(ctx, constraints)
 
 				Expect(updatedConstraints).To(ContainElements(
 					And(OfType(operatorv1alpha1.GardenManagedResourcesHonored), WithStatus(gardencorev1beta1.ConditionFalse), WithReason("ManagedResourcesIgnored"), WithMessageSubstrings("foo")),

--- a/pkg/operator/controller/garden/care/health_test.go
+++ b/pkg/operator/controller/garden/care/health_test.go
@@ -61,6 +61,7 @@ var _ = Describe("Garden health", func() {
 		garden           *operatorv1alpha1.Garden
 		gardenNamespace  string
 		gardenConditions GardenConditions
+		gardenConstraints GardenConstraints
 
 		apiserverAvailabilityCondition          gardencorev1beta1.Condition
 		runtimeComponentsHealthyCondition       gardencorev1beta1.Condition
@@ -110,6 +111,7 @@ var _ = Describe("Garden health", func() {
 		}
 
 		gardenConditions = NewGardenConditions(fakeClock, garden.Status)
+		gardenConstraints = NewGardenConstraints(fakeClock, garden.Status)
 	})
 
 	Describe("#Check", func() {
@@ -128,7 +130,7 @@ var _ = Describe("Garden health", func() {
 			})
 
 			It("should set RuntimeComponentsHealthy and VirtualComponentsHealthy conditions to true", func() {
-				updatedConditions := NewHealth(
+				updatedConditions, _ := NewHealth(
 					garden,
 					runtimeClient,
 					gardenClientSet,
@@ -136,7 +138,7 @@ var _ = Describe("Garden health", func() {
 					nil,
 					gardenNamespace,
 					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-				).Check(ctx, gardenConditions)
+				).Check(ctx, gardenConditions, gardenConstraints)
 
 				Expect(updatedConditions).ToNot(BeEmpty())
 				Expect(updatedConditions).To(ContainElements(
@@ -151,7 +153,7 @@ var _ = Describe("Garden health", func() {
 			var (
 				tests = func(reason, message string) {
 					It("should set RuntimeComponentsHealthy and VirtualComponentsHealthy conditions to False if there is no Progressing threshold duration mapping", func() {
-						updatedConditions := NewHealth(
+						updatedConditions, _ := NewHealth(
 							garden,
 							runtimeClient,
 							gardenClientSet,
@@ -159,7 +161,7 @@ var _ = Describe("Garden health", func() {
 							nil,
 							gardenNamespace,
 							healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-						).Check(ctx, gardenConditions)
+						).Check(ctx, gardenConditions, gardenConstraints)
 
 						Expect(updatedConditions).ToNot(BeEmpty())
 						Expect(updatedConditions).To(ContainElements(
@@ -181,7 +183,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							}
-							updatedConditions := NewHealth(
+							updatedConditions, _ := NewHealth(
 								garden,
 								runtimeClient,
 								gardenClientSet,
@@ -194,7 +196,7 @@ var _ = Describe("Garden health", func() {
 									fakeClock,
 									healthchecker.WithConditionThresholds(conditionThresholds),
 									healthchecker.WithLastOperation(garden.Status.LastOperation)),
-							).Check(ctx, gardenConditions)
+							).Check(ctx, gardenConditions, gardenConstraints)
 
 							Expect(updatedConditions).ToNot(BeEmpty())
 							Expect(updatedConditions).To(ContainElements(
@@ -217,7 +219,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							}
-							updatedConditions := NewHealth(
+							updatedConditions, _ := NewHealth(
 								garden,
 								runtimeClient,
 								gardenClientSet,
@@ -230,7 +232,7 @@ var _ = Describe("Garden health", func() {
 									fakeClock,
 									healthchecker.WithConditionThresholds(conditionThresholds),
 									healthchecker.WithLastOperation(garden.Status.LastOperation)),
-							).Check(ctx, gardenConditions)
+							).Check(ctx, gardenConditions, gardenConstraints)
 
 							Expect(updatedConditions).ToNot(BeEmpty())
 							Expect(updatedConditions).To(ContainElements(
@@ -253,7 +255,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							}
-							updatedConditions := NewHealth(
+							updatedConditions, _ := NewHealth(
 								garden,
 								runtimeClient,
 								gardenClientSet,
@@ -266,7 +268,7 @@ var _ = Describe("Garden health", func() {
 									fakeClock,
 									healthchecker.WithConditionThresholds(conditionThresholds),
 									healthchecker.WithLastOperation(garden.Status.LastOperation)),
-							).Check(ctx, gardenConditions)
+							).Check(ctx, gardenConditions, gardenConstraints)
 
 							Expect(updatedConditions).ToNot(BeEmpty())
 							Expect(updatedConditions).To(ContainElements(
@@ -282,7 +284,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							}
-							updatedConditions := NewHealth(
+							updatedConditions, _ := NewHealth(
 								garden,
 								runtimeClient,
 								gardenClientSet,
@@ -295,7 +297,7 @@ var _ = Describe("Garden health", func() {
 									fakeClock,
 									healthchecker.WithConditionThresholds(conditionThresholds),
 									healthchecker.WithLastOperation(garden.Status.LastOperation)),
-							).Check(ctx, gardenConditions)
+							).Check(ctx, gardenConditions, gardenConstraints)
 
 							Expect(updatedConditions).ToNot(BeEmpty())
 							Expect(updatedConditions).To(ContainElements(
@@ -383,7 +385,7 @@ var _ = Describe("Garden health", func() {
 						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
 					}
 
-					updatedConditions := NewHealth(
+					updatedConditions, _ := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -391,7 +393,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions)
+					).Check(ctx, gardenConditions, gardenConstraints)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainElements(
@@ -411,7 +413,7 @@ var _ = Describe("Garden health", func() {
 						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, false))).To(Succeed())
 					}
 
-					updatedConditions := NewHealth(
+					updatedConditions, _ := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -419,7 +421,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions)
+					).Check(ctx, gardenConditions, gardenConstraints)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainElements(
@@ -436,7 +438,7 @@ var _ = Describe("Garden health", func() {
 				})
 
 				It("should set VirtualComponentsHealthy conditions to false when the ETCDs are missing", func() {
-					updatedConditions := NewHealth(
+					updatedConditions, _ := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -444,7 +446,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions)
+					).Check(ctx, gardenConditions, gardenConstraints)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainElements(
@@ -461,7 +463,7 @@ var _ = Describe("Garden health", func() {
 						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, false))).To(Succeed())
 					}
 
-					updatedConditions := NewHealth(
+					updatedConditions, _ := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -469,7 +471,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions)
+					).Check(ctx, gardenConditions, gardenConstraints)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainElements(
@@ -486,7 +488,7 @@ var _ = Describe("Garden health", func() {
 				It("should set ObservabilityComponentsHealthy conditions to false when ManagedResources are unhealthy", func() {
 					Expect(runtimeClient.Create(ctx, unhealthyManagedResource("baz", "ObservabilityComponentsHealthy"))).To(Succeed())
 
-					updatedConditions := NewHealth(
+					updatedConditions, _ := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -494,7 +496,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions)
+					).Check(ctx, gardenConditions, gardenConstraints)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainCondition(OfType(operatorv1alpha1.ObservabilityComponentsHealthy), WithReason("NotHealthy")))
@@ -503,7 +505,7 @@ var _ = Describe("Garden health", func() {
 				It("should set ObservabilityComponentsHealthy conditions to false when ManagedResources are not applied", func() {
 					Expect(runtimeClient.Create(ctx, unappliedManagedResource("baz", "ObservabilityComponentsHealthy"))).To(Succeed())
 
-					updatedConditions := NewHealth(
+					updatedConditions, _ := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -511,7 +513,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions)
+					).Check(ctx, gardenConditions, gardenConstraints)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainCondition(OfType(operatorv1alpha1.ObservabilityComponentsHealthy), WithReason("NotApplied")))
@@ -520,7 +522,7 @@ var _ = Describe("Garden health", func() {
 				It("should set ObservabilityComponentsHealthy conditions to false when ManagedResources are progressing", func() {
 					Expect(runtimeClient.Create(ctx, progressingManagedResource("baz", "ObservabilityComponentsHealthy"))).To(Succeed())
 
-					updatedConditions := NewHealth(
+					updatedConditions, _ := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -528,7 +530,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions)
+					).Check(ctx, gardenConditions, gardenConstraints)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainCondition(OfType(operatorv1alpha1.ObservabilityComponentsHealthy), WithReason("ResourcesProgressing")))
@@ -540,7 +542,7 @@ var _ = Describe("Garden health", func() {
 						Status: gardencorev1beta1.ConditionTrue}},
 					))).To(Succeed())
 
-					updatedConditions := NewHealth(
+					updatedConditions, _ := NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -548,7 +550,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
-					).Check(ctx, gardenConditions)
+					).Check(ctx, gardenConditions, gardenConstraints)
 
 					Expect(updatedConditions).ToNot(BeEmpty())
 					Expect(updatedConditions).To(ContainCondition(OfType(operatorv1alpha1.ObservabilityComponentsHealthy), WithReason("MissingManagedResourceCondition")))
@@ -586,7 +588,7 @@ var _ = Describe("Garden health", func() {
 			})
 
 			It("should set ObservabilityComponentsHealthy condition to false if Prometheus health check is down", func() {
-				updatedConditions := NewHealth(
+				updatedConditions, _ := NewHealth(
 					garden,
 					runtimeClient,
 					gardenClientSet,
@@ -594,7 +596,7 @@ var _ = Describe("Garden health", func() {
 					nil,
 					gardenNamespace,
 					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithPrometheusHealthChecker(unhealthy)),
-				).Check(ctx, gardenConditions)
+				).Check(ctx, gardenConditions, gardenConstraints)
 
 				Expect(updatedConditions).To(ContainElements(
 					beConditionOfTypeWithStatusReasonAndMessage(
@@ -605,7 +607,7 @@ var _ = Describe("Garden health", func() {
 			})
 
 			It("should set ObservabilityComponentsHealthy condition to false if Prometheus health check is erroring", func() {
-				updatedConditions := NewHealth(
+				updatedConditions, _ := NewHealth(
 					garden,
 					runtimeClient,
 					gardenClientSet,
@@ -613,7 +615,7 @@ var _ = Describe("Garden health", func() {
 					nil,
 					gardenNamespace,
 					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithPrometheusHealthChecker(erroring)),
-				).Check(ctx, gardenConditions)
+				).Check(ctx, gardenConditions, gardenConstraints)
 
 				Expect(updatedConditions).To(ContainElements(
 					beConditionOfTypeWithStatusReasonAndMessage(
@@ -624,7 +626,7 @@ var _ = Describe("Garden health", func() {
 			})
 
 			It("should set ObservabilityComponentsHealthy condition to true if Prometheus is healthy", func() {
-				updatedConditions := NewHealth(
+				updatedConditions, _ := NewHealth(
 					garden,
 					runtimeClient,
 					gardenClientSet,
@@ -632,7 +634,7 @@ var _ = Describe("Garden health", func() {
 					nil,
 					gardenNamespace,
 					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithPrometheusHealthChecker(healthy)),
-				).Check(ctx, gardenConditions)
+				).Check(ctx, gardenConditions, gardenConstraints)
 
 				expectHealthyObservabilityComponents(updatedConditions)
 			})
@@ -640,7 +642,7 @@ var _ = Describe("Garden health", func() {
 			It("should set ObservabilityComponentsHealthy condition to true if Prometheus health check is down but the PrometheusHealthChecks feature gate is disabled", func() {
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.PrometheusHealthChecks, false))
 
-				updatedConditions := NewHealth(
+				updatedConditions, _ := NewHealth(
 					garden,
 					runtimeClient,
 					gardenClientSet,
@@ -648,7 +650,7 @@ var _ = Describe("Garden health", func() {
 					nil,
 					gardenNamespace,
 					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithPrometheusHealthChecker(unhealthy)),
-				).Check(ctx, gardenConditions)
+				).Check(ctx, gardenConditions, gardenConstraints)
 
 				expectHealthyObservabilityComponents(updatedConditions)
 			})
@@ -663,7 +665,7 @@ var _ = Describe("Garden health", func() {
 				// is set to healthy if the Prometheus resource is filtered out.
 				BeforeEach(func() {
 					healthChecker = healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithPrometheusHealthChecker(unhealthy))
-					conditions = NewHealth(
+					conditions, _ = NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -671,7 +673,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthChecker,
-					).Check(ctx, gardenConditions)
+					).Check(ctx, gardenConditions, gardenConstraints)
 
 					Expect(conditions).To(ContainElements(
 						beConditionOfTypeWithStatusReasonAndMessage(
@@ -685,7 +687,7 @@ var _ = Describe("Garden health", func() {
 					prometheus.Labels = map[string]string{"health-check-by": "foo"}
 					Expect(runtimeClient.Update(ctx, prometheus)).To(Succeed())
 
-					conditions = NewHealth(
+					conditions, _ = NewHealth(
 						garden,
 						runtimeClient,
 						gardenClientSet,
@@ -693,7 +695,7 @@ var _ = Describe("Garden health", func() {
 						nil,
 						gardenNamespace,
 						healthChecker,
-					).Check(ctx, gardenConditions)
+					).Check(ctx, gardenConditions, gardenConstraints)
 
 					expectHealthyObservabilityComponents(conditions)
 				})
@@ -753,6 +755,100 @@ var _ = Describe("Garden health", func() {
 					gardencorev1beta1.ConditionType("RuntimeComponentsHealthy"),
 					gardencorev1beta1.ConditionType("VirtualComponentsHealthy"),
 					gardencorev1beta1.ConditionType("ObservabilityComponentsHealthy"),
+				))
+			})
+		})
+	})
+
+	Describe("GardenConstraints", func() {
+		Describe("#NewGardenConstraints", func() {
+			It("should initialize all constraints", func() {
+				constraints := NewGardenConstraints(fakeClock, operatorv1alpha1.GardenStatus{})
+
+				Expect(constraints.ConvertToSlice()).To(ConsistOf(
+					beConditionOfTypeWithStatusReasonAndMessage(operatorv1alpha1.GardenManagedResourcesHonored, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
+				))
+			})
+
+			It("should only initialize missing constraints", func() {
+				constraints := NewGardenConstraints(fakeClock, operatorv1alpha1.GardenStatus{
+					Constraints: []gardencorev1beta1.Condition{
+						{Type: "ManagedResourcesHonored"},
+						{Type: "Foo"},
+					},
+				})
+
+				Expect(constraints.ConvertToSlice()).To(HaveExactElements(
+					OfType("ManagedResourcesHonored"),
+				))
+			})
+		})
+
+		Describe("#ConvertToSlice", func() {
+			It("should return the expected constraints", func() {
+				constraints := NewGardenConstraints(fakeClock, operatorv1alpha1.GardenStatus{})
+
+				Expect(constraints.ConvertToSlice()).To(HaveExactElements(
+					OfType("ManagedResourcesHonored"),
+				))
+			})
+		})
+
+		Describe("#ConstraintTypes", func() {
+			It("should return the expected constraint types", func() {
+				constraints := NewGardenConstraints(fakeClock, operatorv1alpha1.GardenStatus{})
+
+				Expect(constraints.ConstraintTypes()).To(HaveExactElements(
+					gardencorev1beta1.ConditionType("ManagedResourcesHonored"),
+				))
+			})
+		})
+
+		Context("ManagedResourcesHonored constraint check", func() {
+			JustBeforeEach(func() {
+				for _, name := range virtualGardenDeployments {
+					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, true))).To(Succeed())
+				}
+				for _, name := range virtualGardenETCDs {
+					Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
+				}
+			})
+
+			It("should set ManagedResourcesHonored to True if no ManagedResources are ignored", func() {
+				Expect(runtimeClient.Create(ctx, healthyManagedResource("foo", "RuntimeComponentsHealthy"))).To(Succeed())
+
+				_, updatedConstraints := NewHealth(
+					garden,
+					runtimeClient,
+					gardenClientSet,
+					fakeClock,
+					nil,
+					gardenNamespace,
+					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
+				).Check(ctx, gardenConditions, gardenConstraints)
+
+				Expect(updatedConstraints).To(ContainElements(
+					beConditionOfTypeWithStatusReasonAndMessage(operatorv1alpha1.GardenManagedResourcesHonored, gardencorev1beta1.ConditionTrue, "AllManagedResourcesActive", "No ManagedResources are annotated to be ignored."),
+				))
+			})
+
+			It("should set ManagedResourcesHonored to False if a ManagedResource is ignored", func() {
+				mr := healthyManagedResource("foo", "RuntimeComponentsHealthy")
+				mr.Annotations = map[string]string{"resources.gardener.cloud/ignore": "true"}
+				Expect(runtimeClient.Create(ctx, mr)).To(Succeed())
+
+				_, updatedConstraints := NewHealth(
+					garden,
+					runtimeClient,
+					gardenClientSet,
+					fakeClock,
+					nil,
+					gardenNamespace,
+					healthchecker.NewHealthChecker(log, runtimeClient, fakeClock, healthchecker.WithLastOperation(garden.Status.LastOperation)),
+				).Check(ctx, gardenConditions, gardenConstraints)
+
+				Expect(updatedConstraints).To(ContainElements(
+					And(OfType(operatorv1alpha1.GardenManagedResourcesHonored), WithStatus(gardencorev1beta1.ConditionFalse), WithReason("ManagedResourcesIgnored"), WithMessageSubstrings("foo")),
 				))
 			})
 		})

--- a/pkg/operator/controller/garden/care/reconciler.go
+++ b/pkg/operator/controller/garden/care/reconciler.go
@@ -71,6 +71,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 
 	// Initialize conditions based on the current status.
 	gardenConditions := NewGardenConditions(r.Clock, garden.Status)
+	gardenConstraints := NewGardenConstraints(r.Clock, garden.Status)
 
 	gardenClientSet, err := r.GardenClientMap.GetClient(reconcileCtx, keys.ForGarden(garden))
 	if err != nil {
@@ -78,7 +79,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 	}
 
 	conditionThresholds := r.conditionThresholdsToProgressingMapping()
-	updatedConditions := NewHealthCheck(
+	updatedConditions, updatedConstraints := NewHealthCheck(
 		garden,
 		r.RuntimeClient,
 		gardenClientSet,
@@ -94,16 +95,24 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 	).Check(
 		ctx,
 		gardenConditions,
+		gardenConstraints,
 	)
 
-	// Update Garden status conditions if necessary
-	if v1beta1helper.ConditionsNeedUpdate(gardenConditions.ConvertToSlice(), updatedConditions) {
-		log.Info("Updating garden status conditions")
-		patch := client.MergeFrom(garden.DeepCopy())
-		// Rebuild garden conditions to ensure that only the conditions with the
-		// correct types will be updated, and any other conditions will remain intact
-		garden.Status.Conditions = v1beta1helper.BuildConditions(garden.Status.Conditions, updatedConditions, gardenConditions.ConditionTypes())
+	conditionsNeedUpdate := v1beta1helper.ConditionsNeedUpdate(gardenConditions.ConvertToSlice(), updatedConditions)
+	constraintsNeedUpdate := v1beta1helper.ConditionsNeedUpdate(gardenConstraints.ConvertToSlice(), updatedConstraints)
 
+	if conditionsNeedUpdate || constraintsNeedUpdate {
+		// Rebuild garden conditions/constraints to ensure that only the entries with the
+		// correct types will be updated, and any other entries will remain intact
+		patch := client.MergeFrom(garden.DeepCopy())
+		if conditionsNeedUpdate {
+			garden.Status.Conditions = v1beta1helper.BuildConditions(garden.Status.Conditions, updatedConditions, gardenConditions.ConditionTypes())
+		}
+		if constraintsNeedUpdate {
+			garden.Status.Constraints = v1beta1helper.BuildConditions(garden.Status.Constraints, updatedConstraints, gardenConstraints.ConstraintTypes())
+		}
+
+		log.Info("Updating garden status conditions and constraints")
 		if err := r.RuntimeClient.Status().Patch(reconcileCtx, garden, patch); err != nil {
 			log.Error(err, "Could not update garden status")
 			return reconcile.Result{}, err

--- a/pkg/operator/controller/garden/care/reconciler.go
+++ b/pkg/operator/controller/garden/care/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health/checker"
 )
 
@@ -79,24 +80,33 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 	}
 
 	conditionThresholds := r.conditionThresholdsToProgressingMapping()
-	updatedConditions, updatedConstraints := NewHealthCheck(
-		garden,
-		r.RuntimeClient,
-		gardenClientSet,
-		r.Clock,
-		conditionThresholds,
-		r.GardenNamespace,
-		checker.NewHealthChecker(
-			log,
-			r.RuntimeClient,
-			r.Clock,
-			checker.WithConditionThresholds(conditionThresholds),
-			checker.WithLastOperation(garden.Status.LastOperation)),
-	).Check(
-		ctx,
-		gardenConditions,
-		gardenConstraints,
-	)
+
+	var updatedConditions, updatedConstraints []gardencorev1beta1.Condition
+	_ = flow.Parallel(
+		// Trigger health check
+		func(ctx context.Context) error {
+			updatedConditions = NewHealthCheck(
+				garden,
+				r.RuntimeClient,
+				gardenClientSet,
+				r.Clock,
+				conditionThresholds,
+				r.GardenNamespace,
+				checker.NewHealthChecker(
+					log,
+					r.RuntimeClient,
+					r.Clock,
+					checker.WithConditionThresholds(conditionThresholds),
+					checker.WithLastOperation(garden.Status.LastOperation)),
+			).Check(ctx, gardenConditions)
+			return nil
+		},
+		// Trigger constraint check
+		func(ctx context.Context) error {
+			updatedConstraints = NewConstraintCheck(r.RuntimeClient, r.Clock, r.GardenNamespace).Check(ctx, gardenConstraints)
+			return nil
+		},
+	)(ctx)
 
 	conditionsNeedUpdate := v1beta1helper.ConditionsNeedUpdate(gardenConditions.ConvertToSlice(), updatedConditions)
 	constraintsNeedUpdate := v1beta1helper.ConditionsNeedUpdate(gardenConstraints.ConvertToSlice(), updatedConstraints)

--- a/pkg/operator/controller/garden/care/reconciler_test.go
+++ b/pkg/operator/controller/garden/care/reconciler_test.go
@@ -99,7 +99,9 @@ var _ = Describe("Garden Care Control", func() {
 			Context("when no conditions are returned", func() {
 				BeforeEach(func() {
 					DeferCleanup(test.WithVars(&NewHealthCheck,
-						healthCheckFunc(func(_ GardenConditions) []gardencorev1beta1.Condition { return nil })))
+						healthCheckFunc(func(_ GardenConditions, _ GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
+							return nil, nil
+						})))
 				})
 
 				It("should not set conditions", func() {
@@ -132,10 +134,10 @@ var _ = Describe("Garden Care Control", func() {
 			Context("when conditions are returned unchanged", func() {
 				BeforeEach(func() {
 					DeferCleanup(test.WithVars(
-						&NewHealthCheck, healthCheckFunc(func(cond GardenConditions) []gardencorev1beta1.Condition {
+						&NewHealthCheck, healthCheckFunc(func(cond GardenConditions, _ GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
 							conditions := cond.ConvertToSlice()
 							conditionsCopy := append(conditions[:0:0], conditions...)
-							return conditionsCopy
+							return conditionsCopy, nil
 						}),
 					))
 				})
@@ -179,8 +181,8 @@ var _ = Describe("Garden Care Control", func() {
 						},
 					}
 					DeferCleanup(test.WithVars(&NewHealthCheck,
-						healthCheckFunc(func(_ GardenConditions) []gardencorev1beta1.Condition {
-							return conditions
+						healthCheckFunc(func(_ GardenConditions, _ GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
+							return conditions, nil
 						})))
 				})
 
@@ -196,10 +198,10 @@ var _ = Describe("Garden Care Control", func() {
 	})
 })
 
-type resultingConditionFunc func(cond GardenConditions) []gardencorev1beta1.Condition
+type resultingConditionFunc func(cond GardenConditions, constr GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition)
 
-func (c resultingConditionFunc) Check(_ context.Context, conditions GardenConditions) []gardencorev1beta1.Condition {
-	return c(conditions)
+func (c resultingConditionFunc) Check(_ context.Context, conditions GardenConditions, constraints GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
+	return c(conditions, constraints)
 }
 
 func healthCheckFunc(fn resultingConditionFunc) NewHealthCheckFunc {

--- a/pkg/operator/controller/garden/care/reconciler_test.go
+++ b/pkg/operator/controller/garden/care/reconciler_test.go
@@ -99,8 +99,8 @@ var _ = Describe("Garden Care Control", func() {
 			Context("when no conditions are returned", func() {
 				BeforeEach(func() {
 					DeferCleanup(test.WithVars(&NewHealthCheck,
-						healthCheckFunc(func(_ GardenConditions, _ GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
-							return nil, nil
+						healthCheckFunc(func(_ GardenConditions) []gardencorev1beta1.Condition {
+							return nil
 						})))
 				})
 
@@ -134,10 +134,10 @@ var _ = Describe("Garden Care Control", func() {
 			Context("when conditions are returned unchanged", func() {
 				BeforeEach(func() {
 					DeferCleanup(test.WithVars(
-						&NewHealthCheck, healthCheckFunc(func(cond GardenConditions, _ GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
+						&NewHealthCheck, healthCheckFunc(func(cond GardenConditions) []gardencorev1beta1.Condition {
 							conditions := cond.ConvertToSlice()
 							conditionsCopy := append(conditions[:0:0], conditions...)
-							return conditionsCopy, nil
+							return conditionsCopy
 						}),
 					))
 				})
@@ -181,8 +181,8 @@ var _ = Describe("Garden Care Control", func() {
 						},
 					}
 					DeferCleanup(test.WithVars(&NewHealthCheck,
-						healthCheckFunc(func(_ GardenConditions, _ GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
-							return conditions, nil
+						healthCheckFunc(func(_ GardenConditions) []gardencorev1beta1.Condition {
+							return conditions
 						})))
 				})
 
@@ -198,10 +198,10 @@ var _ = Describe("Garden Care Control", func() {
 	})
 })
 
-type resultingConditionFunc func(cond GardenConditions, constr GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition)
+type resultingConditionFunc func(cond GardenConditions) []gardencorev1beta1.Condition
 
-func (c resultingConditionFunc) Check(_ context.Context, conditions GardenConditions, constraints GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition) {
-	return c(conditions, constraints)
+func (c resultingConditionFunc) Check(_ context.Context, conditions GardenConditions) []gardencorev1beta1.Condition {
+	return c(conditions)
 }
 
 func healthCheckFunc(fn resultingConditionFunc) NewHealthCheckFunc {

--- a/pkg/operator/controller/garden/care/types.go
+++ b/pkg/operator/controller/garden/care/types.go
@@ -25,5 +25,21 @@ var defaultNewHealthCheck NewHealthCheckFunc = NewHealth
 
 // HealthCheck is an interface used to perform health checks.
 type HealthCheck interface {
-	Check(ctx context.Context, conditions GardenConditions, constraints GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition)
+	Check(ctx context.Context, conditions GardenConditions) []gardencorev1beta1.Condition
 }
+
+// ConstraintCheck is an interface used to perform constraint checks.
+type ConstraintCheck interface {
+	Check(ctx context.Context, constraints GardenConstraints) []gardencorev1beta1.Condition
+}
+
+// NewConstraintCheckFunc is a function used to create a new instance for performing constraint checks.
+type NewConstraintCheckFunc func(client.Client, clock.Clock, string) ConstraintCheck
+
+// defaultNewConstraintCheck is the default function to create a new instance for performing constraint checks.
+var defaultNewConstraintCheck NewConstraintCheckFunc = func(runtimeClient client.Client, clock clock.Clock, gardenNamespace string) ConstraintCheck {
+	return NewConstraint(runtimeClient, clock, gardenNamespace)
+}
+
+// NewConstraintCheck is used to create a new Constraint check instance.
+var NewConstraintCheck = defaultNewConstraintCheck

--- a/pkg/operator/controller/garden/care/types.go
+++ b/pkg/operator/controller/garden/care/types.go
@@ -25,5 +25,5 @@ var defaultNewHealthCheck NewHealthCheckFunc = NewHealth
 
 // HealthCheck is an interface used to perform health checks.
 type HealthCheck interface {
-	Check(ctx context.Context, conditions GardenConditions) []gardencorev1beta1.Condition
+	Check(ctx context.Context, conditions GardenConditions, constraints GardenConstraints) ([]gardencorev1beta1.Condition, []gardencorev1beta1.Condition)
 }

--- a/pkg/utils/kubernetes/health/managedresource.go
+++ b/pkg/utils/kubernetes/health/managedresource.go
@@ -6,6 +6,10 @@ package health
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -68,4 +72,29 @@ func CheckManagedResourceProgressing(mr *resourcesv1alpha1.ManagedResource) erro
 	}
 
 	return nil
+}
+
+// CheckManagedResourcesHonored checks whether any of the given ManagedResources have been annotated with
+// resources.gardener.cloud/ignore=true, which disables their reconciliation. It returns a condition status,
+// reason, and message suitable for use in a constraint.
+func CheckManagedResourcesHonored(managedResources []resourcesv1alpha1.ManagedResource) (gardencorev1beta1.ConditionStatus, string, string) {
+	ignoredNames := sets.New[string]()
+	for _, mr := range managedResources {
+		if value, ok := mr.GetAnnotations()[resourcesv1alpha1.Ignore]; ok {
+			if truthy, _ := strconv.ParseBool(value); truthy {
+				ignoredNames.Insert(mr.Name)
+			}
+		}
+	}
+
+	if ignoredNames.Len() > 0 {
+		return gardencorev1beta1.ConditionFalse,
+			"ManagedResourcesIgnored",
+			fmt.Sprintf("Some ManagedResources have been annotated with %s=true, meaning their reconciliation is disabled: %s",
+				resourcesv1alpha1.Ignore, strings.Join(sets.List(ignoredNames), ", "))
+	}
+
+	return gardencorev1beta1.ConditionTrue,
+		"AllManagedResourcesActive",
+		"No ManagedResources are annotated to be ignored."
 }

--- a/pkg/utils/kubernetes/health/managedresource_test.go
+++ b/pkg/utils/kubernetes/health/managedresource_test.go
@@ -255,4 +255,71 @@ var _ = Describe("Managedresource", func() {
 			}, HaveOccurred()),
 		)
 	})
+
+	Context("#CheckManagedResourcesHonored", func() {
+		managedResource := func(name string, annotations map[string]string) resourcesv1alpha1.ManagedResource {
+			return resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
+			}
+		}
+
+		DescribeTable("managedresources honored",
+			func(managedResources []resourcesv1alpha1.ManagedResource, expectedStatus gardencorev1beta1.ConditionStatus, expectedReason string, messageMatcher types.GomegaMatcher) {
+				status, reason, message := health.CheckManagedResourcesHonored(managedResources)
+				Expect(status).To(Equal(expectedStatus))
+				Expect(reason).To(Equal(expectedReason))
+				Expect(message).To(messageMatcher)
+			},
+			Entry("no managed resources",
+				nil,
+				gardencorev1beta1.ConditionTrue,
+				"AllManagedResourcesActive",
+				Equal("No ManagedResources are annotated to be ignored."),
+			),
+			Entry("managed resource without ignore annotation",
+				[]resourcesv1alpha1.ManagedResource{managedResource("foo", nil)},
+				gardencorev1beta1.ConditionTrue,
+				"AllManagedResourcesActive",
+				Equal("No ManagedResources are annotated to be ignored."),
+			),
+			Entry("managed resource with ignore annotation set to false",
+				[]resourcesv1alpha1.ManagedResource{managedResource("foo", map[string]string{resourcesv1alpha1.Ignore: "false"})},
+				gardencorev1beta1.ConditionTrue,
+				"AllManagedResourcesActive",
+				Equal("No ManagedResources are annotated to be ignored."),
+			),
+			Entry("managed resource with ignore annotation set to a non-boolean value",
+				[]resourcesv1alpha1.ManagedResource{managedResource("foo", map[string]string{resourcesv1alpha1.Ignore: "foo"})},
+				gardencorev1beta1.ConditionTrue,
+				"AllManagedResourcesActive",
+				Equal("No ManagedResources are annotated to be ignored."),
+			),
+			Entry("single managed resource with ignore annotation set to true",
+				[]resourcesv1alpha1.ManagedResource{managedResource("foo", map[string]string{resourcesv1alpha1.Ignore: "true"})},
+				gardencorev1beta1.ConditionFalse,
+				"ManagedResourcesIgnored",
+				ContainSubstring("foo"),
+			),
+			Entry("multiple ignored managed resources are listed alphabetically",
+				[]resourcesv1alpha1.ManagedResource{
+					managedResource("zeta", map[string]string{resourcesv1alpha1.Ignore: "true"}),
+					managedResource("alpha", map[string]string{resourcesv1alpha1.Ignore: "true"}),
+					managedResource("mid", map[string]string{resourcesv1alpha1.Ignore: "true"}),
+				},
+				gardencorev1beta1.ConditionFalse,
+				"ManagedResourcesIgnored",
+				Equal("Some ManagedResources have been annotated with resources.gardener.cloud/ignore=true, meaning their reconciliation is disabled: alpha, mid, zeta"),
+			),
+			Entry("mix of ignored and non-ignored managed resources lists only the ignored ones",
+				[]resourcesv1alpha1.ManagedResource{
+					managedResource("ignored", map[string]string{resourcesv1alpha1.Ignore: "true"}),
+					managedResource("active", nil),
+					managedResource("disabled-ignore", map[string]string{resourcesv1alpha1.Ignore: "false"}),
+				},
+				gardencorev1beta1.ConditionFalse,
+				"ManagedResourcesIgnored",
+				And(ContainSubstring("ignored"), Not(ContainSubstring("active")), Not(ContainSubstring("disabled-ignore"))),
+			),
+		)
+	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
 /area ops-productivity
 /area control-plane
 /kind enhancement

**What this PR does / why we need it**:
  The `gardenlet` and `gardener-operator` now expose a dedicated `ManagedResourcesHonored` constraint that surfaces any `ManagedResource` annotated `with resources.gardener.cloud/ignore=true` in the `seed's` or `garden's` namespaces.

  - `ManagedResourcesHonored` is added to `Seed.status.constraints` by the `gardenlet`'s seed care controller.
  - `ManagedResourcesHonored` is added to `Garden.status.constraints` by the `gardener-operator`'s garden care controller.
  - The same constraint type name and reasons are used for `Shoot`, `Seed`, and `Garden` — aligned with the existing `ShootManagedResourcesHonored` constraint on `Shoot.status.constraints`.
  - When at least one `ManagedResource` carries the ignore annotation the constraint is set to `False` with reason `ManagedResourcesIgnored` and a message listing the affected resource names (sorted alphabetically). When no `ManagedResource` is ignored the constraint is `True` with reason `AllManagedResourcesActive`.
  - The check logic is extracted into a shared helper `CheckManagedResourcesHonored` in `pkg/utils/kubernetes/health`, reused by all three controllers (`Shoot`, `Seed`, `Garden`).
  - `Seed.status.constraints` and `Garden.status.constraints` are new API fields — the CRD YAML (`crd-gardens.yaml`) and the `gardener-apiserver `OpenAPI schema (`openapi_generated.go`) are updated accordingly.
  
This makes it immediately visible to operators that one or more resources have had reconciliation disabled, reducing the risk of diverging state going unnoticed after manual intervention.

**Which issue(s) this PR fixes**:
  This PR is a continuation of https://github.com/gardener/gardener/pull/15023 and supersedes the previous approach https://github.com/gardener/gardener/pull/15155 in this PR. Per the discussion in #15023, `.status.constraints` is the correct place for this information (not `.status.conditions`), and `Seed` and `Garden` now have a constraints field added to their API for this purpose.

**Special notes for your reviewer**:
  - The constraint type value is `ManagedResourcesHonored` (same for `Shoot`, `Seed`, and `Garden`) — renamed from the previous `HasIgnoredManagedResources` per @timuthy's [suggestion](https://github.com/gardener/gardener/pull/15155#pullrequestreview-4671388140).
  - The reason `NoManagedResourcesIgnored` was renamed to `AllManagedResourcesActive` for consistency.
  
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`ManagedResourcesHonored` constraint is now reported on `Seed.status.constraints` and `Garden.status.constraints`, surfacing any `ManagedResource` annotated with `resources.gardener.cloud/ignore=true` to alert operators of disabled reconciliation. The same constraint is also renamed from `HasIgnoredManagedResources` to `ManagedResourcesHonored` on `Shoot.status.constraints` for consistency across all three resource types.
```
