### PR TITLE
[GEP-28] Forbid impossible scenarios for self-hosted shoot clusters via validation

### DIFF
--- a/pkg/api/core/helper/shoot.go
+++ b/pkg/api/core/helper/shoot.go
@@ -316,6 +316,11 @@ func IsShootSelfHosted(workers []core.Worker) bool {
 	})
 }
 
+// HasManagedInfrastructure returns true if the shoot's infrastructure (network, machines, etc.) is managed by Gardener.
+func HasManagedInfrastructure(shoot *core.Shoot) bool {
+	return shoot.Spec.CredentialsBindingName != nil || shoot.Spec.SecretBindingName != nil
+}
+
 // ControlPlaneWorkerPoolForShoot returns the worker pool running the control plane in case the shoot is self-hosted.
 func ControlPlaneWorkerPoolForShoot(workers []core.Worker) *core.Worker {
 	if idx := slices.IndexFunc(workers, func(worker core.Worker) bool {

--- a/pkg/api/core/helper/shoot_test.go
+++ b/pkg/api/core/helper/shoot_test.go
@@ -709,6 +709,23 @@ var _ = Describe("Helper", func() {
 		})
 	})
 
+	Describe("#HasManagedInfrastructure", func() {
+		It("should return false when both CredentialsBindingName and SecretBindingName are nil", func() {
+			shoot := &core.Shoot{Spec: core.ShootSpec{CredentialsBindingName: nil, SecretBindingName: nil}}
+			Expect(HasManagedInfrastructure(shoot)).To(BeFalse())
+		})
+
+		It("should return true when CredentialsBindingName is set", func() {
+			shoot := &core.Shoot{Spec: core.ShootSpec{CredentialsBindingName: new("binding")}}
+			Expect(HasManagedInfrastructure(shoot)).To(BeTrue())
+		})
+
+		It("should return true when SecretBindingName is set", func() {
+			shoot := &core.Shoot{Spec: core.ShootSpec{SecretBindingName: new("binding")}}
+			Expect(HasManagedInfrastructure(shoot)).To(BeTrue())
+		})
+	})
+
 	Describe("#ControlPlaneWorkerPoolForShoot", func() {
 		It("should return nil because shoot has no workers", func() {
 			shoot := &core.Shoot{}

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -3186,6 +3186,7 @@ func validateShootOperation(operations, maintenanceOperations []string, shoot *c
 		allErrs            = field.ErrorList{}
 		encryptedResources = sets.New[schema.GroupResource]()
 		k8sLess134         = versionutils.ConstraintK8sLess134.CheckVersion(shoot.Spec.Kubernetes.Version)
+		isSelfHosted       = helper.IsShootSelfHosted(shoot.Spec.Provider.Workers)
 	)
 
 	if len(operations) == 0 && len(maintenanceOperations) == 0 {
@@ -3197,6 +3198,8 @@ func validateShootOperation(operations, maintenanceOperations []string, shoot *c
 			return append(allErrs, field.NotSupported(fldPathOp, op, sets.List(availableShootOperations)))
 		} else if len(operations) > 1 && !availableShootOperationsToRunInParallel.Has(op) && !strings.HasPrefix(op, v1beta1constants.OperationRotateRolloutWorkers) && !strings.HasPrefix(op, v1beta1constants.OperationRolloutWorkers) {
 			return append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted to be run in parallel with other operations", op)))
+		} else if isSelfHosted && !helper.HasManagedInfrastructure(shoot) && (strings.HasPrefix(op, v1beta1constants.OperationRotateRolloutWorkers) || strings.HasPrefix(op, v1beta1constants.OperationRolloutWorkers)) {
+			return append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters without managed infrastructure", op)))
 		}
 	}
 
@@ -3205,6 +3208,8 @@ func validateShootOperation(operations, maintenanceOperations []string, shoot *c
 			return append(allErrs, field.NotSupported(fldPathMaintOp, op, sets.List(availableShootOperations)))
 		} else if len(maintenanceOperations) > 1 && !availableShootOperationsToRunInParallel.Has(op) && !strings.HasPrefix(op, v1beta1constants.OperationRotateRolloutWorkers) && !strings.HasPrefix(op, v1beta1constants.OperationRolloutWorkers) {
 			return append(allErrs, field.Forbidden(fldPathMaintOp, fmt.Sprintf("operation '%s' is not permitted to be run in parallel with other operations", op)))
+		} else if isSelfHosted && !helper.HasManagedInfrastructure(shoot) && (strings.HasPrefix(op, v1beta1constants.OperationRotateRolloutWorkers) || strings.HasPrefix(op, v1beta1constants.OperationRolloutWorkers)) {
+			return append(allErrs, field.Forbidden(fldPathMaintOp, fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters without managed infrastructure", op)))
 		}
 	}
 

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -336,7 +336,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, opts shootV
 	allErrs = append(allErrs, validateNetworking(spec.Networking, workerless, fldPath.Child("networking"))...)
 	allErrs = append(allErrs, validateMaintenance(spec.Maintenance, fldPath.Child("maintenance"), workerless)...)
 	allErrs = append(allErrs, validateMonitoring(spec.Monitoring, fldPath.Child("monitoring"))...)
-	allErrs = append(allErrs, ValidateHibernation(meta.Annotations, spec.Hibernation, fldPath.Child("hibernation"))...)
+	allErrs = append(allErrs, ValidateHibernation(meta.Annotations, spec.Hibernation, helper.IsShootSelfHosted(spec.Provider.Workers), fldPath.Child("hibernation"))...)
 
 	if len(spec.Region) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "must specify a region"))
@@ -2880,11 +2880,15 @@ func ValidateSystemComponentWorkers(workers []core.Worker, fldPath *field.Path) 
 }
 
 // ValidateHibernation validates a Hibernation object.
-func ValidateHibernation(annotations map[string]string, hibernation *core.Hibernation, fldPath *field.Path) field.ErrorList {
+func ValidateHibernation(annotations map[string]string, hibernation *core.Hibernation, isSelfHosted bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if hibernation == nil {
 		return allErrs
+	}
+
+	if isSelfHosted {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "hibernation is not supported for self-hosted shoots"))
 	}
 
 	for _, op := range v1beta1helper.GetShootMaintenanceOperations(annotations) {

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -2888,7 +2888,7 @@ func ValidateHibernation(annotations map[string]string, hibernation *core.Hibern
 	}
 
 	if isSelfHosted {
-		allErrs = append(allErrs, field.Forbidden(fldPath, "hibernation is not supported for self-hosted shoots"))
+		return append(allErrs, field.Forbidden(fldPath, "hibernation is not supported for self-hosted shoots"))
 	}
 
 	for _, op := range v1beta1helper.GetShootMaintenanceOperations(annotations) {
@@ -3199,7 +3199,7 @@ func validateShootOperation(operations, maintenanceOperations []string, shoot *c
 		} else if len(operations) > 1 && !availableShootOperationsToRunInParallel.Has(op) && !strings.HasPrefix(op, v1beta1constants.OperationRotateRolloutWorkers) && !strings.HasPrefix(op, v1beta1constants.OperationRolloutWorkers) {
 			return append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted to be run in parallel with other operations", op)))
 		} else if isSelfHosted && !helper.HasManagedInfrastructure(shoot) && (strings.HasPrefix(op, v1beta1constants.OperationRotateRolloutWorkers) || strings.HasPrefix(op, v1beta1constants.OperationRolloutWorkers)) {
-			return append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters without managed infrastructure", op)))
+			return append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters with unmanaged infrastructure", op)))
 		}
 	}
 
@@ -3209,7 +3209,7 @@ func validateShootOperation(operations, maintenanceOperations []string, shoot *c
 		} else if len(maintenanceOperations) > 1 && !availableShootOperationsToRunInParallel.Has(op) && !strings.HasPrefix(op, v1beta1constants.OperationRotateRolloutWorkers) && !strings.HasPrefix(op, v1beta1constants.OperationRolloutWorkers) {
 			return append(allErrs, field.Forbidden(fldPathMaintOp, fmt.Sprintf("operation '%s' is not permitted to be run in parallel with other operations", op)))
 		} else if isSelfHosted && !helper.HasManagedInfrastructure(shoot) && (strings.HasPrefix(op, v1beta1constants.OperationRotateRolloutWorkers) || strings.HasPrefix(op, v1beta1constants.OperationRolloutWorkers)) {
-			return append(allErrs, field.Forbidden(fldPathMaintOp, fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters without managed infrastructure", op)))
+			return append(allErrs, field.Forbidden(fldPathMaintOp, fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters with unmanaged infrastructure", op)))
 		}
 	}
 

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -7589,7 +7589,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeForbidden),
 						"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
-						"Detail": ContainSubstring(fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters without managed infrastructure", forbiddenOp)),
+						"Detail": ContainSubstring(fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters with unmanaged infrastructure", forbiddenOp)),
 					}))))
 					delete(shoot.Annotations, "gardener.cloud/operation")
 
@@ -7597,7 +7597,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeForbidden),
 						"Field":  Equal("metadata.annotations[maintenance.gardener.cloud/operation]"),
-						"Detail": ContainSubstring(fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters without managed infrastructure", forbiddenOp)),
+						"Detail": ContainSubstring(fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters with unmanaged infrastructure", forbiddenOp)),
 					}))))
 					delete(shoot.Annotations, "maintenance.gardener.cloud/operation")
 				},

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -10111,6 +10111,34 @@ var _ = Describe("Shoot Validation Tests", func() {
 		})
 	})
 
