### PR TITLE
[GEP-28] Prevent `gardenadm init` with `gardenlet` running

### DIFF
--- a/docs/cli-reference/gardenadm/gardenadm_init.md
+++ b/docs/cli-reference/gardenadm/gardenadm_init.md
@@ -24,6 +24,7 @@ gardenadm init --config-dir /path/to/manifests --zone zone-a
 
 ```
   -d, --config-dir string    Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
+      --force                If set, the init command will be executed even if the control plane is already initialized.
   -h, --help                 help for init
       --use-bootstrap-etcd   If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This can be useful for testing purposes to save time.
       --use-host-network     If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
@@ -85,7 +83,7 @@ func run(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("failed creating client set for self-hosted shoot: %w", err)
 	}
 
-	if alreadyConnected, err := isGardenletDeployed(ctx, b); err != nil {
+	if alreadyConnected, err := cmd.IsGardenletDeployed(ctx, b); err != nil {
 		return fmt.Errorf("failed checking if gardenlet is already deployed: %w", err)
 	} else if !alreadyConnected || opts.Force {
 		bootstrapClientSet, err := cmd.NewClientSetFromBootstrapToken(opts.ControlPlaneAddress, opts.CertificateAuthority, opts.BootstrapToken, kubernetes.GardenScheme)
@@ -178,24 +176,6 @@ Happy Gardening!
 `, b.Shoot.ControlPlaneNamespace, opts.BootstrapToken, opts.ConfigDir)
 
 	return nil
-}
-
-func isGardenletDeployed(ctx context.Context, b *botanist.GardenadmBotanist) (bool, error) {
-	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Namespace: b.Shoot.ControlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenlet}, &appsv1.Deployment{}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return false, fmt.Errorf("failed checking if gardenlet deployment already exists: %w", err)
-		}
-		return false, nil
-	}
-
-	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Namespace: b.Shoot.ControlPlaneNamespace, Name: gardenletdeployer.GardenletDefaultKubeconfigSecretName}, &corev1.Secret{}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return false, fmt.Errorf("failed checking if gardenlet's kubeconfig secret already exists: %w", err)
-		}
-		return false, nil
-	}
-
-	return true, nil
 }
 
 func prepareGardenerResources(ctx context.Context, b *botanist.GardenadmBotanist) error {

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -83,7 +83,7 @@ func run(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("failed creating client set for self-hosted shoot: %w", err)
 	}
 
-	if alreadyConnected, err := cmd.IsGardenletDeployed(ctx, b); err != nil {
+	if alreadyConnected, err := cmd.IsGardenletDeployed(ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace); err != nil {
 		return fmt.Errorf("failed checking if gardenlet is already deployed: %w", err)
 	} else if !alreadyConnected || opts.Force {
 		bootstrapClientSet, err := cmd.NewClientSetFromBootstrapToken(opts.ControlPlaneAddress, opts.CertificateAuthority, opts.BootstrapToken, kubernetes.GardenScheme)

--- a/pkg/gardenadm/cmd/gardenlet.go
+++ b/pkg/gardenadm/cmd/gardenlet.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
+	"github.com/gardener/gardener/pkg/gardenadm/botanist"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IsGardenletDeployed indicates whether gardenlet is running in the shoot cluster.
+// It checks for the existence of the gardenlet deployment and its kubeconfig secret in the control plane namespace.
+func IsGardenletDeployed(ctx context.Context, b *botanist.GardenadmBotanist) (bool, error) {
+	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Namespace: b.Shoot.ControlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenlet}, &appsv1.Deployment{}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed checking if gardenlet deployment already exists: %w", err)
+		}
+		return false, nil
+	}
+
+	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Namespace: b.Shoot.ControlPlaneNamespace, Name: gardenletdeployer.GardenletDefaultKubeconfigSecretName}, &corev1.Secret{}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed checking if gardenlet's kubeconfig secret already exists: %w", err)
+		}
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/pkg/gardenadm/cmd/gardenlet.go
+++ b/pkg/gardenadm/cmd/gardenlet.go
@@ -10,7 +10,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
-	"github.com/gardener/gardener/pkg/gardenadm/botanist"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -19,15 +18,15 @@ import (
 
 // IsGardenletDeployed indicates whether gardenlet is running in the shoot cluster.
 // It checks for the existence of the gardenlet deployment and its kubeconfig secret in the control plane namespace.
-func IsGardenletDeployed(ctx context.Context, b *botanist.GardenadmBotanist) (bool, error) {
-	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Namespace: b.Shoot.ControlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenlet}, &appsv1.Deployment{}); err != nil {
+func IsGardenletDeployed(ctx context.Context, c client.Client, namespace string) (bool, error) {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.DeploymentNameGardenlet}, &appsv1.Deployment{}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return false, fmt.Errorf("failed checking if gardenlet deployment already exists: %w", err)
 		}
 		return false, nil
 	}
 
