### PR TITLE
[GEP-28] Do not allow `gardenadm connect` while bootstrap ETCD is still being used

### DIFF
--- a/docs/cli-reference/gardenadm/gardenadm_connect.md
+++ b/docs/cli-reference/gardenadm/gardenadm_connect.md
@@ -23,7 +23,7 @@ gardenadm connect
       --bootstrap-token string       Bootstrap token for connecting the self-hosted shoot cluster to a garden cluster (create it with 'gardenadm token' in the garden cluster)
       --ca-certificate bytesBase64   Base64-encoded certificate authority bundle of the Gardener control plane
   -d, --config-dir string            Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
-      --force                        Forces the deployment of gardenlet, even if it already exists
+      --force                        Forces the deployment of gardenlet, even if it already exists or bootstrap etcd is still running
   -h, --help                         help for connect
 ```
 

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -90,12 +90,19 @@ func run(ctx context.Context, opts *Options) error {
 	if bootstrapEtcdExists, err := isBootstrapEtcdStillRunning(ctx, b); err != nil {
 		return fmt.Errorf("failed checking if bootstrap etcd is still running: %w", err)
 	} else if bootstrapEtcdExists {
-		return fmt.Errorf("bootstrap etcd is still running in the self-hosted shoot cluster, please run 'gardenadm init --use-bootstrap-etcd=false' first")
+		if !opts.Force {
+			return fmt.Errorf("bootstrap etcd is still running in the self-hosted shoot cluster, please run 'gardenadm init --use-bootstrap-etcd=false' first")
+		}
+		opts.Log.Info("Warning: Bootstrap etcd is still running, --force override active")
 	}
 
 	if alreadyConnected, err := cmd.IsGardenletDeployed(ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace); err != nil {
 		return fmt.Errorf("failed checking if gardenlet is already deployed: %w", err)
 	} else if !alreadyConnected || opts.Force {
+		if alreadyConnected {
+			opts.Log.Info("Warning: Gardenlet is already deployed, --force override active")
+		}
+
 		bootstrapClientSet, err := cmd.NewClientSetFromBootstrapToken(opts.ControlPlaneAddress, opts.CertificateAuthority, opts.BootstrapToken, kubernetes.GardenScheme)
 		if err != nil {
 			return fmt.Errorf("failed creating a new bootstrap garden client set: %w", err)
@@ -207,7 +214,7 @@ func isBootstrapEtcdStillRunning(ctx context.Context, b *botanist.GardenadmBotan
 		}
 	}
 
-	return true, nil
+	return false, nil
 }
 
 func prepareGardenerResources(ctx context.Context, b *botanist.GardenadmBotanist) error {

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
 	"github.com/gardener/gardener/pkg/gardenadm/botanist"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
+	"github.com/gardener/gardener/pkg/gardenadm/staticpod"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/oci"
@@ -196,7 +197,7 @@ Happy Gardening!
 func isBootstrapEtcdStillRunning(ctx context.Context, b *botanist.GardenadmBotanist) (bool, error) {
 	podList := &metav1.PartialObjectMetadataList{}
 	podList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PodList"))
-	if err := b.SeedClientSet.Client().List(ctx, podList, client.InNamespace(b.Shoot.ControlPlaneNamespace)); err != nil {
+	if err := b.SeedClientSet.Client().List(ctx, podList, client.InNamespace(b.Shoot.ControlPlaneNamespace), client.MatchingLabels{staticpod.LabelKeyIsStaticPod: staticpod.LabelValueIsStaticPod}); err != nil {
 		return false, fmt.Errorf("failed checking if bootstrap etcd still exists: %w", err)
 	}
 

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -29,7 +29,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/component/etcd/bootstrap"
+	bootstrapetcd "github.com/gardener/gardener/pkg/component/etcd/bootstrap"
 	corebackupbucket "github.com/gardener/gardener/pkg/component/garden/backupbucket"
 	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
 	"github.com/gardener/gardener/pkg/gardenadm/botanist"
@@ -201,7 +201,7 @@ func isBootstrapEtcdStillRunning(ctx context.Context, b *botanist.GardenadmBotan
 	}
 
 	for _, pod := range podList.Items {
-		if strings.HasPrefix(pod.GetName(), bootstrap.NamePrefix) {
+		if strings.HasPrefix(pod.GetName(), bootstrapetcd.NamePrefix) {
 			return true, nil
 		}
 	}

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -7,10 +7,12 @@ package connect
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
@@ -27,6 +29,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component/etcd/bootstrap"
 	corebackupbucket "github.com/gardener/gardener/pkg/component/garden/backupbucket"
 	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
 	"github.com/gardener/gardener/pkg/gardenadm/botanist"
@@ -81,6 +84,12 @@ func run(ctx context.Context, opts *Options) error {
 	b.SeedClientSet, err = b.CreateClientSet(ctx)
 	if err != nil {
 		return fmt.Errorf("failed creating client set for self-hosted shoot: %w", err)
+	}
+
+	if bootstrapEtcdExists, err := isBootstrapEtcdStillRunning(ctx, b); err != nil {
+		return fmt.Errorf("failed checking if bootstrap etcd is still running: %w", err)
+	} else if bootstrapEtcdExists {
+		return fmt.Errorf("bootstrap etcd is still running in the self-hosted shoot cluster, please run 'gardenadm init --use-bootstrap-etcd=false' first")
 	}
 
 	if alreadyConnected, err := cmd.IsGardenletDeployed(ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace); err != nil {
@@ -182,6 +191,22 @@ Happy Gardening!
 `, b.Shoot.ControlPlaneNamespace, opts.BootstrapToken, opts.ConfigDir)
 
 	return nil