+	Describe("#ValidateHibernation", func() {
+		DescribeTable("validate hibernation",
+			func(hibernation *core.Hibernation, annotations map[string]string, isSelfHosted bool, matcher gomegatypes.GomegaMatcher) {
+				Expect(ValidateHibernation(annotations, hibernation, isSelfHosted, nil)).To(matcher)
+			},
+			Entry("nil hibernation", nil, nil, false, BeEmpty()),
+			Entry("hosted hibernation", &core.Hibernation{Enabled: new(true)}, nil, false, BeEmpty()),
+			Entry("self-hosted hibernation", &core.Hibernation{Enabled: new(true)}, nil, true, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Detail": Equal("hibernation is not supported for self-hosted shoots"),
+			})))),
+			Entry("forbidden annotation", &core.Hibernation{Enabled: new(true)}, map[string]string{"maintenance.gardener.cloud/operation": "rotate-credentials-start"}, false, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Detail": Equal("shoot cannot be hibernated when maintenance.gardener.cloud/operation annotation contains rotate-credentials-start operation"),
+			})))),
+			Entry("multiple forbidden annotations", &core.Hibernation{Enabled: new(true)}, map[string]string{"maintenance.gardener.cloud/operation": "rotate-etcd-encryption-key;rotate-serviceaccount-key-start"}, false, ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Detail": Equal("shoot cannot be hibernated when maintenance.gardener.cloud/operation annotation contains rotate-etcd-encryption-key operation"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Detail": Equal("shoot cannot be hibernated when maintenance.gardener.cloud/operation annotation contains rotate-serviceaccount-key-start operation"),
+				})),
+			)),
+		)
+	})
+
 	Describe("#ValidateHibernationSchedules", func() {
 		DescribeTable("validate hibernation schedules",
 			func(schedules []core.HibernationSchedule, matcher gomegatypes.GomegaMatcher) {

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -7578,6 +7578,33 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))))
 				})
 			})