-	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Namespace: b.Shoot.ControlPlaneNamespace, Name: gardenletdeployer.GardenletDefaultKubeconfigSecretName}, &corev1.Secret{}); err != nil {
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: gardenletdeployer.GardenletDefaultKubeconfigSecretName}, &corev1.Secret{}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return false, fmt.Errorf("failed checking if gardenlet's kubeconfig secret already exists: %w", err)
 		}

--- a/pkg/gardenadm/cmd/gardenlet.go
+++ b/pkg/gardenadm/cmd/gardenlet.go
@@ -8,12 +8,13 @@ import (
 	"context"
 	"fmt"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
 )
 
 // IsGardenletDeployed indicates whether gardenlet is running in the shoot cluster.

--- a/pkg/gardenadm/cmd/gardenlet_test.go
+++ b/pkg/gardenadm/cmd/gardenlet_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/gardenadm/cmd"
+)
+
+var _ = Describe("IsGardenletDeployed", func() {
+	var (
+		ctx       = context.Background()
+		c         client.Client
+		namespace = "foo"
+	)
+
+	BeforeEach(func() {
+		c = fake.NewClientBuilder().Build()
+	})
+
+	When("gardenlet deployment does not exist", func() {
+		It("should return false if no error occurs", func() {
+			deployed, err := cmd.IsGardenletDeployed(ctx, c, namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployed).To(BeFalse())
+		})
+	})
+
+	When("gardenlet deployment exists", func() {
+		BeforeEach(func() {
+			Expect(c.Create(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gardenlet", Namespace: namespace}})).NotTo(HaveOccurred())
+		})
+
+		When("kubeconfig secret does not exist", func() {
+			It("should return false if the kubeconfig secret does not exist", func() {
+				deployed, err := cmd.IsGardenletDeployed(ctx, c, namespace)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(deployed).To(BeFalse())
+			})
+		})
+
+		When("kubeconfig secret exists", func() {
+			BeforeEach(func() {
+				Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "gardenlet-kubeconfig", Namespace: namespace}})).NotTo(HaveOccurred())
+			})
+
+			It("should return true if both deployment and kubeconfig secret exist", func() {
+				deployed, err := cmd.IsGardenletDeployed(ctx, c, namespace)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(deployed).To(BeTrue())
+			})
+		})
+	})
+})

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -516,6 +516,21 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*botanist.Garden
 
 	if kubeconfigFileExists {
 		b.Logger.Info("Found existing kubeconfig file, skipping initialization of control plane", "path", botanist.PathKubeconfig)
+
+		if opts.Force {
+			b.Logger.Info("Force flag is set, skipping check for existing gardenlet deployment in shoot control plane namespace")
+		} else {
+			clientSet, err := b.CreateClientSet(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed creating client set from existing kubeconfig file %s: %w", botanist.PathKubeconfig, err)
+			}
+
+			if gardenletExists, err := cmd.IsGardenletDeployed(ctx, clientSet.Client(), b.Shoot.ControlPlaneNamespace); err != nil {
+				return nil, fmt.Errorf("failed checking if gardenlet is already deployed: %w", err)
+			} else if gardenletExists {
+				return nil, fmt.Errorf("found existing gardenlet deployment in shoot control plane namespace %s, aborting initialization", b.Shoot.ControlPlaneNamespace)
+			}
+		}
 	}
 
 	var (

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -21,6 +21,8 @@ type Options struct {
 	*cmd.Options
 	cmd.ManifestOptions
 
+	// Force forces the execution of the init command, even if the control plane is already initialized (default: false).
+	Force bool
 	// UseBootstrapEtcd indicates whether to use the bootstrap etcd instead of transitioning to etcd-druid
 	// (default: false). This helps `gardenadm init` to run faster.
 	UseBootstrapEtcd bool
@@ -93,4 +95,5 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.UseBootstrapEtcd, "use-bootstrap-etcd", false, "If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This can be useful for testing purposes to save time.")
 	fs.BoolVar(&o.UseHostNetwork, "use-host-network", false, "If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.")
 	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
+	fs.BoolVar(&o.Force, "force", false, "If set, the init command will be executed even if the control plane is already initialized.")
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Prevent `gardenadm init` with `gardenlet` running.

As discussed in https://github.com/gardener/hackathon/issues/45#issuecomment-4423399104, it makes sense to prevent `gardenadm init` if the self-hosted shoot cluster already has `gardenlet` running. There is a command line option to override the default behaviour.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:

/cc @rfranzke @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
