### PR TITLE
fix(shoot-mutator): honor machine image providerConfig updates on unchanged name/version

### DIFF
--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -518,8 +518,11 @@ func (c *mutationContext) ensureMachineImage(oldWorkers []core.Worker, worker co
 		if oldWorker.Machine.Image.Name == worker.Machine.Image.Name {
 			// image name was not changed
 			if len(worker.Machine.Image.Version) == 0 || worker.Machine.Image.Version == oldWorker.Machine.Image.Version {
-				// if the version from the new worker is not specified or it is equal to the old worker image version -> keep the old one
-				return oldWorker.Machine.Image, nil
+				// if the version from the new worker is not specified, or it is equal to the old worker image version -> keep the old one
+				image := oldWorker.Machine.Image.DeepCopy()
+				// ensure provider config is updated
+				image.ProviderConfig = worker.Machine.Image.ProviderConfig
+				return image, nil
 			}
 		}
 	}

--- a/plugin/pkg/shoot/mutator/admission_test.go
+++ b/plugin/pkg/shoot/mutator/admission_test.go
@@ -1436,6 +1436,23 @@ var _ = Describe("mutator", func() {
 					}))
 				})
 
+				It("should use updated machine image providerConfig even if name and version are unchanged", func() {
+					shoot.Spec.Provider.Workers[0].Machine.Image.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{"foo":"old-value"}`)}
+
+					newShoot := shoot.DeepCopy()
+					newShoot.Spec.Provider.Workers[0].Machine.Image.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{"foo":"new-value"}`)}
+
+					attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(newShoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&core.ShootMachineImage{
+						Name:           imageName1,
+						Version:        nonExpiredVersion,
+						ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"foo":"new-value"}`)},
+					}))
+				})
+
 				It("should default a version prefix of an existing worker pool to the latest supported non-preview version", func() {
 					expectedImageVersion := latestNonExpiredVersionThatSupportsCapabilities
 					if !isCapabilityCloudProfile {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The shoot mutating admission plugin's machine image defaulting logic preserved the old worker's machine image whenever the image name and version were unchanged, in order to avoid accidentally bumping the version to the CloudProfile default outside the maintenance window.

However, it returned the entire old `Machine.Image` object, which also silently discarded any user changes to `machine.image.providerConfig` (e.g. a `memoryone-chost` OSC's `systemMemory`). Such edits never reached the resulting shoot manifest.

Keep the old image name/version to retain the version-drift protection, but honor the incoming `providerConfig` so provider-config-only updates take effect.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
fix(shoot-mutator): honor machine image providerConfig updates on unchanged name/version
```