+}
+
+func isBootstrapEtcdStillRunning(ctx context.Context, b *botanist.GardenadmBotanist) (bool, error) {
+	podList := &metav1.PartialObjectMetadataList{}
+	podList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PodList"))
+	if err := b.SeedClientSet.Client().List(ctx, podList, client.InNamespace(b.Shoot.ControlPlaneNamespace)); err != nil {
+		return false, fmt.Errorf("failed checking if bootstrap etcd still exists: %w", err)
+	}
+
+	for _, pod := range podList.Items {
+		if strings.HasPrefix(pod.GetName(), bootstrap.NamePrefix) {
+			return true, nil
+		}
+	}
+
+	return true, nil
 }
 
 func prepareGardenerResources(ctx context.Context, b *botanist.GardenadmBotanist) error {

--- a/pkg/gardenadm/cmd/connect/options.go
+++ b/pkg/gardenadm/cmd/connect/options.go
@@ -25,7 +25,7 @@ type Options struct {
 	BootstrapToken string
 	// CertificateAuthority is the CA bundle of the control plane.
 	CertificateAuthority []byte
-	// Force forces the deployment of gardenlet, even if it already exists.
+	// Force forces the deployment of gardenlet, even if it already exists or bootstrap etcd is still running.
 	Force bool
 }
 
@@ -65,5 +65,5 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	o.ManifestOptions.AddFlags(fs)
 	fs.BytesBase64Var(&o.CertificateAuthority, "ca-certificate", nil, "Base64-encoded certificate authority bundle of the Gardener control plane")
 	fs.StringVar(&o.BootstrapToken, "bootstrap-token", "", "Bootstrap token for connecting the self-hosted shoot cluster to a garden cluster (create it with 'gardenadm token' in the garden cluster)")
-	fs.BoolVar(&o.Force, "force", false, "Forces the deployment of gardenlet, even if it already exists")
+	fs.BoolVar(&o.Force, "force", false, "Forces the deployment of gardenlet, even if it already exists or bootstrap etcd is still running")
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Do not allow `gardenadm connect` while bootstrap ETCD is still being used.

As discussed in https://github.com/gardener/hackathon/issues/45#issuecomment-4423399104, it makes sense to prevent `gardenadm connect` if the self-hosted shoot cluster is still using the bootstrap ETCD.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:

/cc @rfranzke @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