+
+			DescribeTable("forbid certain operations when shoot is self-hosted",
+				func(operation, forbiddenOp string) {
+					shoot.Namespace = "garden"
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					shoot.Spec.SecretBindingName = nil
+
+					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", operation)
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+						"Detail": ContainSubstring(fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters without managed infrastructure", forbiddenOp)),
+					}))))
+					delete(shoot.Annotations, "gardener.cloud/operation")
+
+					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", operation)
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("metadata.annotations[maintenance.gardener.cloud/operation]"),
+						"Detail": ContainSubstring(fmt.Sprintf("operation '%s' is not permitted for self-hosted shoot clusters without managed infrastructure", forbiddenOp)),
+					}))))
+					delete(shoot.Annotations, "maintenance.gardener.cloud/operation")
+				},
+
+				Entry("rotate-rollout-workers", "rotate-rollout-workers", "rotate-rollout-workers"),
+				Entry("rollout-workers", "rollout-workers", "rollout-workers"),
+			)
 		})
 
 		Context("scheduler name", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Forbid impossible scenarios for self-hosted shoot clusters via validation.

As discussed in https://github.com/gardener/hackathon/issues/45#issuecomment-4423399104, it makes sense to forbid hibernation in general for self-hosted shoot clusters and worker rollout operations for self-hosted shoot clusters with unmanaged infrastructure.

**Which issue(s) this PR fixes**:

Part of #2906 

**Special notes for your reviewer**:

/cc @rfranzke @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
