### PR TITLE
[GEP-28] Prepare `Shoot` controller to distinguish between hosted and self-hosted flows

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -420,13 +420,12 @@ func (g *garden) Start(ctx context.Context) error {
 						// Gardenlet does not have the required RBAC permissions for listing/watching the following
 						// resources on cluster level. Hence, we need to watch them individually with the help of a
 						// SingleObject cache.
-						&corev1.ConfigMap{}:                         kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ConfigMap{}),
-						&corev1.Secret{}:                            kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Secret{}),
-						&corev1.ServiceAccount{}:                    kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ServiceAccount{}),
-						&gardencorev1.ControllerDeployment{}:        kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1.ControllerDeployment{}),
-						&gardencorev1beta1.ControllerRegistration{}: kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1beta1.ControllerRegistration{}),
-						&corev1.Namespace{}:                         kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Namespace{}),
-						&gardencorev1beta1.Project{}:                kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1beta1.Project{}),
+						&corev1.ConfigMap{}:                  kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ConfigMap{}),
+						&corev1.Secret{}:                     kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Secret{}),
+						&corev1.ServiceAccount{}:             kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ServiceAccount{}),
+						&gardencorev1.ControllerDeployment{}: kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1.ControllerDeployment{}),
+						&corev1.Namespace{}:                  kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Namespace{}),
+						&gardencorev1beta1.Project{}:         kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1beta1.Project{}),
 					},
 					kubernetes.GardenScheme,
 				)(config, opts)

--- a/dev-setup/gind.sh
+++ b/dev-setup/gind.sh
@@ -56,7 +56,20 @@ case "$COMMAND" in
       if [[ "${FAST:-}" == "true" ]]; then
         GARDENADM_INIT_FLAGS="${GARDENADM_INIT_FLAGS:-} --use-bootstrap-etcd --use-host-network"
       fi
-      docker compose -f "$GIND_COMPOSE_FILE" exec machine-0 bash -c "gardenadm init -d /gardenadm/resources ${GARDENADM_INIT_FLAGS:-}"
+
+      # Skip `gardenadm init` if gardenlet is already running in the self-hosted shoot cluster (e.g., on a re-run of
+      # this script after a prior scenario reached level >= 4).Users can override this by passing `--force` via
+      # the `GARDENADM_INIT_FLAGS` env var.
+      skip_init=false
+      if [[ "${GARDENADM_INIT_FLAGS:-}" != *"--force"* ]] && \
+        docker compose -f "$GIND_COMPOSE_FILE" exec machine-0 bash -c 'kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system get deployment gardenlet' &>/dev/null; then
+        echo "gardenlet is already running in the self-hosted shoot cluster - skipping 'gardenadm init' (pass '--force' via GARDENADM_INIT_FLAGS to override)"
+        skip_init=true
+      fi
+      if [[ "$skip_init" == "false" ]]; then
+        docker compose -f "$GIND_COMPOSE_FILE" exec machine-0 bash -c "gardenadm init -d /gardenadm/resources ${GARDENADM_INIT_FLAGS:-}"
+      fi
+
       ./hack/usage/generate-kubeconfig.sh self-hosted-shoot --docker gind-machine-0 > "$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER"
     fi
 

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -210,7 +210,9 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 			)
 
 		case controllerRegistrationResource:
-			return requestAuthorizer.CheckRead(graph.VertexTypeControllerRegistration, attrs)
+			return requestAuthorizer.Check(graph.VertexTypeControllerRegistration, attrs,
+				authwebhook.WithAlwaysAllowedVerbs("get", "list", "watch"),
+			)
 
 		case eventCoreResource, eventResource:
 			return a.authorizeEvent(log, attrs)

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -940,16 +940,12 @@ var _ = Describe("Shoot", func() {
 			})
 
 			When("requested for ControllerRegistrations", func() {
-				var (
-					name  string
-					attrs *auth.AttributesRecord
-				)
+				var attrs *auth.AttributesRecord
 
 				BeforeEach(func() {
-					name = "foo"
 					attrs = &auth.AttributesRecord{
 						User:            gardenletUser,
-						Name:            name,
+						Name:            "foo",
 						APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
 						Resource:        "controllerregistrations",
 						ResourceRequest: true,
@@ -957,11 +953,10 @@ var _ = Describe("Shoot", func() {
 					}
 				})
 
-				DescribeTable("should return correct result if path exists",
+				DescribeTable("should allow without consulting the graph",
 					func(verb string) {
 						attrs.Verb = verb
 
-						graph.EXPECT().HasPathFrom(graphutils.VertexTypeControllerRegistration, "", name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(true)
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionAllow))
@@ -972,6 +967,16 @@ var _ = Describe("Shoot", func() {
 					Entry("list", "list"),
 					Entry("watch", "watch"),
 				)
+
+				It("should allow list/watch without resource name", func() {
+					attrs.Name = ""
+					attrs.Verb = "list"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
 
 				DescribeTable("should have no opinion because no allowed verb", func(verb string) {
 					attrs.Verb = verb
@@ -988,16 +993,6 @@ var _ = Describe("Shoot", func() {
 					Entry("deletecollection", "deletecollection"),
 				)
 
-				It("should have no opinion because path to shoot does not exist", func() {
-					graph.EXPECT().HasPathFrom(graphutils.VertexTypeControllerRegistration, "", name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
-
-					decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-					Expect(err).NotTo(HaveOccurred())
-					Expect(decision).To(Equal(auth.DecisionNoOpinion))
-					Expect(reason).To(ContainSubstring("no relationship found"))
-				})
-
 				It("should have no opinion because request is for a subresource", func() {
 					attrs.Subresource = "status"
 
@@ -1006,16 +1001,6 @@ var _ = Describe("Shoot", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(decision).To(Equal(auth.DecisionNoOpinion))
 					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: []"))
-				})
-
-				It("should have no opinion because no resource name is given", func() {
-					attrs.Name = ""
-
-					decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-					Expect(err).NotTo(HaveOccurred())
-					Expect(decision).To(Equal(auth.DecisionNoOpinion))
-					Expect(reason).To(ContainSubstring("No Object name found"))
 				})
 			})
 

--- a/pkg/component/garden/system/virtual/virtual.go
+++ b/pkg/component/garden/system/virtual/virtual.go
@@ -340,6 +340,7 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 					APIGroups: []string{gardencorev1beta1.GroupName},
 					Resources: []string{
 						"cloudprofiles",
+						"controllerregistrations",
 						"exposureclasses",
 						"seeds",
 					},

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -360,6 +360,7 @@ var _ = Describe("Virtual", func() {
 					APIGroups: []string{"core.gardener.cloud"},
 					Resources: []string{
 						"cloudprofiles",
+						"controllerregistrations",
 						"exposureclasses",
 						"seeds",
 					},

--- a/pkg/gardenadm/botanist/botanist_test.go
+++ b/pkg/gardenadm/botanist/botanist_test.go
@@ -81,7 +81,7 @@ metadata:
 
 					Expect(b.Shoot.GetInfo().Status.LastOperation).NotTo(BeNil())
 					Expect(b.Shoot.GetInfo().Status.LastOperation.Type).To(Equal(gardencorev1beta1.LastOperationTypeRestore))
-					Expect(b.IsRestorePhase()).To(BeTrue())
+					Expect(b.Shoot.IsRestorePhase()).To(BeTrue())
 				})
 			})
 
@@ -108,7 +108,7 @@ metadata:
 
 					Expect(b.Shoot.GetInfo().Status.LastOperation.Type).To(Equal(gardencorev1beta1.LastOperationTypeRestore))
 					Expect(b.Shoot.GetShootState().Name).To(Equal("gardenadm"))
-					Expect(b.IsRestorePhase()).To(BeTrue())
+					Expect(b.Shoot.IsRestorePhase()).To(BeTrue())
 				})
 			})
 

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -554,7 +554,7 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*gardenadmbotani
 		initializeSecretsManagement = g.Add(flow.Task{
 			Name:   "Initializing secrets management",
 			Fn:     b.InitializeSecretsManagement,
-			SkipIf: kubeconfigFileExists && !b.IsRestorePhase(),
+			SkipIf: kubeconfigFileExists && !b.Shoot.IsRestorePhase(),
 		})
 		writeKubeletBootstrapKubeconfig = g.Add(flow.Task{
 			Name:         "Writing kubelet bootstrap kubeconfig with a fake token to disk to make kubelet start",
@@ -573,7 +573,7 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*gardenadmbotani
 			Fn: func(ctx context.Context) error {
 				return b.PersistBootstrapSecrets(ctx, opts.ConfigDir)
 			},
-			SkipIf:       b.IsRestorePhase(),
+			SkipIf:       b.Shoot.IsRestorePhase(),
 			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfigSecretForNodeAgent),
 		})
 		applyOperatingSystemConfig = g.Add(flow.Task{
@@ -598,7 +598,7 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*gardenadmbotani
 				}
 				return b.CleanupBootstrapSecrets(opts.ConfigDir)
 			},
-			SkipIf:       kubeconfigFileExists && !b.IsRestorePhase(),
+			SkipIf:       kubeconfigFileExists && !b.Shoot.IsRestorePhase(),
 			Dependencies: flow.NewTaskIDs(persistBootstrapSecrets, initializeClientSet),
 		})
 	)

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -590,16 +590,20 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*gardenadmbotani
 			}).RetryUntilTimeout(2*time.Second, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(applyOperatingSystemConfig),
 		})
-		_ = g.Add(flow.Task{
+		importSecrets = g.Add(flow.Task{
 			Name: "Importing secrets into control plane",
 			Fn: func(ctx context.Context) error {
-				if err := b.MigrateSecrets(ctx, b.SeedClientSet.Client(), clientSet.Client()); err != nil {
-					return err
-				}
-				return b.CleanupBootstrapSecrets(opts.ConfigDir)
+				return b.MigrateSecrets(ctx, b.SeedClientSet.Client(), clientSet.Client())
 			},
 			SkipIf:       kubeconfigFileExists && !b.Shoot.IsRestorePhase(),
 			Dependencies: flow.NewTaskIDs(persistBootstrapSecrets, initializeClientSet),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Deleting temporary ShootState containing bootstrap secrets",
+			Fn: func(_ context.Context) error {
+				return b.CleanupBootstrapSecrets(opts.ConfigDir)
+			},
+			Dependencies: flow.NewTaskIDs(importSecrets),
 		})
 	)
 

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -306,7 +306,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Name: "Waiting until required extensions are ready",
 			Fn: func(ctx context.Context) error {
 				return retry.UntilTimeout(ctx, 5*time.Second, time.Minute, func(ctx context.Context) (done bool, err error) {
-					if err := gardenerutils.RequiredExtensionsReady(ctx, r.GardenClient, seed.GetInfo().Name, gardenerutils.ComputeRequiredExtensionsForSeed(seed.GetInfo(), controllerRegistrationList)); err != nil {
+					if err := gardenerutils.RequiredExtensionsReady(ctx, r.GardenClient, seed.GetInfo(), nil, gardenerutils.ComputeRequiredExtensionsForSeed(seed.GetInfo(), controllerRegistrationList)); err != nil {
 						return retry.MinorError(err)
 					}
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -208,7 +208,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 						return err
 					}
 				}
-				return removeTaskAnnotation(ctx, o, generation, v1beta1constants.ShootTaskDeployInfrastructure)
+				return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskDeployInfrastructure)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployInfrastructure),
@@ -235,7 +235,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				if err := botanist.DeployOrDestroyInternalDNSRecord(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, o, generation, v1beta1constants.ShootTaskDeployDNSRecordInternal)
+				return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskDeployDNSRecordInternal)
 			}),
 			SkipIf:       o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
@@ -246,7 +246,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				if err := botanist.DeployOrDestroyExternalDNSRecord(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, o, generation, v1beta1constants.ShootTaskDeployDNSRecordExternal)
+				return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskDeployDNSRecordExternal)
 			}),
 			SkipIf:       o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
@@ -657,7 +657,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 					return err
 				}
 				if controllerutils.HasTask(o.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartCoreAddons) {
-					return removeTaskAnnotation(ctx, o, generation, v1beta1constants.ShootTaskRestartCoreAddons)
+					return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskRestartCoreAddons)
 				}
 				return nil
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -1052,7 +1052,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				if err := botanist.RestartControlPlanePods(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, o, generation, v1beta1constants.ShootTaskRestartControlPlanePods)
+				return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskRestartControlPlanePods)
 			}),
 			SkipIf:       !requestControlPlanePodsRestart,
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager, deployControlPlane),
@@ -1107,19 +1107,19 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	return nil
 }
 
-func removeTaskAnnotation(ctx context.Context, o *operation.Operation, generation int64, tasksToRemove ...string) error {
+func removeTaskAnnotation(ctx context.Context, b *botanistpkg.Botanist, tasksToRemove ...string) error {
 	// Check if shoot generation was changed mid-air, i.e., whether we need to wait for the next reconciliation until we
 	// can safely remove the task annotations to ensure all required tasks are executed.
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := o.GardenClient.Get(ctx, client.ObjectKeyFromObject(o.Shoot.GetInfo()), shoot); err != nil {
+	if err := b.GardenClient.Get(ctx, client.ObjectKeyFromObject(b.Shoot.GetInfo()), shoot); err != nil {
 		return err
 	}
 
-	if shoot.Generation != generation {
+	if shoot.Generation != b.Shoot.GetInfo().Generation {
 		return nil
 	}
 
-	return o.Shoot.UpdateInfo(ctx, o.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
+	return b.Shoot.UpdateInfo(ctx, b.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
 		controllerutils.RemoveTasks(shoot.Annotations, tasksToRemove...)
 		return nil
 	})

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -87,7 +87,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	}
 
 	var (
-		botanist     *botanistpkg.Botanist
+		b            *botanistpkg.Botanist
 		worker       *extensionsv1alpha1.Worker
 		errorContext = errors.NewErrorContext(fmt.Sprintf("Shoot cluster %s", utils.IifString(flowCtx.isRestoring, "restoration", "reconciliation")), tasksWithErrors)
 	)
@@ -100,7 +100,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		nil,
 		errors.ToExecute("Create botanist", func() error {
 			return retryutils.UntilTimeout(ctx, 10*time.Second, 10*time.Minute, func(context.Context) (done bool, err error) {
-				botanist, err = botanistpkg.New(ctx, o)
+				b, err = botanistpkg.New(ctx, o)
 				if err != nil {
 					return retryutils.MinorError(err)
 				}
@@ -108,18 +108,18 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			})
 		}),
 		errors.ToExecute("Check required extensions", func() error {
-			return botanist.WaitUntilRequiredExtensionsReady(ctx)
+			return b.WaitUntilRequiredExtensionsReady(ctx)
 		}),
 		errors.ToExecute("Check if copy of backups is required", func() error {
 			var err error
-			flowCtx.isCopyOfBackupsRequired, err = botanist.IsCopyOfBackupsRequired(ctx)
+			flowCtx.isCopyOfBackupsRequired, err = b.IsCopyOfBackupsRequired(ctx)
 			return err
 		}),
 		errors.ToExecute("Retrieve the Worker resource", func() error {
 			if o.Shoot.IsWorkerless {
 				return nil
 			}
-			obj, err := botanist.Shoot.Components.Extensions.Worker.Get(ctx)
+			obj, err := b.Shoot.Components.Extensions.Worker.Get(ctx)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					return nil
@@ -151,7 +151,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	}
 
 	if flowCtx.hasNodesCIDR {
-		if err := botanist.UpdateDualStackMigrationConditionIfNeeded(ctx); err != nil {
+		if err := b.UpdateDualStackMigrationConditionIfNeeded(ctx); err != nil {
 			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 		}
 		networks, err := shoot.ToNetworks(o.Shoot.GetInfo(), o.Shoot.IsWorkerless)
@@ -161,7 +161,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		o.Shoot.Networks = networks
 	}
 
-	if err := botanist.SetInPlaceUpdatePendingWorkers(ctx, worker); err != nil {
+	if err := b.SetInPlaceUpdatePendingWorkers(ctx, worker); err != nil {
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 	}
 
@@ -170,43 +170,43 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 
 		deployNamespace = g.Add(flow.Task{
 			Name: "Deploying Shoot namespace in Seed",
-			Fn:   flow.TaskFn(botanist.DeployControlPlaneNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:   flow.TaskFn(b.DeployControlPlaneNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
 		})
 		ensureShootClusterIdentity = g.Add(flow.Task{
 			Name:         "Ensuring Shoot cluster identity",
-			Fn:           flow.TaskFn(botanist.EnsureShootClusterIdentity).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.EnsureShootClusterIdentity).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		deployCloudProviderSecret = g.Add(flow.Task{
 			Name:         "Deploying cloud provider account secret",
-			Fn:           flow.TaskFn(botanist.DeployCloudProviderSecret).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployCloudProviderSecret).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		reconcileIstioInternalLoadbalancingConfigMap = g.Add(flow.Task{
 			Name:         "Reconcile Istio internal load balancing ConfigMap",
-			Fn:           flow.TaskFn(botanist.ReconcileIstioInternalLoadBalancingConfigMap).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.ReconcileIstioInternalLoadBalancingConfigMap).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		initializeSecretsManagement = g.Add(flow.Task{
 			Name:         "Initializing secrets management",
-			Fn:           flow.TaskFn(botanist.InitializeSecretsManagement).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.InitializeSecretsManagement).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace, reconcileIstioInternalLoadbalancingConfigMap),
 		})
 		initialValiDeployment = g.Add(flow.Task{
 			Name:         "Deploying initial shoot logging stack in Seed",
-			Fn:           flow.TaskFn(botanist.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       flowCtx.isHibernatingShootWithWorkers,
 			Dependencies: flow.NewTaskIDs(deployNamespace, initializeSecretsManagement),
 		})
 		deployReferencedResources = g.Add(flow.Task{
 			Name:         "Deploying referenced resources",
-			Fn:           flow.TaskFn(botanist.DeployReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		deployInfrastructure = g.Add(flow.Task{
 			Name:         "Deploying Shoot infrastructure",
-			Fn:           flow.TaskFn(botanist.DeployInfrastructure).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployInfrastructure).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, deployReferencedResources),
 		})
@@ -214,38 +214,38 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Name: "Waiting until shoot infrastructure has been reconciled",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				if !flowCtx.skipReadiness {
-					if err := botanist.WaitForInfrastructure(ctx); err != nil {
+					if err := b.WaitForInfrastructure(ctx); err != nil {
 						return err
 					}
 				}
-				return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskDeployInfrastructure)
+				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployInfrastructure)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployInfrastructure),
 		})
 		deployKubeAPIServerService = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes API server service in the Seed cluster",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServerService.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.Shoot.Components.ControlPlane.KubeAPIServerService.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootClusterIdentity, initializeSecretsManagement).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		waitUntilKubeAPIServerServiceIsReady = g.Add(flow.Task{
 			Name:         "Waiting until Kubernetes API server service in the Seed cluster has reported readiness",
-			Fn:           botanist.Shoot.Components.ControlPlane.KubeAPIServerService.Wait,
+			Fn:           b.Shoot.Components.ControlPlane.KubeAPIServerService.Wait,
 			SkipIf:       o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerService),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Ensuring advertised addresses for the Shoot",
-			Fn:           botanist.UpdateAdvertisedAddresses,
+			Fn:           b.UpdateAdvertisedAddresses,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilKubeAPIServerServiceIsReady),
 		})
 		deployInternalDomainDNSRecord = g.Add(flow.Task{
 			Name: "Deploying internal domain DNS record",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if err := botanist.DeployOrDestroyInternalDNSRecord(ctx); err != nil {
+				if err := b.DeployOrDestroyInternalDNSRecord(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskDeployDNSRecordInternal)
+				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployDNSRecordInternal)
 			}),
 			SkipIf:       o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
@@ -253,95 +253,95 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name: "Deploying external domain DNS record",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if err := botanist.DeployOrDestroyExternalDNSRecord(ctx); err != nil {
+				if err := b.DeployOrDestroyExternalDNSRecord(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskDeployDNSRecordExternal)
+				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployDNSRecordExternal)
 			}),
 			SkipIf:       o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
 		})
 		deploySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Deploying source backup entry",
-			Fn:           botanist.DeploySourceBackupEntry,
+			Fn:           b.DeploySourceBackupEntry,
 			SkipIf:       !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		waitUntilSourceBackupEntryInGardenReconciled = g.Add(flow.Task{
 			Name:         "Waiting until the source backup entry has been reconciled",
-			Fn:           botanist.Shoot.Components.SourceBackupEntry.Wait,
+			Fn:           b.Shoot.Components.SourceBackupEntry.Wait,
 			SkipIf:       flowCtx.skipReadiness || !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(deploySourceBackupEntry),
 		})
 		deployBackupEntryInGarden = g.Add(flow.Task{
 			Name:         "Deploying backup entry",
-			Fn:           botanist.DeployBackupEntry,
+			Fn:           b.DeployBackupEntry,
 			SkipIf:       !flowCtx.allowBackup,
 			Dependencies: flow.NewTaskIDs(deployNamespace, waitUntilSourceBackupEntryInGardenReconciled),
 		})
 		waitUntilBackupEntryInGardenReconciled = g.Add(flow.Task{
 			Name:         "Waiting until the backup entry has been reconciled",
-			Fn:           botanist.Shoot.Components.BackupEntry.Wait,
+			Fn:           b.Shoot.Components.BackupEntry.Wait,
 			SkipIf:       flowCtx.skipReadiness || !flowCtx.allowBackup,
 			Dependencies: flow.NewTaskIDs(deployBackupEntryInGarden),
 		})
 		copyEtcdBackups = g.Add(flow.Task{
 			Name:         "Copying etcd backups to new seed's backup bucket",
-			Fn:           botanist.DeployEtcdCopyBackupsTask,
+			Fn:           b.DeployEtcdCopyBackupsTask,
 			SkipIf:       !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilBackupEntryInGardenReconciled, waitUntilSourceBackupEntryInGardenReconciled),
 		})
 		waitUntilEtcdBackupsCopied = g.Add(flow.Task{
 			Name:         "Waiting until etcd backups are copied",
-			Fn:           botanist.Shoot.Components.ControlPlane.EtcdCopyBackupsTask.Wait,
+			Fn:           b.Shoot.Components.ControlPlane.EtcdCopyBackupsTask.Wait,
 			SkipIf:       flowCtx.skipReadiness || !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(copyEtcdBackups),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying copy etcd backups task resource",
-			Fn:           botanist.Shoot.Components.ControlPlane.EtcdCopyBackupsTask.Destroy,
+			Fn:           b.Shoot.Components.ControlPlane.EtcdCopyBackupsTask.Destroy,
 			SkipIf:       !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(waitUntilEtcdBackupsCopied),
 		})
 		deployETCD = g.Add(flow.Task{
 			Name:         "Deploying main and events etcd",
-			Fn:           flow.TaskFn(botanist.DeployEtcd).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(o.Shoot, defaultTimeout)),
+			Fn:           flow.TaskFn(b.DeployEtcd).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(o.Shoot, defaultTimeout)),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilBackupEntryInGardenReconciled, waitUntilEtcdBackupsCopied),
 		})
 		destroySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Destroying source backup entry",
-			Fn:           botanist.DestroySourceBackupEntry,
-			SkipIf:       !flowCtx.allowBackup || !botanist.Shoot.IsRestorePhase(),
+			Fn:           b.DestroySourceBackupEntry,
+			SkipIf:       !flowCtx.allowBackup || !b.Shoot.IsRestorePhase(),
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until source backup entry has been deleted",
-			Fn:           botanist.Shoot.Components.SourceBackupEntry.WaitCleanup,
-			SkipIf:       !flowCtx.allowBackup || flowCtx.skipReadiness || !botanist.Shoot.IsRestorePhase(),
+			Fn:           b.Shoot.Components.SourceBackupEntry.WaitCleanup,
+			SkipIf:       !flowCtx.allowBackup || flowCtx.skipReadiness || !b.Shoot.IsRestorePhase(),
 			Dependencies: flow.NewTaskIDs(destroySourceBackupEntry),
 		})
 		waitUntilEtcdReady = g.Add(flow.Task{
 			Name:         "Waiting until main and event etcd report readiness",
-			Fn:           botanist.WaitUntilEtcdsReady,
+			Fn:           b.WaitUntilEtcdsReady,
 			SkipIf:       (!flowCtx.isRestoringHAControlPlane && o.Shoot.HibernationEnabled) || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
 		deployExtensionResourcesBeforeKAPI = g.Add(flow.Task{
 			Name:         "Deploying extension resources before kube-apiserver",
-			Fn:           flow.TaskFn(botanist.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, deployReferencedResources, waitUntilInfrastructureReady),
 		})
 		waitUntilExtensionResourcesBeforeKAPIReady = g.Add(flow.Task{
 			Name:         "Waiting until extension resources handled before kube-apiserver are ready",
-			Fn:           botanist.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
+			Fn:           b.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
 			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesBeforeKAPI),
 		})
 		deployKubeAPIServer = g.Add(flow.Task{
 			Name: "Deploying Kubernetes API server",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.DeployKubeAPIServer(ctx)
+				return b.DeployKubeAPIServer(ctx)
 			}).RetryUntilTimeout(defaultInterval, flowCtx.deployKubeAPIServerTaskTimeout),
 			Dependencies: flow.NewTaskIDs(
 				initializeSecretsManagement,
@@ -353,35 +353,35 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		waitUntilKubeAPIServerIsReady = g.Add(flow.Task{
 			Name:         "Waiting until Kubernetes API server rolled out",
-			Fn:           botanist.Shoot.Components.ControlPlane.KubeAPIServer.Wait,
+			Fn:           b.Shoot.Components.ControlPlane.KubeAPIServer.Wait,
 			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServer),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes API server service SNI settings in the Seed cluster",
-			Fn:           flow.TaskFn(botanist.DeployKubeAPIServerSNI).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployKubeAPIServerSNI).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
 		})
 		scaleEtcdAfterRestore = g.Add(flow.Task{
 			Name:         "Scaling main and events etcd after kube-apiserver is ready",
-			Fn:           flow.TaskFn(botanist.ScaleUpETCD).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(o.Shoot, defaultTimeout)),
+			Fn:           flow.TaskFn(b.ScaleUpETCD).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(o.Shoot, defaultTimeout)),
 			SkipIf:       !flowCtx.isRestoringHAControlPlane,
 			Dependencies: flow.NewTaskIDs(waitUntilEtcdReady, waitUntilKubeAPIServerIsReady),
 		})
 		waitUntilEtcdScaledAfterRestore = g.Add(flow.Task{
 			Name:         "Waiting until main and events etcd scaled up after kube-apiserver is ready",
-			Fn:           flow.TaskFn(botanist.WaitUntilEtcdsReady),
+			Fn:           flow.TaskFn(b.WaitUntilEtcdsReady),
 			SkipIf:       !flowCtx.isRestoringHAControlPlane || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(scaleEtcdAfterRestore),
 		})
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name:         "Deploying gardener-resource-manager",
-			Fn:           flow.TaskFn(botanist.DeployGardenerResourceManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployGardenerResourceManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
 		})
 		waitUntilGardenerResourceManagerReady = g.Add(flow.Task{
 			Name:         "Waiting until gardener-resource-manager reports readiness",
-			Fn:           botanist.Shoot.Components.ControlPlane.ResourceManager.Wait,
+			Fn:           b.Shoot.Components.ControlPlane.ResourceManager.Wait,
 			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
@@ -401,50 +401,50 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		deployControlPlane = g.Add(flow.Task{
 			Name:         "Deploying shoot control plane components",
-			Fn:           flow.TaskFn(botanist.DeployControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
 		waitUntilControlPlaneReady = g.Add(flow.Task{
 			Name: "Waiting until shoot control plane has been reconciled",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.Extensions.ControlPlane.Wait(ctx)
+				return b.Shoot.Components.Extensions.ControlPlane.Wait(ctx)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployControlPlane),
 		})
 		deployShootNamespaces = g.Add(flow.Task{
 			Name:         "Deploying shoot namespaces system component",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.SystemComponents.Namespaces.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.Shoot.Components.SystemComponents.Namespaces.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
 		waitUntilShootNamespacesReady = g.Add(flow.Task{
 			Name:         "Waiting until shoot namespaces have been reconciled",
-			Fn:           botanist.Shoot.Components.SystemComponents.Namespaces.Wait,
+			Fn:           b.Shoot.Components.SystemComponents.Namespaces.Wait,
 			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, deployShootNamespaces),
 		})
 		deployVPNSeedServer = g.Add(flow.Task{
 			Name:         "Deploying vpn-seed-server",
-			Fn:           flow.TaskFn(botanist.DeployVPNServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployVPNServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployNamespace, waitUntilGardenerResourceManagerReady),
 		})
 		deployGardenerAccess = g.Add(flow.Task{
 			Name:         "Deploying Gardener shoot access resources",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.GardenerAccess.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.Shoot.Components.GardenerAccess.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		initializeShootClients = g.Add(flow.Task{
 			Name:         "Initializing connection to Shoot",
-			Fn:           flow.TaskFn(botanist.InitializeDesiredShootClients).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(b.InitializeDesiredShootClients).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployGardenerAccess),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Sync public service account signing keys to Garden cluster",
-			Fn:   botanist.SyncPublicServiceAccountKeys,
+			Fn:   b.SyncPublicServiceAccountKeys,
 			SkipIf: o.Shoot.HibernationEnabled ||
-				!v1beta1helper.HasManagedIssuer(botanist.Shoot.GetInfo()),
+				!v1beta1helper.HasManagedIssuer(b.Shoot.GetInfo()),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
 		rewriteResourcesAddLabel = g.Add(flow.Task{
@@ -461,7 +461,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		snapshotETCD = g.Add(flow.Task{
 			Name: "Snapshotting ETCD after modification of encryption config or resources are re-encrypted with new ETCD encryption key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, o.SeedClientSet.Client(), botanist.SnapshotEtcd, o.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer)
+				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, o.SeedClientSet.Client(), b.SnapshotEtcd, o.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer)
 			}),
 			SkipIf: !flowCtx.allowBackup || o.Shoot.HibernationEnabled ||
 				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
@@ -521,31 +521,31 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployKubeScheduler = g.Add(flow.Task{
 			Name: "Deploying Kubernetes scheduler",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.ControlPlane.KubeScheduler.Deploy(ctx)
+				return b.Shoot.Components.ControlPlane.KubeScheduler.Deploy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Reconciling Kubernetes vertical pod autoscaler",
-			Fn:           flow.TaskFn(botanist.DeployVerticalPodAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployVerticalPodAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying dependency-watchdog shoot access resources",
-			Fn:           flow.TaskFn(botanist.DeployDependencyWatchdogAccess).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployDependencyWatchdogAccess).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		deployKubeControllerManager = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes controller manager",
-			Fn:           flow.TaskFn(botanist.DeployKubeControllerManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployKubeControllerManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilGardenerResourceManagerReady),
 		})
 		waitUntilKubeControllerManagerReady = g.Add(flow.Task{
 			Name: "Waiting until kube-controller-manager reports readiness",
-			Fn:   botanist.Shoot.Components.ControlPlane.KubeControllerManager.Wait,
+			Fn:   b.Shoot.Components.ControlPlane.KubeControllerManager.Wait,
 			SkipIf: flowCtx.skipReadiness || !sets.New(
 				gardencorev1beta1.RotationPreparing,
 				gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
@@ -573,31 +573,31 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		deleteBastions = g.Add(flow.Task{
 			Name:         "Deleting Bastions",
-			Fn:           botanist.DeleteBastions,
+			Fn:           b.DeleteBastions,
 			SkipIf:       flowCtx.shootSSHAccessEnabled,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady),
 		})
 		deployExtensionResourcesAfterKAPI = g.Add(flow.Task{
 			Name:         deployExtensionAfterKAPIMsg,
-			Fn:           flow.TaskFn(botanist.DeployExtensionsAfterKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployExtensionsAfterKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, initializeShootClients),
 		})
 		waitUntilExtensionResourcesAfterKAPIReady = g.Add(flow.Task{
 			Name:         waitExtensionAfterKAPIMsg,
-			Fn:           botanist.Shoot.Components.Extensions.Extension.WaitAfterKubeAPIServer,
+			Fn:           b.Shoot.Components.Extensions.Extension.WaitAfterKubeAPIServer,
 			SkipIf:       flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterKAPI),
 		})
 		deployOperatingSystemConfig = g.Add(flow.Task{
 			Name:         "Deploying operating system specific configuration for shoot workers",
-			Fn:           flow.TaskFn(botanist.DeployOperatingSystemConfig).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployOperatingSystemConfig).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady, deleteBastions, waitUntilExtensionResourcesAfterKAPIReady),
 		})
 		waitUntilOperatingSystemConfigReady = g.Add(flow.Task{
 			Name: "Waiting until operating system configurations for worker nodes have been reconciled",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.Extensions.OperatingSystemConfig.Wait(ctx)
+				return b.Shoot.Components.Extensions.OperatingSystemConfig.Wait(ctx)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfig),
@@ -605,7 +605,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deleteStaleOperatingSystemConfigResources = g.Add(flow.Task{
 			Name: "Delete stale operating system config resources",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.Extensions.OperatingSystemConfig.DeleteStaleResources(ctx)
+				return b.Shoot.Components.Extensions.OperatingSystemConfig.DeleteStaleResources(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfig),
@@ -613,21 +613,21 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name: "Waiting until stale operating system config resources are deleted",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.Extensions.OperatingSystemConfig.WaitCleanupStaleResources(ctx)
+				return b.Shoot.Components.Extensions.OperatingSystemConfig.WaitCleanupStaleResources(ctx)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deleteStaleOperatingSystemConfigResources),
 		})
 		deployNetwork = g.Add(flow.Task{
 			Name:         "Deploying shoot network plugin",
-			Fn:           flow.TaskFn(botanist.DeployNetwork).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployNetwork).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilGardenerResourceManagerReady, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		waitUntilNetworkIsReady = g.Add(flow.Task{
 			Name: "Waiting until shoot network plugin has been reconciled",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.Extensions.Network.Wait(ctx)
+				return b.Shoot.Components.Extensions.Network.Wait(ctx)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployNetwork),
@@ -635,7 +635,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name: "Check coreDNS migration",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.CheckDNSServiceMigration(ctx)
+				return b.CheckDNSServiceMigration(ctx)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilNetworkIsReady),
@@ -643,31 +643,31 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name: "Deploying shoot cluster identity",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.DeployClusterIdentity(ctx)
+				return b.DeployClusterIdentity(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
 		deployShootSystemResources = g.Add(flow.Task{
 			Name:   "Deploying shoot system resources",
-			Fn:     flow.TaskFn(botanist.DeployShootSystem).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:     flow.TaskFn(b.DeployShootSystem).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, waitUntilOperatingSystemConfigReady, waitUntilShootNamespacesReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Populating static manifests from seed to shoot",
-			Fn:           flow.TaskFn(botanist.PopulateStaticManifestsFromSeedToShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.PopulateStaticManifestsFromSeedToShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, waitUntilShootNamespacesReady),
 		})
 		deployCoreDNS = g.Add(flow.Task{
 			Name: "Deploying CoreDNS system component",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if err := botanist.DeployCoreDNS(ctx); err != nil {
+				if err := b.DeployCoreDNS(ctx); err != nil {
 					return err
 				}
 				if controllerutils.HasTask(o.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartCoreAddons) {
-					return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskRestartCoreAddons)
+					return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskRestartCoreAddons)
 				}
 				return nil
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -677,7 +677,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		deployNodeLocalDNS = g.Add(flow.Task{
 			Name:   "Reconcile node-local-dns system component",
-			Fn:     flow.TaskFn(botanist.ReconcileNodeLocalDNS),
+			Fn:     flow.TaskFn(b.ReconcileNodeLocalDNS),
 			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				deployGardenerResourceManager, initializeShootClients, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady, waitUntilNetworkIsReady),
@@ -685,7 +685,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployMetricsServer = g.Add(flow.Task{
 			Name: "Deploying metrics-server system component",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.SystemComponents.MetricsServer.Deploy(ctx)
+				return b.Shoot.Components.SystemComponents.MetricsServer.Deploy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
@@ -693,7 +693,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		deployVPNShoot = g.Add(flow.Task{
 			Name:   "Deploying vpn-shoot system component",
-			Fn:     flow.TaskFn(botanist.DeployVPNShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:     flow.TaskFn(b.DeployVPNShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, deployGardenerResourceManager, deployKubeScheduler, deployVPNSeedServer, waitUntilShootNamespacesReady),
@@ -701,7 +701,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployNodeProblemDetector = g.Add(flow.Task{
 			Name: "Deploying node-problem-detector system component",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.SystemComponents.NodeProblemDetector.Deploy(ctx)
+				return b.Shoot.Components.SystemComponents.NodeProblemDetector.Deploy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
@@ -709,7 +709,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		deployKubeProxy = g.Add(flow.Task{
 			Name:   "Deploying kube-proxy system component",
-			Fn:     flow.TaskFn(botanist.DeployKubeProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:     flow.TaskFn(b.DeployKubeProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || !flowCtx.kubeProxyEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				deployGardenerResourceManager, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
@@ -717,7 +717,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name: "Deleting stale kube-proxy DaemonSets",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.SystemComponents.KubeProxy.DeleteStaleResources(ctx)
+				return b.Shoot.Components.SystemComponents.KubeProxy.DeleteStaleResources(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || !flowCtx.kubeProxyEnabled,
 			Dependencies: flow.NewTaskIDs(deployKubeProxy),
@@ -725,21 +725,21 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name: "Deleting kube-proxy system component",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.SystemComponents.KubeProxy.Destroy(ctx)
+				return b.Shoot.Components.SystemComponents.KubeProxy.Destroy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.kubeProxyEnabled,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler),
 		})
 		deployAPIServerProxy = g.Add(flow.Task{
 			Name:   "Deploying apiserver-proxy",
-			Fn:     flow.TaskFn(botanist.DeployAPIServerProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:     flow.TaskFn(b.DeployAPIServerProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployBlackboxExporter = g.Add(flow.Task{
 			Name:   "Deploying blackbox-exporter",
-			Fn:     flow.TaskFn(botanist.ReconcileBlackboxExporterCluster).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:     flow.TaskFn(b.ReconcileBlackboxExporterCluster).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
@@ -747,7 +747,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployNodeExporter = g.Add(flow.Task{
 			Name: "Deploying node-exporter",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.ReconcileNodeExporter(ctx)
+				return b.ReconcileNodeExporter(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
@@ -755,21 +755,21 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		deployKubernetesDashboard = g.Add(flow.Task{
 			Name:   "Deploying addon Kubernetes Dashboard",
-			Fn:     flow.TaskFn(botanist.DeployKubernetesDashboard).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:     flow.TaskFn(b.DeployKubernetesDashboard).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployNginxIngressAddon = g.Add(flow.Task{
 			Name:   "Deploying addon Nginx Ingress Controller",
-			Fn:     flow.TaskFn(botanist.DeployNginxIngressAddon).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:     flow.TaskFn(b.DeployNginxIngressAddon).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployManagedResourceForGardenerNodeAgent = g.Add(flow.Task{
 			Name:         "Deploying managed resources for the gardener-node-agent",
-			Fn:           flow.TaskFn(botanist.DeployManagedResourceForGardenerNodeAgent).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployManagedResourceForGardenerNodeAgent).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
@@ -792,53 +792,53 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 
 		scaleClusterAutoscalerToZero = g.Add(flow.Task{
 			Name:         "Scaling down cluster autoscaler",
-			Fn:           flow.TaskFn(botanist.ScaleClusterAutoscalerToZero).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.ScaleClusterAutoscalerToZero).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless || !o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployManagedResourceForGardenerNodeAgent),
 		})
 		deployMachineControllerManager = g.Add(flow.Task{
 			Name:         "Deploying machine-controller-manager",
-			Fn:           flow.TaskFn(botanist.DeployMachineControllerManager),
+			Fn:           flow.TaskFn(b.DeployMachineControllerManager),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployCloudProviderSecret, deployReferencedResources, waitUntilInfrastructureReady, initializeShootClients, waitUntilOperatingSystemConfigReady, waitUntilNetworkIsReady, createNewServiceAccountSecrets, scaleClusterAutoscalerToZero),
 		})
 		deployWorker = g.Add(flow.Task{
 			Name:         "Configuring shoot worker pools",
-			Fn:           flow.TaskFn(botanist.DeployWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployMachineControllerManager),
 		})
 		waitUntilWorkerStatusUpdate = g.Add(flow.Task{
 			Name: "Waiting until worker resource status is updated with latest machine deployments",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.Extensions.Worker.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)
+				return b.Shoot.Components.Extensions.Worker.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployWorker),
 		})
 		deployExtensionResourcesAfterWorker = g.Add(flow.Task{
 			Name:         "Deploying extension resources after workers",
-			Fn:           flow.TaskFn(botanist.DeployExtensionsAfterWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployExtensionsAfterWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
 		})
 		deployClusterAutoscaler = g.Add(flow.Task{
 			Name:         "Deploying cluster autoscaler",
-			Fn:           flow.TaskFn(botanist.DeployClusterAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployClusterAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate, deployManagedResourceForGardenerNodeAgent),
 		})
 		waitUntilWorkerReady = g.Add(flow.Task{
 			Name: "Waiting until shoot worker nodes have been reconciled",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if err := botanist.Shoot.Components.Extensions.Worker.Wait(ctx); err != nil {
+				if err := b.Shoot.Components.Extensions.Worker.Wait(ctx); err != nil {
 					return err
 				}
 
 				// If the worker is ready, all the AutoInPlaceUpdate worker pools should be updated already, so we can remove them from the status.
 				if shootHasPendingInPlaceUpdateWorkers(o.Shoot.GetInfo()) {
 					// gardenlet's shoot status reconciler might concurrently update the status, so we need to use optimistic locking.
-					if err := botanist.Shoot.UpdateInfoStatus(ctx, o.GardenClient, false, true, func(shoot *gardencorev1beta1.Shoot) error {
+					if err := b.Shoot.UpdateInfoStatus(ctx, o.GardenClient, false, true, func(shoot *gardencorev1beta1.Shoot) error {
 						shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate = nil
 
 						if len(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate) == 0 {
@@ -858,7 +858,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				// If there are no pending workers rollouts for in-place updates, we can remove the force in-place update annotation.
 				if (o.Shoot.GetInfo().Status.InPlaceUpdates == nil || o.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates == nil) &&
 					kubernetesutils.HasMetaDataAnnotation(o.Shoot.GetInfo(), v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationForceInPlaceUpdate) {
-					return botanist.Shoot.UpdateInfo(ctx, o.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
+					return b.Shoot.UpdateInfo(ctx, o.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
 						delete(shoot.Annotations, v1beta1constants.GardenerOperation)
 						return nil
 					})
@@ -871,103 +871,103 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Checking if we have dual-stack pod CIDRs in nodes",
-			Fn:           botanist.CheckPodCIDRsInNodes,
+			Fn:           b.CheckPodCIDRsInNodes,
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until extension resources handled after workers are ready",
-			Fn:           botanist.Shoot.Components.Extensions.Extension.WaitAfterWorker,
+			Fn:           b.Shoot.Components.Extensions.Extension.WaitAfterWorker,
 			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterWorker),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Scaling down machine-controller-manager",
-			Fn:           flow.TaskFn(botanist.ScaleMachineControllerManagerToZero).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.ScaleMachineControllerManagerToZero).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless || !o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
 		})
 
 		deploySeedLogging = g.Add(flow.Task{
 			Name:         "Deploying shoot logging stack in Seed",
-			Fn:           flow.TaskFn(botanist.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(initialValiDeployment, waitUntilGardenerResourceManagerReady).InsertIf(flowCtx.isHibernatingShootWithWorkers, waitUntilWorkerReady),
 		})
 		deployPlutonoForLogging = g.Add(flow.Task{
 			Name:         "Reconciling Plutono for Shoot in Seed for the logging stack",
-			Fn:           flow.TaskFn(botanist.DeployPlutono).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(b.DeployPlutono).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(deploySeedLogging),
 		})
 		nginxLBReady = g.Add(flow.Task{
 			Name:         "Waiting until nginx ingress LoadBalancer is ready",
-			Fn:           botanist.WaitUntilNginxIngressServiceIsReady,
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || !v1beta1helper.NginxIngressEnabled(botanist.Shoot.GetInfo().Spec.Addons),
+			Fn:           b.WaitUntilNginxIngressServiceIsReady,
+			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || !v1beta1helper.NginxIngressEnabled(b.Shoot.GetInfo().Spec.Addons),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilWorkerReady, ensureShootClusterIdentity),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Deploying nginx ingress DNS record",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if err := botanist.DeployOrDestroyIngressDNSRecord(ctx); err != nil {
+				if err := b.DeployOrDestroyIngressDNSRecord(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskDeployDNSRecordIngress)
+				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployDNSRecordIngress)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(nginxLBReady),
 		})
 		waitUntilTunnelConnectionExists = g.Add(flow.Task{
 			Name:         "Waiting until the Kubernetes API server can connect to the Shoot workers",
-			Fn:           botanist.WaitUntilTunnelConnectionExists,
+			Fn:           b.WaitUntilTunnelConnectionExists,
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, waitUntilNetworkIsReady, waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Waiting until all shoot worker nodes have updated the operating system config",
 			Fn: func(ctx context.Context) error {
-				return botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)
+				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)
 			},
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady, waitUntilTunnelConnectionExists),
 		})
 		deployAlertmanager = g.Add(flow.Task{
 			Name:         "Reconciling Shoot Alertmanager",
-			Fn:           flow.TaskFn(botanist.DeployAlertManager).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(b.DeployAlertManager).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		waitUntilAlertmanagerReconciled = g.Add(flow.Task{
 			Name:         "Waiting until Shoot Alertmanager is reconciled",
-			Fn:           botanist.WaitForAlertManager,
+			Fn:           b.WaitForAlertManager,
 			Dependencies: flow.NewTaskIDs(deployAlertmanager),
 		})
 		deployPrometheus = g.Add(flow.Task{
 			Name:         "Reconciling Shoot Prometheus",
-			Fn:           flow.TaskFn(botanist.DeployPrometheus).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(b.DeployPrometheus).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		waitUntilPrometheusReconciled = g.Add(flow.Task{
 			Name:         "Waiting until Shoot Prometheus is reconciled",
-			Fn:           botanist.WaitForPrometheus,
+			Fn:           b.WaitForPrometheus,
 			Dependencies: flow.NewTaskIDs(deployPrometheus),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying control plane blackbox-exporter",
-			Fn:           flow.TaskFn(botanist.ReconcileBlackboxExporterControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(b.ReconcileBlackboxExporterControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Reconciling kube-state-metrics for Shoot in Seed for the monitoring stack",
-			Fn:           flow.TaskFn(botanist.DeployKubeStateMetrics).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(b.DeployKubeStateMetrics).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployPrometheus, deployAlertmanager),
 		})
 		deployPlutonoForMonitoring = g.Add(flow.Task{
 			Name:         "Reconciling Plutono for Shoot in Seed for the monitoring stack",
-			Fn:           flow.TaskFn(botanist.DeployPlutono).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(b.DeployPlutono).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(deployPrometheus, deployAlertmanager),
 		})
 		waitUntilPlutonoReconciled = g.Add(flow.Task{
 			Name:         "Waiting until Plutono for Shoot in Seed is reconciled",
-			Fn:           botanist.WaitForPlutono,
+			Fn:           b.WaitForPlutono,
 			Dependencies: flow.NewTaskIDs(deployPlutonoForLogging, deployPlutonoForMonitoring),
 		})
 		_ = g.Add(flow.Task{
@@ -978,7 +978,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 
 		hibernateControlPlane = g.Add(flow.Task{
 			Name:         "Hibernating control plane",
-			Fn:           flow.TaskFn(botanist.HibernateControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(b.HibernateControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			SkipIf:       !o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(initializeShootClients, deployPrometheus, deployAlertmanager, deploySeedLogging, deployClusterAutoscaler, waitUntilWorkerReady, waitUntilExtensionResourcesAfterKAPIReady, waitUntilEtcdScaledAfterRestore),
 		})
@@ -987,55 +987,55 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		// extensions that are deployed before the kube-apiserver are hibernated after it
 		hibernateExtensionResourcesAfterKAPIHibernation = g.Add(flow.Task{
 			Name:         "Hibernating extension resources after kube-apiserver hibernation",
-			Fn:           flow.TaskFn(botanist.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       !o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until extension resources hibernated after kube-apiserver hibernation are ready",
-			Fn:           botanist.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
+			Fn:           b.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
 			SkipIf:       flowCtx.skipReadiness || !o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(hibernateExtensionResourcesAfterKAPIHibernation),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying ingress domain DNS record if hibernated",
-			Fn:           botanist.DestroyIngressDNSRecord,
+			Fn:           b.DestroyIngressDNSRecord,
 			SkipIf:       !o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying external domain DNS record if hibernated",
-			Fn:           botanist.DestroyExternalDNSRecord,
+			Fn:           b.DestroyExternalDNSRecord,
 			SkipIf:       !o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying internal domain DNS record if hibernated",
-			Fn:           botanist.DestroyInternalDNSRecord,
+			Fn:           b.DestroyInternalDNSRecord,
 			SkipIf:       !o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		deleteStaleExtensionResources = g.Add(flow.Task{
 			Name:         "Deleting stale extension resources",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.Extension.DeleteStaleResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.Shoot.Components.Extensions.Extension.DeleteStaleResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until stale extension resources are deleted",
-			Fn:           botanist.Shoot.Components.Extensions.Extension.WaitCleanupStaleResources,
+			Fn:           b.Shoot.Components.Extensions.Extension.WaitCleanupStaleResources,
 			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deleteStaleExtensionResources),
 		})
 		deployContainerRuntimeResources = g.Add(flow.Task{
 			Name:         "Deploying container runtime resources",
-			Fn:           flow.TaskFn(botanist.DeployContainerRuntime).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(b.DeployContainerRuntime).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, initializeShootClients),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Waiting until container runtime resources are ready",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.Extensions.ContainerRuntime.Wait(ctx)
+				return b.Shoot.Components.Extensions.ContainerRuntime.Wait(ctx)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployContainerRuntimeResources),
@@ -1043,7 +1043,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deleteStaleContainerRuntimeResources = g.Add(flow.Task{
 			Name: "Deleting stale container runtime resources",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.Extensions.ContainerRuntime.DeleteStaleResources(ctx)
+				return b.Shoot.Components.Extensions.ContainerRuntime.DeleteStaleResources(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
@@ -1051,7 +1051,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name: "Waiting until stale container runtime resources are deleted",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.Extensions.ContainerRuntime.WaitCleanupStaleResources(ctx)
+				return b.Shoot.Components.Extensions.ContainerRuntime.WaitCleanupStaleResources(ctx)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deleteStaleContainerRuntimeResources),
@@ -1059,10 +1059,10 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name: "Restarting control plane pods",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if err := botanist.RestartControlPlanePods(ctx); err != nil {
+				if err := b.RestartControlPlanePods(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskRestartControlPlanePods)
+				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskRestartControlPlanePods)
 			}),
 			SkipIf:       !flowCtx.requestControlPlanePodsRestart,
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager, deployControlPlane),
@@ -1081,14 +1081,14 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	}
 
 	o.Logger.Info("Cleaning no longer required secrets")
-	if err := botanist.SecretsManager.Cleanup(ctx); err != nil {
+	if err := b.SecretsManager.Cleanup(ctx); err != nil {
 		err = fmt.Errorf("failed to clean no longer required secrets: %w", err)
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 	}
 
-	if !r.ShootStateControllerEnabled && botanist.Shoot.IsRestorePhase() {
+	if !r.ShootStateControllerEnabled && b.Shoot.IsRestorePhase() {
 		o.Logger.Info("Deleting Shoot State after successful restoration")
-		if err := shootstate.Delete(ctx, botanist.GardenClient, botanist.Shoot.GetInfo()); err != nil {
+		if err := shootstate.Delete(ctx, b.GardenClient, b.Shoot.GetInfo()); err != nil {
 			err = fmt.Errorf("failed to delete shoot state: %w", err)
 			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 		}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -116,7 +116,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			return err
 		}),
 		errors.ToExecute("Retrieve the Worker resource", func() error {
-			if o.Shoot.IsWorkerless {
+			if b.Shoot.IsWorkerless {
 				return nil
 			}
 			obj, err := b.Shoot.Components.Extensions.Worker.Get(ctx)
@@ -137,7 +137,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	// different deployment functions call the `Wait` method after the first deployment. Hence, we should use
 	// the respective timeout in this case instead of the (too short) default timeout to prevent undesired and confusing
 	// errors in the reconciliation flow.
-	if v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPreparing {
+	if v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPreparing {
 		flowCtx.deployKubeAPIServerTaskTimeout = kubeapiserver.TimeoutWaitForDeployment
 	}
 
@@ -145,7 +145,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployExtensionAfterKAPIMsg = "Deploying extension resources after kube-apiserver"
 		waitExtensionAfterKAPIMsg   = "Waiting until extension resources handled after kube-apiserver are ready"
 	)
-	if o.Shoot.HibernationEnabled {
+	if b.Shoot.HibernationEnabled {
 		deployExtensionAfterKAPIMsg = "Hibernating extension resources before kube-apiserver hibernation"
 		waitExtensionAfterKAPIMsg = "Waiting until extension resources hibernated before kube-apiserver hibernation are ready"
 	}
@@ -154,11 +154,11 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		if err := b.UpdateDualStackMigrationConditionIfNeeded(ctx); err != nil {
 			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 		}
-		networks, err := shoot.ToNetworks(o.Shoot.GetInfo(), o.Shoot.IsWorkerless)
+		networks, err := shoot.ToNetworks(b.Shoot.GetInfo(), b.Shoot.IsWorkerless)
 		if err != nil {
 			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 		}
-		o.Shoot.Networks = networks
+		b.Shoot.Networks = networks
 	}
 
 	if err := b.SetInPlaceUpdatePendingWorkers(ctx, worker); err != nil {
@@ -180,7 +180,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployCloudProviderSecret = g.Add(flow.Task{
 			Name:         "Deploying cloud provider account secret",
 			Fn:           flow.TaskFn(b.DeployCloudProviderSecret).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		reconcileIstioInternalLoadbalancingConfigMap = g.Add(flow.Task{
@@ -207,7 +207,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployInfrastructure = g.Add(flow.Task{
 			Name:         "Deploying Shoot infrastructure",
 			Fn:           flow.TaskFn(b.DeployInfrastructure).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, deployReferencedResources),
 		})
 		waitUntilInfrastructureReady = g.Add(flow.Task{
@@ -220,7 +220,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				}
 				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployInfrastructure)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployInfrastructure),
 		})
 		deployKubeAPIServerService = g.Add(flow.Task{
@@ -231,7 +231,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilKubeAPIServerServiceIsReady = g.Add(flow.Task{
 			Name:         "Waiting until Kubernetes API server service in the Seed cluster has reported readiness",
 			Fn:           b.Shoot.Components.ControlPlane.KubeAPIServerService.Wait,
-			SkipIf:       o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerService),
 		})
 		_ = g.Add(flow.Task{
@@ -247,7 +247,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				}
 				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployDNSRecordInternal)
 			}),
-			SkipIf:       o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
 		})
 		_ = g.Add(flow.Task{
@@ -258,7 +258,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				}
 				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployDNSRecordExternal)
 			}),
-			SkipIf:       o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
 		})
 		deploySourceBackupEntry = g.Add(flow.Task{
@@ -305,7 +305,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		deployETCD = g.Add(flow.Task{
 			Name:         "Deploying main and events etcd",
-			Fn:           flow.TaskFn(b.DeployEtcd).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(o.Shoot, defaultTimeout)),
+			Fn:           flow.TaskFn(b.DeployEtcd).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(b.Shoot, defaultTimeout)),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilBackupEntryInGardenReconciled, waitUntilEtcdBackupsCopied),
 		})
 		destroySourceBackupEntry = g.Add(flow.Task{
@@ -323,19 +323,19 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilEtcdReady = g.Add(flow.Task{
 			Name:         "Waiting until main and event etcd report readiness",
 			Fn:           b.WaitUntilEtcdsReady,
-			SkipIf:       (!flowCtx.isRestoringHAControlPlane && o.Shoot.HibernationEnabled) || flowCtx.skipReadiness,
+			SkipIf:       (!flowCtx.isRestoringHAControlPlane && b.Shoot.HibernationEnabled) || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
 		deployExtensionResourcesBeforeKAPI = g.Add(flow.Task{
 			Name:         "Deploying extension resources before kube-apiserver",
 			Fn:           flow.TaskFn(b.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, deployReferencedResources, waitUntilInfrastructureReady),
 		})
 		waitUntilExtensionResourcesBeforeKAPIReady = g.Add(flow.Task{
 			Name:         "Waiting until extension resources handled before kube-apiserver are ready",
 			Fn:           b.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
-			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesBeforeKAPI),
 		})
 		deployKubeAPIServer = g.Add(flow.Task{
@@ -354,7 +354,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilKubeAPIServerIsReady = g.Add(flow.Task{
 			Name:         "Waiting until Kubernetes API server rolled out",
 			Fn:           b.Shoot.Components.ControlPlane.KubeAPIServer.Wait,
-			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServer),
 		})
 		_ = g.Add(flow.Task{
@@ -364,7 +364,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		scaleEtcdAfterRestore = g.Add(flow.Task{
 			Name:         "Scaling main and events etcd after kube-apiserver is ready",
-			Fn:           flow.TaskFn(b.ScaleUpETCD).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(o.Shoot, defaultTimeout)),
+			Fn:           flow.TaskFn(b.ScaleUpETCD).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(b.Shoot, defaultTimeout)),
 			SkipIf:       !flowCtx.isRestoringHAControlPlane,
 			Dependencies: flow.NewTaskIDs(waitUntilEtcdReady, waitUntilKubeAPIServerIsReady),
 		})
@@ -382,27 +382,27 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilGardenerResourceManagerReady = g.Add(flow.Task{
 			Name:         "Waiting until gardener-resource-manager reports readiness",
 			Fn:           b.Shoot.Components.ControlPlane.ResourceManager.Wait,
-			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Renewing shoot access secrets after creation of new ServiceAccount signing key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return tokenrequest.RenewAccessSecrets(ctx, o.SeedClientSet.Client(),
-					client.InNamespace(o.Shoot.ControlPlaneNamespace),
+				return tokenrequest.RenewAccessSecrets(ctx, b.SeedClientSet.Client(),
+					client.InNamespace(b.Shoot.ControlPlaneNamespace),
 					client.MatchingLabels{resourcesv1alpha1.ResourceManagerClass: resourcesv1alpha1.ResourceManagerClassShoot},
 				)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: !sets.New(
 				gardencorev1beta1.RotationPreparing,
 				gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
-			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials)),
+			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
 		deployControlPlane = g.Add(flow.Task{
 			Name:         "Deploying shoot control plane components",
 			Fn:           flow.TaskFn(b.DeployControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
 		waitUntilControlPlaneReady = g.Add(flow.Task{
@@ -410,7 +410,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.ControlPlane.Wait(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployControlPlane),
 		})
 		deployShootNamespaces = g.Add(flow.Task{
@@ -421,13 +421,13 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilShootNamespacesReady = g.Add(flow.Task{
 			Name:         "Waiting until shoot namespaces have been reconciled",
 			Fn:           b.Shoot.Components.SystemComponents.Namespaces.Wait,
-			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, deployShootNamespaces),
 		})
 		deployVPNSeedServer = g.Add(flow.Task{
 			Name:         "Deploying vpn-seed-server",
 			Fn:           flow.TaskFn(b.DeployVPNServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployNamespace, waitUntilGardenerResourceManagerReady),
 		})
 		deployGardenerAccess = g.Add(flow.Task{
@@ -443,49 +443,49 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name: "Sync public service account signing keys to Garden cluster",
 			Fn:   b.SyncPublicServiceAccountKeys,
-			SkipIf: o.Shoot.HibernationEnabled ||
+			SkipIf: b.Shoot.HibernationEnabled ||
 				!v1beta1helper.HasManagedIssuer(b.Shoot.GetInfo()),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
 		rewriteResourcesAddLabel = g.Add(flow.Task{
 			Name: "Labeling resources after modification of encryption config or to encrypt them with new ETCD encryption key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, o.Logger, o.SeedClientSet.Client(), o.ShootClientSet, o.SecretsManager, o.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer, o.Shoot.ResourcesToEncrypt, o.Shoot.EncryptedResources, gardenerutils.DefaultGVKsForEncryption())
+				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, b.Logger, b.SeedClientSet.Client(), b.ShootClientSet, b.SecretsManager, b.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer, b.Shoot.ResourcesToEncrypt, b.Shoot.EncryptedResources, gardenerutils.DefaultGVKsForEncryption())
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf: o.Shoot.HibernationEnabled ||
-				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
-					sets.New(o.Shoot.ResourcesToEncrypt...).Equal(sets.New(o.Shoot.EncryptedResources...)) && (o.Shoot.EncryptionProviderToUse == o.Shoot.UsedEncryptionProvider ||
-					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting)),
+			SkipIf: b.Shoot.HibernationEnabled ||
+				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
+					sets.New(b.Shoot.ResourcesToEncrypt...).Equal(sets.New(b.Shoot.EncryptedResources...)) && (b.Shoot.EncryptionProviderToUse == b.Shoot.UsedEncryptionProvider ||
+					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting)),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
 		snapshotETCD = g.Add(flow.Task{
 			Name: "Snapshotting ETCD after modification of encryption config or resources are re-encrypted with new ETCD encryption key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, o.SeedClientSet.Client(), b.SnapshotEtcd, o.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer)
+				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, b.SeedClientSet.Client(), b.SnapshotEtcd, b.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer)
 			}),
-			SkipIf: !flowCtx.allowBackup || o.Shoot.HibernationEnabled ||
-				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
-					sets.New(o.Shoot.ResourcesToEncrypt...).Equal(sets.New(o.Shoot.EncryptedResources...)) && (o.Shoot.EncryptionProviderToUse == o.Shoot.UsedEncryptionProvider ||
-					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting)),
+			SkipIf: !flowCtx.allowBackup || b.Shoot.HibernationEnabled ||
+				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
+					sets.New(b.Shoot.ResourcesToEncrypt...).Equal(sets.New(b.Shoot.EncryptedResources...)) && (b.Shoot.EncryptionProviderToUse == b.Shoot.UsedEncryptionProvider ||
+					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting)),
 			Dependencies: flow.NewTaskIDs(rewriteResourcesAddLabel),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Removing label from resources after modification of encryption config or rotation of ETCD encryption key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if err := secretsrotation.RewriteEncryptedDataRemoveLabel(ctx, o.Logger, o.SeedClientSet.Client(), o.ShootClientSet, o.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer, o.Shoot.ResourcesToEncrypt, o.Shoot.EncryptedResources, gardenerutils.DefaultGVKsForEncryption()); err != nil {
+				if err := secretsrotation.RewriteEncryptedDataRemoveLabel(ctx, b.Logger, b.SeedClientSet.Client(), b.ShootClientSet, b.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer, b.Shoot.ResourcesToEncrypt, b.Shoot.EncryptedResources, gardenerutils.DefaultGVKsForEncryption()); err != nil {
 					return err
 				}
 
-				if !sets.New(o.Shoot.ResourcesToEncrypt...).Equal(sets.New(o.Shoot.EncryptedResources...)) ||
-					o.Shoot.EncryptionProviderToUse != o.Shoot.UsedEncryptionProvider {
-					if err := o.Shoot.UpdateInfoStatus(ctx, o.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
+				if !sets.New(b.Shoot.ResourcesToEncrypt...).Equal(sets.New(b.Shoot.EncryptedResources...)) ||
+					b.Shoot.EncryptionProviderToUse != b.Shoot.UsedEncryptionProvider {
+					if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
 						var (
 							encryptedResources     []string
 							encryptionProviderType gardencorev1beta1.EncryptionProviderType
 						)
-						if o.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer != nil {
-							encryptedResources = shared.StringifyGroupResources(shared.GetResourcesForEncryptionFromConfig(o.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer.EncryptionConfig))
-							encryptionProviderType = v1beta1helper.GetEncryptionProviderType(o.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer)
+						if b.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer != nil {
+							encryptedResources = shared.StringifyGroupResources(shared.GetResourcesForEncryptionFromConfig(b.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer.EncryptionConfig))
+							encryptionProviderType = v1beta1helper.GetEncryptionProviderType(b.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer)
 						}
 
 						if shoot.Status.Credentials == nil {
@@ -511,11 +511,11 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 
 				return nil
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf: o.Shoot.HibernationEnabled ||
-				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting &&
-					sets.New(o.Shoot.ResourcesToEncrypt...).Equal(sets.New(o.Shoot.EncryptedResources...)) && (o.Shoot.EncryptionProviderToUse == o.Shoot.UsedEncryptionProvider ||
-					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPreparing ||
-					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPrepared)),
+			SkipIf: b.Shoot.HibernationEnabled ||
+				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting &&
+					sets.New(b.Shoot.ResourcesToEncrypt...).Equal(sets.New(b.Shoot.EncryptedResources...)) && (b.Shoot.EncryptionProviderToUse == b.Shoot.UsedEncryptionProvider ||
+					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPreparing ||
+					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPrepared)),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, snapshotETCD),
 		})
 		deployKubeScheduler = g.Add(flow.Task{
@@ -523,19 +523,19 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.ControlPlane.KubeScheduler.Deploy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Reconciling Kubernetes vertical pod autoscaler",
 			Fn:           flow.TaskFn(b.DeployVerticalPodAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying dependency-watchdog shoot access resources",
 			Fn:           flow.TaskFn(b.DeployDependencyWatchdogAccess).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		deployKubeControllerManager = g.Add(flow.Task{
@@ -549,26 +549,26 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			SkipIf: flowCtx.skipReadiness || !sets.New(
 				gardencorev1beta1.RotationPreparing,
 				gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
-			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials)),
+			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)),
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager),
 		})
 		createNewServiceAccountSecrets = g.Add(flow.Task{
 			Name: "Creating new ServiceAccount secrets after creation of new signing key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return secretsrotation.CreateNewServiceAccountSecrets(ctx, o.Logger, o.ShootClientSet.Client(), o.SecretsManager)
+				return secretsrotation.CreateNewServiceAccountSecrets(ctx, b.Logger, b.ShootClientSet.Client(), b.SecretsManager)
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
 			SkipIf: !sets.New(
 				gardencorev1beta1.RotationPreparing,
 				gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
-			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials)),
+			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilKubeControllerManagerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Deleting old ServiceAccount secrets after rotation of signing key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return secretsrotation.DeleteOldServiceAccountSecrets(ctx, o.Logger, o.ShootClientSet.Client(), o.Shoot.GetInfo().Status.Credentials.Rotation.ServiceAccountKey.LastInitiationFinishedTime.Time)
+				return secretsrotation.DeleteOldServiceAccountSecrets(ctx, b.Logger, b.ShootClientSet.Client(), b.Shoot.GetInfo().Status.Credentials.Rotation.ServiceAccountKey.LastInitiationFinishedTime.Time)
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf:       v1beta1helper.GetShootServiceAccountKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting,
+			SkipIf:       v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting,
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilKubeControllerManagerReady),
 		})
 		deleteBastions = g.Add(flow.Task{
@@ -591,7 +591,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployOperatingSystemConfig = g.Add(flow.Task{
 			Name:         "Deploying operating system specific configuration for shoot workers",
 			Fn:           flow.TaskFn(b.DeployOperatingSystemConfig).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady, deleteBastions, waitUntilExtensionResourcesAfterKAPIReady),
 		})
 		waitUntilOperatingSystemConfigReady = g.Add(flow.Task{
@@ -599,7 +599,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.OperatingSystemConfig.Wait(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfig),
 		})
 		deleteStaleOperatingSystemConfigResources = g.Add(flow.Task{
@@ -607,7 +607,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.OperatingSystemConfig.DeleteStaleResources(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfig),
 		})
 		_ = g.Add(flow.Task{
@@ -615,13 +615,13 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.OperatingSystemConfig.WaitCleanupStaleResources(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deleteStaleOperatingSystemConfigResources),
 		})
 		deployNetwork = g.Add(flow.Task{
 			Name:         "Deploying shoot network plugin",
 			Fn:           flow.TaskFn(b.DeployNetwork).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilGardenerResourceManagerReady, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		waitUntilNetworkIsReady = g.Add(flow.Task{
@@ -629,7 +629,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.Network.Wait(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployNetwork),
 		})
 		_ = g.Add(flow.Task{
@@ -637,7 +637,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.CheckDNSServiceMigration(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilNetworkIsReady),
 		})
 		_ = g.Add(flow.Task{
@@ -645,13 +645,13 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.DeployClusterIdentity(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
 		deployShootSystemResources = g.Add(flow.Task{
 			Name:   "Deploying shoot system resources",
 			Fn:     flow.TaskFn(b.DeployShootSystem).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, waitUntilOperatingSystemConfigReady, waitUntilShootNamespacesReady),
 		})
@@ -666,19 +666,19 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				if err := b.DeployCoreDNS(ctx); err != nil {
 					return err
 				}
-				if controllerutils.HasTask(o.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartCoreAddons) {
+				if controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartCoreAddons) {
 					return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskRestartCoreAddons)
 				}
 				return nil
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployNodeLocalDNS = g.Add(flow.Task{
 			Name:   "Reconcile node-local-dns system component",
 			Fn:     flow.TaskFn(b.ReconcileNodeLocalDNS),
-			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				deployGardenerResourceManager, initializeShootClients, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady, waitUntilNetworkIsReady),
 		})
@@ -687,14 +687,14 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.SystemComponents.MetricsServer.Deploy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployVPNShoot = g.Add(flow.Task{
 			Name:   "Deploying vpn-shoot system component",
 			Fn:     flow.TaskFn(b.DeployVPNShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, deployGardenerResourceManager, deployKubeScheduler, deployVPNSeedServer, waitUntilShootNamespacesReady),
 		})
@@ -703,14 +703,14 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.SystemComponents.NodeProblemDetector.Deploy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				deployGardenerResourceManager, waitUntilOperatingSystemConfigReady, waitUntilShootNamespacesReady),
 		})
 		deployKubeProxy = g.Add(flow.Task{
 			Name:   "Deploying kube-proxy system component",
 			Fn:     flow.TaskFn(b.DeployKubeProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || !flowCtx.kubeProxyEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || !flowCtx.kubeProxyEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				deployGardenerResourceManager, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
@@ -719,7 +719,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.SystemComponents.KubeProxy.DeleteStaleResources(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || !flowCtx.kubeProxyEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || !flowCtx.kubeProxyEnabled,
 			Dependencies: flow.NewTaskIDs(deployKubeProxy),
 		})
 		_ = g.Add(flow.Task{
@@ -727,20 +727,20 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.SystemComponents.KubeProxy.Destroy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.kubeProxyEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.kubeProxyEnabled,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler),
 		})
 		deployAPIServerProxy = g.Add(flow.Task{
 			Name:   "Deploying apiserver-proxy",
 			Fn:     flow.TaskFn(b.DeployAPIServerProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.IsWorkerless,
+			SkipIf: b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployBlackboxExporter = g.Add(flow.Task{
 			Name:   "Deploying blackbox-exporter",
 			Fn:     flow.TaskFn(b.ReconcileBlackboxExporterCluster).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
@@ -749,28 +749,28 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.ReconcileNodeExporter(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployKubernetesDashboard = g.Add(flow.Task{
 			Name:   "Deploying addon Kubernetes Dashboard",
 			Fn:     flow.TaskFn(b.DeployKubernetesDashboard).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployNginxIngressAddon = g.Add(flow.Task{
 			Name:   "Deploying addon Nginx Ingress Controller",
 			Fn:     flow.TaskFn(b.DeployNginxIngressAddon).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployManagedResourceForGardenerNodeAgent = g.Add(flow.Task{
 			Name:         "Deploying managed resources for the gardener-node-agent",
 			Fn:           flow.TaskFn(b.DeployManagedResourceForGardenerNodeAgent).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
 
@@ -793,19 +793,19 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		scaleClusterAutoscalerToZero = g.Add(flow.Task{
 			Name:         "Scaling down cluster autoscaler",
 			Fn:           flow.TaskFn(b.ScaleClusterAutoscalerToZero).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless || !o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || !b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployManagedResourceForGardenerNodeAgent),
 		})
 		deployMachineControllerManager = g.Add(flow.Task{
 			Name:         "Deploying machine-controller-manager",
 			Fn:           flow.TaskFn(b.DeployMachineControllerManager),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployCloudProviderSecret, deployReferencedResources, waitUntilInfrastructureReady, initializeShootClients, waitUntilOperatingSystemConfigReady, waitUntilNetworkIsReady, createNewServiceAccountSecrets, scaleClusterAutoscalerToZero),
 		})
 		deployWorker = g.Add(flow.Task{
 			Name:         "Configuring shoot worker pools",
 			Fn:           flow.TaskFn(b.DeployWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployMachineControllerManager),
 		})
 		waitUntilWorkerStatusUpdate = g.Add(flow.Task{
@@ -813,19 +813,19 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.Worker.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployWorker),
 		})
 		deployExtensionResourcesAfterWorker = g.Add(flow.Task{
 			Name:         "Deploying extension resources after workers",
 			Fn:           flow.TaskFn(b.DeployExtensionsAfterWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
 		})
 		deployClusterAutoscaler = g.Add(flow.Task{
 			Name:         "Deploying cluster autoscaler",
 			Fn:           flow.TaskFn(b.DeployClusterAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate, deployManagedResourceForGardenerNodeAgent),
 		})
 		waitUntilWorkerReady = g.Add(flow.Task{
@@ -836,9 +836,9 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				}
 
 				// If the worker is ready, all the AutoInPlaceUpdate worker pools should be updated already, so we can remove them from the status.
-				if shootHasPendingInPlaceUpdateWorkers(o.Shoot.GetInfo()) {
+				if shootHasPendingInPlaceUpdateWorkers(b.Shoot.GetInfo()) {
 					// gardenlet's shoot status reconciler might concurrently update the status, so we need to use optimistic locking.
-					if err := b.Shoot.UpdateInfoStatus(ctx, o.GardenClient, false, true, func(shoot *gardencorev1beta1.Shoot) error {
+					if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, false, true, func(shoot *gardencorev1beta1.Shoot) error {
 						shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate = nil
 
 						if len(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate) == 0 {
@@ -856,9 +856,9 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				}
 
 				// If there are no pending workers rollouts for in-place updates, we can remove the force in-place update annotation.
-				if (o.Shoot.GetInfo().Status.InPlaceUpdates == nil || o.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates == nil) &&
-					kubernetesutils.HasMetaDataAnnotation(o.Shoot.GetInfo(), v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationForceInPlaceUpdate) {
-					return b.Shoot.UpdateInfo(ctx, o.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
+				if (b.Shoot.GetInfo().Status.InPlaceUpdates == nil || b.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates == nil) &&
+					kubernetesutils.HasMetaDataAnnotation(b.Shoot.GetInfo(), v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationForceInPlaceUpdate) {
+					return b.Shoot.UpdateInfo(ctx, b.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
 						delete(shoot.Annotations, v1beta1constants.GardenerOperation)
 						return nil
 					})
@@ -866,25 +866,25 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 
 				return nil
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployWorker, waitUntilWorkerStatusUpdate, deployManagedResourceForGardenerNodeAgent),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Checking if we have dual-stack pod CIDRs in nodes",
 			Fn:           b.CheckPodCIDRsInNodes,
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until extension resources handled after workers are ready",
 			Fn:           b.Shoot.Components.Extensions.Extension.WaitAfterWorker,
-			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterWorker),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Scaling down machine-controller-manager",
 			Fn:           flow.TaskFn(b.ScaleMachineControllerManagerToZero).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless || !o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || !b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
 		})
 
@@ -901,7 +901,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		nginxLBReady = g.Add(flow.Task{
 			Name:         "Waiting until nginx ingress LoadBalancer is ready",
 			Fn:           b.WaitUntilNginxIngressServiceIsReady,
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || !v1beta1helper.NginxIngressEnabled(b.Shoot.GetInfo().Spec.Addons),
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || !v1beta1helper.NginxIngressEnabled(b.Shoot.GetInfo().Spec.Addons),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilWorkerReady, ensureShootClusterIdentity),
 		})
 		_ = g.Add(flow.Task{
@@ -912,13 +912,13 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				}
 				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployDNSRecordIngress)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(nginxLBReady),
 		})
 		waitUntilTunnelConnectionExists = g.Add(flow.Task{
 			Name:         "Waiting until the Kubernetes API server can connect to the Shoot workers",
 			Fn:           b.WaitUntilTunnelConnectionExists,
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, waitUntilNetworkIsReady, waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
@@ -926,7 +926,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: func(ctx context.Context) error {
 				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)
 			},
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady, waitUntilTunnelConnectionExists),
 		})
 		deployAlertmanager = g.Add(flow.Task{
@@ -957,7 +957,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name:         "Reconciling kube-state-metrics for Shoot in Seed for the monitoring stack",
 			Fn:           flow.TaskFn(b.DeployKubeStateMetrics).RetryUntilTimeout(defaultInterval, 2*time.Minute),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployPrometheus, deployAlertmanager),
 		})
 		deployPlutonoForMonitoring = g.Add(flow.Task{
@@ -972,14 +972,14 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying istio-basic-auth-server",
-			Fn:           flow.TaskFn(o.Shoot.Components.ControlPlane.IstioBasicAuthServer.Deploy).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(b.Shoot.Components.ControlPlane.IstioBasicAuthServer.Deploy).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(waitUntilAlertmanagerReconciled, waitUntilPrometheusReconciled, waitUntilPlutonoReconciled),
 		})
 
 		hibernateControlPlane = g.Add(flow.Task{
 			Name:         "Hibernating control plane",
 			Fn:           flow.TaskFn(b.HibernateControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
-			SkipIf:       !o.Shoot.HibernationEnabled,
+			SkipIf:       !b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(initializeShootClients, deployPrometheus, deployAlertmanager, deploySeedLogging, deployClusterAutoscaler, waitUntilWorkerReady, waitUntilExtensionResourcesAfterKAPIReady, waitUntilEtcdScaledAfterRestore),
 		})
 
@@ -988,31 +988,31 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		hibernateExtensionResourcesAfterKAPIHibernation = g.Add(flow.Task{
 			Name:         "Hibernating extension resources after kube-apiserver hibernation",
 			Fn:           flow.TaskFn(b.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       !o.Shoot.HibernationEnabled,
+			SkipIf:       !b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until extension resources hibernated after kube-apiserver hibernation are ready",
 			Fn:           b.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
-			SkipIf:       flowCtx.skipReadiness || !o.Shoot.HibernationEnabled,
+			SkipIf:       flowCtx.skipReadiness || !b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(hibernateExtensionResourcesAfterKAPIHibernation),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying ingress domain DNS record if hibernated",
 			Fn:           b.DestroyIngressDNSRecord,
-			SkipIf:       !o.Shoot.HibernationEnabled,
+			SkipIf:       !b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying external domain DNS record if hibernated",
 			Fn:           b.DestroyExternalDNSRecord,
-			SkipIf:       !o.Shoot.HibernationEnabled,
+			SkipIf:       !b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying internal domain DNS record if hibernated",
 			Fn:           b.DestroyInternalDNSRecord,
-			SkipIf:       !o.Shoot.HibernationEnabled,
+			SkipIf:       !b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		deleteStaleExtensionResources = g.Add(flow.Task{
@@ -1023,13 +1023,13 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until stale extension resources are deleted",
 			Fn:           b.Shoot.Components.Extensions.Extension.WaitCleanupStaleResources,
-			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deleteStaleExtensionResources),
 		})
 		deployContainerRuntimeResources = g.Add(flow.Task{
 			Name:         "Deploying container runtime resources",
 			Fn:           flow.TaskFn(b.DeployContainerRuntime).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, initializeShootClients),
 		})
 		_ = g.Add(flow.Task{
@@ -1037,7 +1037,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.ContainerRuntime.Wait(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployContainerRuntimeResources),
 		})
 		deleteStaleContainerRuntimeResources = g.Add(flow.Task{
@@ -1045,7 +1045,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.ContainerRuntime.DeleteStaleResources(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
 		_ = g.Add(flow.Task{
@@ -1053,7 +1053,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.ContainerRuntime.WaitCleanupStaleResources(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deleteStaleContainerRuntimeResources),
 		})
 		_ = g.Add(flow.Task{
@@ -1072,22 +1072,22 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	f := g.Compile()
 
 	if err := f.Run(ctx, flow.Opts{
-		Log:              o.Logger,
-		ProgressReporter: r.newProgressReporter(o.ReportShootProgress),
+		Log:              b.Logger,
+		ProgressReporter: r.newProgressReporter(b.ReportShootProgress),
 		ErrorContext:     errorContext,
-		ErrorCleaner:     o.CleanShootTaskError,
+		ErrorCleaner:     b.CleanShootTaskError,
 	}); err != nil {
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
 	}
 
-	o.Logger.Info("Cleaning no longer required secrets")
+	b.Logger.Info("Cleaning no longer required secrets")
 	if err := b.SecretsManager.Cleanup(ctx); err != nil {
 		err = fmt.Errorf("failed to clean no longer required secrets: %w", err)
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 	}
 
 	if !r.ShootStateControllerEnabled && b.Shoot.IsRestorePhase() {
-		o.Logger.Info("Deleting Shoot State after successful restoration")
+		b.Logger.Info("Deleting Shoot State after successful restoration")
 		if err := shootstate.Delete(ctx, b.GardenClient, b.Shoot.GetInfo()); err != nil {
 			err = fmt.Errorf("failed to delete shoot state: %w", err)
 			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
@@ -1095,17 +1095,17 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	}
 
 	// ensure that shoot client is invalidated after it has been hibernated
-	if o.Shoot.HibernationEnabled {
-		if err := o.ShootClientMap.InvalidateClient(keys.ForShoot(o.Shoot.GetInfo())); err != nil {
+	if b.Shoot.HibernationEnabled {
+		if err := b.ShootClientMap.InvalidateClient(keys.ForShoot(b.Shoot.GetInfo())); err != nil {
 			err = fmt.Errorf("failed to invalidate shoot client: %w", err)
 			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 		}
 	}
 
-	if _, ok := o.Shoot.GetInfo().Annotations[v1beta1constants.AnnotationShootSkipReadiness]; ok {
-		o.Logger.Info("Removing skip-readiness annotation")
+	if _, ok := b.Shoot.GetInfo().Annotations[v1beta1constants.AnnotationShootSkipReadiness]; ok {
+		b.Logger.Info("Removing skip-readiness annotation")
 
-		if err := o.Shoot.UpdateInfo(ctx, o.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
+		if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
 			delete(shoot.Annotations, v1beta1constants.AnnotationShootSkipReadiness)
 			return nil
 		}); err != nil {
@@ -1113,7 +1113,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		}
 	}
 
-	o.Logger.Info("Successfully reconciled Shoot cluster", "operation", utils.IifString(flowCtx.isRestoring, "restored", "reconciled"))
+	b.Logger.Info("Successfully reconciled Shoot cluster", "operation", utils.IifString(flowCtx.isRestoring, "restored", "reconciled"))
 	return nil
 }
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -61,20 +61,6 @@ type flowContext struct {
 // runReconcileShootFlow reconciles the Shoot cluster.
 // It receives an Operation object <o> which stores the Shoot object.
 func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Operation, operationType gardencorev1beta1.LastOperationType) *v1beta1helper.WrappedLastErrors {
-	flowCtx := flowContext{
-		operationType:                  operationType,
-		allowBackup:                    v1beta1helper.GetBackupConfigForShoot(o.Shoot.GetInfo(), o.GetSeed()) != nil,
-		requestControlPlanePodsRestart: controllerutils.HasTask(o.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartControlPlanePods),
-		kubeProxyEnabled:               v1beta1helper.KubeProxyEnabled(o.Shoot.GetInfo().Spec.Kubernetes.KubeProxy),
-		deployKubeAPIServerTaskTimeout: defaultTimeout,
-		shootSSHAccessEnabled:          v1beta1helper.ShootEnablesSSHAccess(o.Shoot.GetInfo()),
-		skipReadiness:                  metav1.HasAnnotation(o.Shoot.GetInfo().ObjectMeta, v1beta1constants.AnnotationShootSkipReadiness),
-		isRestoring:                    operationType == gardencorev1beta1.LastOperationTypeRestore,
-		isRestoringHAControlPlane:      o.Shoot.IsRestorePhase() && v1beta1helper.IsHAControlPlaneConfigured(o.Shoot.GetInfo()),
-		isHibernatingShootWithWorkers:  o.Shoot.HibernationEnabled && !o.Shoot.GetInfo().Status.IsHibernated && !o.Shoot.IsWorkerless,
-	}
-	flowCtx.hasNodesCIDR = o.Shoot.GetInfo().Spec.Networking != nil && o.Shoot.GetInfo().Spec.Networking.Nodes != nil && (o.Shoot.GetInfo().Status.Networking != nil || flowCtx.skipReadiness)
-
 	var tasksWithErrors []string
 	for _, lastError := range o.Shoot.GetInfo().Status.LastErrors {
 		if lastError.TaskID != nil {
@@ -83,6 +69,21 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	}
 
 	var (
+		skipReadiness = metav1.HasAnnotation(o.Shoot.GetInfo().ObjectMeta, v1beta1constants.AnnotationShootSkipReadiness)
+		flowCtx       = flowContext{
+			operationType:                  operationType,
+			allowBackup:                    v1beta1helper.GetBackupConfigForShoot(o.Shoot.GetInfo(), o.GetSeed()) != nil,
+			hasNodesCIDR:                   o.Shoot.GetInfo().Spec.Networking != nil && o.Shoot.GetInfo().Spec.Networking.Nodes != nil && (o.Shoot.GetInfo().Status.Networking != nil || skipReadiness),
+			requestControlPlanePodsRestart: controllerutils.HasTask(o.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartControlPlanePods),
+			kubeProxyEnabled:               v1beta1helper.KubeProxyEnabled(o.Shoot.GetInfo().Spec.Kubernetes.KubeProxy),
+			deployKubeAPIServerTaskTimeout: defaultTimeout,
+			shootSSHAccessEnabled:          v1beta1helper.ShootEnablesSSHAccess(o.Shoot.GetInfo()),
+			skipReadiness:                  skipReadiness,
+			isRestoring:                    operationType == gardencorev1beta1.LastOperationTypeRestore,
+			isRestoringHAControlPlane:      o.Shoot.IsRestorePhase() && v1beta1helper.IsHAControlPlaneConfigured(o.Shoot.GetInfo()),
+			isHibernatingShootWithWorkers:  o.Shoot.HibernationEnabled && !o.Shoot.GetInfo().Status.IsHibernated && !o.Shoot.IsWorkerless,
+		}
+
 		b            *botanistpkg.Botanist
 		worker       *extensionsv1alpha1.Worker
 		errorContext = errors.NewErrorContext(fmt.Sprintf("Shoot cluster %s", utils.IifString(flowCtx.isRestoring, "restoration", "reconciliation")), tasksWithErrors)

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -38,6 +38,26 @@ import (
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 )
 
+const (
+	defaultTimeout  = 30 * time.Second
+	defaultInterval = 5 * time.Second
+)
+
+type flowContext struct {
+	operationType                  gardencorev1beta1.LastOperationType
+	allowBackup                    bool
+	hasNodesCIDR                   bool
+	requestControlPlanePodsRestart bool
+	kubeProxyEnabled               bool
+	deployKubeAPIServerTaskTimeout time.Duration
+	shootSSHAccessEnabled          bool
+	skipReadiness                  bool
+	isCopyOfBackupsRequired        bool
+	isRestoring                    bool
+	isRestoringHAControlPlane      bool
+	isHibernatingShootWithWorkers  bool
+}
+
 // runReconcileShootFlow reconciles the Shoot cluster.
 // It receives an Operation object <o> which stores the Shoot object.
 func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Operation, operationType gardencorev1beta1.LastOperationType) *v1beta1helper.WrappedLastErrors {
@@ -45,27 +65,34 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		return nil
 	}
 
-	// We create the botanists (which will do the actual work).
-	var (
-		botanist                *botanistpkg.Botanist
-		worker                  *extensionsv1alpha1.Worker
-		err                     error
-		isCopyOfBackupsRequired bool
-		tasksWithErrors         []string
+	flowCtx := flowContext{
+		operationType:                  operationType,
+		allowBackup:                    v1beta1helper.GetBackupConfigForShoot(o.Shoot.GetInfo(), o.GetSeed()) != nil,
+		requestControlPlanePodsRestart: controllerutils.HasTask(o.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartControlPlanePods),
+		kubeProxyEnabled:               v1beta1helper.KubeProxyEnabled(o.Shoot.GetInfo().Spec.Kubernetes.KubeProxy),
+		deployKubeAPIServerTaskTimeout: defaultTimeout,
+		shootSSHAccessEnabled:          v1beta1helper.ShootEnablesSSHAccess(o.Shoot.GetInfo()),
+		skipReadiness:                  metav1.HasAnnotation(o.Shoot.GetInfo().ObjectMeta, v1beta1constants.AnnotationShootSkipReadiness),
+		isRestoring:                    operationType == gardencorev1beta1.LastOperationTypeRestore,
+		isRestoringHAControlPlane:      o.Shoot.IsRestorePhase() && v1beta1helper.IsHAControlPlaneConfigured(o.Shoot.GetInfo()),
+		isHibernatingShootWithWorkers:  o.Shoot.HibernationEnabled && !o.Shoot.GetInfo().Status.IsHibernated && !o.Shoot.IsWorkerless,
+	}
+	flowCtx.hasNodesCIDR = o.Shoot.GetInfo().Spec.Networking != nil && o.Shoot.GetInfo().Spec.Networking.Nodes != nil && (o.Shoot.GetInfo().Status.Networking != nil || flowCtx.skipReadiness)
 
-		isRestoring   = operationType == gardencorev1beta1.LastOperationTypeRestore
-		skipReadiness = metav1.HasAnnotation(o.Shoot.GetInfo().ObjectMeta, v1beta1constants.AnnotationShootSkipReadiness)
-	)
-
+	var tasksWithErrors []string
 	for _, lastError := range o.Shoot.GetInfo().Status.LastErrors {
 		if lastError.TaskID != nil {
 			tasksWithErrors = append(tasksWithErrors, *lastError.TaskID)
 		}
 	}
 
-	errorContext := errors.NewErrorContext(fmt.Sprintf("Shoot cluster %s", utils.IifString(isRestoring, "restoration", "reconciliation")), tasksWithErrors)
+	var (
+		botanist     *botanistpkg.Botanist
+		worker       *extensionsv1alpha1.Worker
+		errorContext = errors.NewErrorContext(fmt.Sprintf("Shoot cluster %s", utils.IifString(flowCtx.isRestoring, "restoration", "reconciliation")), tasksWithErrors)
+	)
 
-	err = errors.HandleErrors(errorContext,
+	if err := errors.HandleErrors(errorContext,
 		func(errorID string) error {
 			o.CleanShootTaskError(ctx, errorID)
 			return nil
@@ -84,7 +111,8 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			return botanist.WaitUntilRequiredExtensionsReady(ctx)
 		}),
 		errors.ToExecute("Check if copy of backups is required", func() error {
-			isCopyOfBackupsRequired, err = botanist.IsCopyOfBackupsRequired(ctx)
+			var err error
+			flowCtx.isCopyOfBackupsRequired, err = botanist.IsCopyOfBackupsRequired(ctx)
 			return err
 		}),
 		errors.ToExecute("Retrieve the Worker resource", func() error {
@@ -101,34 +129,16 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			worker = obj
 			return nil
 		}),
-	)
-	if err != nil {
+	); err != nil {
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 	}
-
-	const (
-		defaultTimeout  = 30 * time.Second
-		defaultInterval = 5 * time.Second
-	)
-
-	var (
-		allowBackup                    = o.Seed.GetInfo().Spec.Backup != nil
-		hasNodesCIDR                   = o.Shoot.GetInfo().Spec.Networking != nil && o.Shoot.GetInfo().Spec.Networking.Nodes != nil && (o.Shoot.GetInfo().Status.Networking != nil || skipReadiness)
-		generation                     = o.Shoot.GetInfo().Generation
-		requestControlPlanePodsRestart = controllerutils.HasTask(o.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartControlPlanePods)
-		kubeProxyEnabled               = v1beta1helper.KubeProxyEnabled(o.Shoot.GetInfo().Spec.Kubernetes.KubeProxy)
-		deployKubeAPIServerTaskTimeout = defaultTimeout
-		shootSSHAccessEnabled          = v1beta1helper.ShootEnablesSSHAccess(o.Shoot.GetInfo())
-		isRestoringHAControlPlane      = botanist.IsRestorePhase() && v1beta1helper.IsHAControlPlaneConfigured(o.Shoot.GetInfo())
-		isHibernatingShootWithWorkers  = o.Shoot.HibernationEnabled && !o.Shoot.GetInfo().Status.IsHibernated && !o.Shoot.IsWorkerless
-	)
 
 	// During the 'Preparing' phase of different rotation operations, components are deployed twice. Also, the
 	// different deployment functions call the `Wait` method after the first deployment. Hence, we should use
 	// the respective timeout in this case instead of the (too short) default timeout to prevent undesired and confusing
 	// errors in the reconciliation flow.
 	if v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPreparing {
-		deployKubeAPIServerTaskTimeout = kubeapiserver.TimeoutWaitForDeployment
+		flowCtx.deployKubeAPIServerTaskTimeout = kubeapiserver.TimeoutWaitForDeployment
 	}
 
 	var (
@@ -140,7 +150,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitExtensionAfterKAPIMsg = "Waiting until extension resources hibernated before kube-apiserver hibernation are ready"
 	}
 
-	if hasNodesCIDR {
+	if flowCtx.hasNodesCIDR {
 		if err := botanist.UpdateDualStackMigrationConditionIfNeeded(ctx); err != nil {
 			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 		}
@@ -156,7 +166,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	}
 
 	var (
-		g = flow.NewGraph(fmt.Sprintf("Shoot cluster %s", utils.IifString(isRestoring, "restoration", "reconciliation")))
+		g = flow.NewGraph(fmt.Sprintf("Shoot cluster %s", utils.IifString(flowCtx.isRestoring, "restoration", "reconciliation")))
 
 		deployNamespace = g.Add(flow.Task{
 			Name: "Deploying Shoot namespace in Seed",
@@ -186,7 +196,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		initialValiDeployment = g.Add(flow.Task{
 			Name:         "Deploying initial shoot logging stack in Seed",
 			Fn:           flow.TaskFn(botanist.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       isHibernatingShootWithWorkers,
+			SkipIf:       flowCtx.isHibernatingShootWithWorkers,
 			Dependencies: flow.NewTaskIDs(deployNamespace, initializeSecretsManagement),
 		})
 		deployReferencedResources = g.Add(flow.Task{
@@ -203,7 +213,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilInfrastructureReady = g.Add(flow.Task{
 			Name: "Waiting until shoot infrastructure has been reconciled",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if !skipReadiness {
+				if !flowCtx.skipReadiness {
 					if err := botanist.WaitForInfrastructure(ctx); err != nil {
 						return err
 					}
@@ -216,7 +226,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployKubeAPIServerService = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes API server service in the Seed cluster",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServerService.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootClusterIdentity, initializeSecretsManagement).InsertIf(!hasNodesCIDR, waitUntilInfrastructureReady),
+			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootClusterIdentity, initializeSecretsManagement).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		waitUntilKubeAPIServerServiceIsReady = g.Add(flow.Task{
 			Name:         "Waiting until Kubernetes API server service in the Seed cluster has reported readiness",
@@ -254,43 +264,43 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deploySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Deploying source backup entry",
 			Fn:           botanist.DeploySourceBackupEntry,
-			SkipIf:       !isCopyOfBackupsRequired,
+			SkipIf:       !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		waitUntilSourceBackupEntryInGardenReconciled = g.Add(flow.Task{
 			Name:         "Waiting until the source backup entry has been reconciled",
 			Fn:           botanist.Shoot.Components.SourceBackupEntry.Wait,
-			SkipIf:       skipReadiness || !isCopyOfBackupsRequired,
+			SkipIf:       flowCtx.skipReadiness || !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(deploySourceBackupEntry),
 		})
 		deployBackupEntryInGarden = g.Add(flow.Task{
 			Name:         "Deploying backup entry",
 			Fn:           botanist.DeployBackupEntry,
-			SkipIf:       !allowBackup,
+			SkipIf:       !flowCtx.allowBackup,
 			Dependencies: flow.NewTaskIDs(deployNamespace, waitUntilSourceBackupEntryInGardenReconciled),
 		})
 		waitUntilBackupEntryInGardenReconciled = g.Add(flow.Task{
 			Name:         "Waiting until the backup entry has been reconciled",
 			Fn:           botanist.Shoot.Components.BackupEntry.Wait,
-			SkipIf:       skipReadiness || !allowBackup,
+			SkipIf:       flowCtx.skipReadiness || !flowCtx.allowBackup,
 			Dependencies: flow.NewTaskIDs(deployBackupEntryInGarden),
 		})
 		copyEtcdBackups = g.Add(flow.Task{
 			Name:         "Copying etcd backups to new seed's backup bucket",
 			Fn:           botanist.DeployEtcdCopyBackupsTask,
-			SkipIf:       !isCopyOfBackupsRequired,
+			SkipIf:       !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilBackupEntryInGardenReconciled, waitUntilSourceBackupEntryInGardenReconciled),
 		})
 		waitUntilEtcdBackupsCopied = g.Add(flow.Task{
 			Name:         "Waiting until etcd backups are copied",
 			Fn:           botanist.Shoot.Components.ControlPlane.EtcdCopyBackupsTask.Wait,
-			SkipIf:       skipReadiness || !isCopyOfBackupsRequired,
+			SkipIf:       flowCtx.skipReadiness || !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(copyEtcdBackups),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying copy etcd backups task resource",
 			Fn:           botanist.Shoot.Components.ControlPlane.EtcdCopyBackupsTask.Destroy,
-			SkipIf:       !isCopyOfBackupsRequired,
+			SkipIf:       !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(waitUntilEtcdBackupsCopied),
 		})
 		deployETCD = g.Add(flow.Task{
@@ -301,19 +311,19 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		destroySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Destroying source backup entry",
 			Fn:           botanist.DestroySourceBackupEntry,
-			SkipIf:       !allowBackup || !botanist.Shoot.IsRestorePhase(),
+			SkipIf:       !flowCtx.allowBackup || !botanist.Shoot.IsRestorePhase(),
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until source backup entry has been deleted",
 			Fn:           botanist.Shoot.Components.SourceBackupEntry.WaitCleanup,
-			SkipIf:       !allowBackup || skipReadiness || !botanist.Shoot.IsRestorePhase(),
+			SkipIf:       !flowCtx.allowBackup || flowCtx.skipReadiness || !botanist.Shoot.IsRestorePhase(),
 			Dependencies: flow.NewTaskIDs(destroySourceBackupEntry),
 		})
 		waitUntilEtcdReady = g.Add(flow.Task{
 			Name:         "Waiting until main and event etcd report readiness",
 			Fn:           botanist.WaitUntilEtcdsReady,
-			SkipIf:       (!isRestoringHAControlPlane && o.Shoot.HibernationEnabled) || skipReadiness,
+			SkipIf:       (!flowCtx.isRestoringHAControlPlane && o.Shoot.HibernationEnabled) || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
 		deployExtensionResourcesBeforeKAPI = g.Add(flow.Task{
@@ -325,26 +335,26 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilExtensionResourcesBeforeKAPIReady = g.Add(flow.Task{
 			Name:         "Waiting until extension resources handled before kube-apiserver are ready",
 			Fn:           botanist.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
-			SkipIf:       o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesBeforeKAPI),
 		})
 		deployKubeAPIServer = g.Add(flow.Task{
 			Name: "Deploying Kubernetes API server",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.DeployKubeAPIServer(ctx)
-			}).RetryUntilTimeout(defaultInterval, deployKubeAPIServerTaskTimeout),
+			}).RetryUntilTimeout(defaultInterval, flowCtx.deployKubeAPIServerTaskTimeout),
 			Dependencies: flow.NewTaskIDs(
 				initializeSecretsManagement,
 				deployETCD,
 				waitUntilEtcdReady,
 				waitUntilKubeAPIServerServiceIsReady,
 				waitUntilExtensionResourcesBeforeKAPIReady,
-			).InsertIf(!hasNodesCIDR, waitUntilInfrastructureReady),
+			).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		waitUntilKubeAPIServerIsReady = g.Add(flow.Task{
 			Name:         "Waiting until Kubernetes API server rolled out",
 			Fn:           botanist.Shoot.Components.ControlPlane.KubeAPIServer.Wait,
-			SkipIf:       o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServer),
 		})
 		_ = g.Add(flow.Task{
@@ -355,13 +365,13 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		scaleEtcdAfterRestore = g.Add(flow.Task{
 			Name:         "Scaling main and events etcd after kube-apiserver is ready",
 			Fn:           flow.TaskFn(botanist.ScaleUpETCD).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(o.Shoot, defaultTimeout)),
-			SkipIf:       !isRestoringHAControlPlane,
+			SkipIf:       !flowCtx.isRestoringHAControlPlane,
 			Dependencies: flow.NewTaskIDs(waitUntilEtcdReady, waitUntilKubeAPIServerIsReady),
 		})
 		waitUntilEtcdScaledAfterRestore = g.Add(flow.Task{
 			Name:         "Waiting until main and events etcd scaled up after kube-apiserver is ready",
 			Fn:           flow.TaskFn(botanist.WaitUntilEtcdsReady),
-			SkipIf:       !isRestoringHAControlPlane || skipReadiness,
+			SkipIf:       !flowCtx.isRestoringHAControlPlane || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(scaleEtcdAfterRestore),
 		})
 		deployGardenerResourceManager = g.Add(flow.Task{
@@ -372,7 +382,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilGardenerResourceManagerReady = g.Add(flow.Task{
 			Name:         "Waiting until gardener-resource-manager reports readiness",
 			Fn:           botanist.Shoot.Components.ControlPlane.ResourceManager.Wait,
-			SkipIf:       o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
@@ -400,7 +410,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.Shoot.Components.Extensions.ControlPlane.Wait(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || skipReadiness,
+			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployControlPlane),
 		})
 		deployShootNamespaces = g.Add(flow.Task{
@@ -411,7 +421,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilShootNamespacesReady = g.Add(flow.Task{
 			Name:         "Waiting until shoot namespaces have been reconciled",
 			Fn:           botanist.Shoot.Components.SystemComponents.Namespaces.Wait,
-			SkipIf:       o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, deployShootNamespaces),
 		})
 		deployVPNSeedServer = g.Add(flow.Task{
@@ -453,7 +463,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, o.SeedClientSet.Client(), botanist.SnapshotEtcd, o.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer)
 			}),
-			SkipIf: !allowBackup || o.Shoot.HibernationEnabled ||
+			SkipIf: !flowCtx.allowBackup || o.Shoot.HibernationEnabled ||
 				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
 					sets.New(o.Shoot.ResourcesToEncrypt...).Equal(sets.New(o.Shoot.EncryptedResources...)) && (o.Shoot.EncryptionProviderToUse == o.Shoot.UsedEncryptionProvider ||
 					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting)),
@@ -536,7 +546,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilKubeControllerManagerReady = g.Add(flow.Task{
 			Name: "Waiting until kube-controller-manager reports readiness",
 			Fn:   botanist.Shoot.Components.ControlPlane.KubeControllerManager.Wait,
-			SkipIf: skipReadiness || !sets.New(
+			SkipIf: flowCtx.skipReadiness || !sets.New(
 				gardencorev1beta1.RotationPreparing,
 				gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
 			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials)),
@@ -564,7 +574,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deleteBastions = g.Add(flow.Task{
 			Name:         "Deleting Bastions",
 			Fn:           botanist.DeleteBastions,
-			SkipIf:       shootSSHAccessEnabled,
+			SkipIf:       flowCtx.shootSSHAccessEnabled,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady),
 		})
 		deployExtensionResourcesAfterKAPI = g.Add(flow.Task{
@@ -575,7 +585,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilExtensionResourcesAfterKAPIReady = g.Add(flow.Task{
 			Name:         waitExtensionAfterKAPIMsg,
 			Fn:           botanist.Shoot.Components.Extensions.Extension.WaitAfterKubeAPIServer,
-			SkipIf:       skipReadiness,
+			SkipIf:       flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterKAPI),
 		})
 		deployOperatingSystemConfig = g.Add(flow.Task{
@@ -605,7 +615,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.Shoot.Components.Extensions.OperatingSystemConfig.WaitCleanupStaleResources(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deleteStaleOperatingSystemConfigResources),
 		})
 		deployNetwork = g.Add(flow.Task{
@@ -619,7 +629,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.Shoot.Components.Extensions.Network.Wait(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || skipReadiness,
+			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployNetwork),
 		})
 		_ = g.Add(flow.Task{
@@ -700,7 +710,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployKubeProxy = g.Add(flow.Task{
 			Name:   "Deploying kube-proxy system component",
 			Fn:     flow.TaskFn(botanist.DeployKubeProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || !kubeProxyEnabled,
+			SkipIf: o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || !flowCtx.kubeProxyEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				deployGardenerResourceManager, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
@@ -709,7 +719,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.Shoot.Components.SystemComponents.KubeProxy.DeleteStaleResources(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || !kubeProxyEnabled,
+			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || !flowCtx.kubeProxyEnabled,
 			Dependencies: flow.NewTaskIDs(deployKubeProxy),
 		})
 		_ = g.Add(flow.Task{
@@ -717,7 +727,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.Shoot.Components.SystemComponents.KubeProxy.Destroy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || kubeProxyEnabled,
+			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.kubeProxyEnabled,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler),
 		})
 		deployAPIServerProxy = g.Add(flow.Task{
@@ -856,7 +866,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 
 				return nil
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || skipReadiness,
+			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployWorker, waitUntilWorkerStatusUpdate, deployManagedResourceForGardenerNodeAgent),
 		})
 		_ = g.Add(flow.Task{
@@ -868,7 +878,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until extension resources handled after workers are ready",
 			Fn:           botanist.Shoot.Components.Extensions.Extension.WaitAfterWorker,
-			SkipIf:       o.Shoot.IsWorkerless || skipReadiness,
+			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterWorker),
 		})
 		_ = g.Add(flow.Task{
@@ -881,7 +891,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deploySeedLogging = g.Add(flow.Task{
 			Name:         "Deploying shoot logging stack in Seed",
 			Fn:           flow.TaskFn(botanist.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(initialValiDeployment, waitUntilGardenerResourceManagerReady).InsertIf(isHibernatingShootWithWorkers, waitUntilWorkerReady),
+			Dependencies: flow.NewTaskIDs(initialValiDeployment, waitUntilGardenerResourceManagerReady).InsertIf(flowCtx.isHibernatingShootWithWorkers, waitUntilWorkerReady),
 		})
 		deployPlutonoForLogging = g.Add(flow.Task{
 			Name:         "Reconciling Plutono for Shoot in Seed for the logging stack",
@@ -900,7 +910,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				if err := botanist.DeployOrDestroyIngressDNSRecord(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, o, generation, v1beta1constants.ShootTaskDeployDNSRecordIngress)
+				return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskDeployDNSRecordIngress)
 			}),
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(nginxLBReady),
@@ -908,7 +918,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilTunnelConnectionExists = g.Add(flow.Task{
 			Name:         "Waiting until the Kubernetes API server can connect to the Shoot workers",
 			Fn:           botanist.WaitUntilTunnelConnectionExists,
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, waitUntilNetworkIsReady, waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
@@ -922,7 +932,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployAlertmanager = g.Add(flow.Task{
 			Name:         "Reconciling Shoot Alertmanager",
 			Fn:           flow.TaskFn(botanist.DeployAlertManager).RetryUntilTimeout(defaultInterval, 2*time.Minute),
-			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!hasNodesCIDR, waitUntilInfrastructureReady),
+			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		waitUntilAlertmanagerReconciled = g.Add(flow.Task{
 			Name:         "Waiting until Shoot Alertmanager is reconciled",
@@ -932,7 +942,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployPrometheus = g.Add(flow.Task{
 			Name:         "Reconciling Shoot Prometheus",
 			Fn:           flow.TaskFn(botanist.DeployPrometheus).RetryUntilTimeout(defaultInterval, 2*time.Minute),
-			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!hasNodesCIDR, waitUntilInfrastructureReady),
+			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		waitUntilPrometheusReconciled = g.Add(flow.Task{
 			Name:         "Waiting until Shoot Prometheus is reconciled",
@@ -942,7 +952,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name:         "Deploying control plane blackbox-exporter",
 			Fn:           flow.TaskFn(botanist.ReconcileBlackboxExporterControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
-			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!hasNodesCIDR, waitUntilInfrastructureReady),
+			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Reconciling kube-state-metrics for Shoot in Seed for the monitoring stack",
@@ -984,7 +994,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until extension resources hibernated after kube-apiserver hibernation are ready",
 			Fn:           botanist.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
-			SkipIf:       skipReadiness || !o.Shoot.HibernationEnabled,
+			SkipIf:       flowCtx.skipReadiness || !o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(hibernateExtensionResourcesAfterKAPIHibernation),
 		})
 		_ = g.Add(flow.Task{
@@ -1013,7 +1023,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until stale extension resources are deleted",
 			Fn:           botanist.Shoot.Components.Extensions.Extension.WaitCleanupStaleResources,
-			SkipIf:       o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deleteStaleExtensionResources),
 		})
 		deployContainerRuntimeResources = g.Add(flow.Task{
@@ -1027,7 +1037,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.Shoot.Components.Extensions.ContainerRuntime.Wait(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || skipReadiness,
+			SkipIf:       o.Shoot.IsWorkerless || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployContainerRuntimeResources),
 		})
 		deleteStaleContainerRuntimeResources = g.Add(flow.Task{
@@ -1043,7 +1053,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.Shoot.Components.Extensions.ContainerRuntime.WaitCleanupStaleResources(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || skipReadiness,
+			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deleteStaleContainerRuntimeResources),
 		})
 		_ = g.Add(flow.Task{
@@ -1054,7 +1064,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				}
 				return removeTaskAnnotation(ctx, botanist, v1beta1constants.ShootTaskRestartControlPlanePods)
 			}),
-			SkipIf:       !requestControlPlanePodsRestart,
+			SkipIf:       !flowCtx.requestControlPlanePodsRestart,
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager, deployControlPlane),
 		})
 	)
@@ -1103,7 +1113,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		}
 	}
 
-	o.Logger.Info("Successfully reconciled Shoot cluster", "operation", utils.IifString(isRestoring, "restored", "reconciled"))
+	o.Logger.Info("Successfully reconciled Shoot cluster", "operation", utils.IifString(flowCtx.isRestoring, "restored", "reconciled"))
 	return nil
 }
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -61,10 +61,6 @@ type flowContext struct {
 // runReconcileShootFlow reconciles the Shoot cluster.
 // It receives an Operation object <o> which stores the Shoot object.
 func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Operation, operationType gardencorev1beta1.LastOperationType) *v1beta1helper.WrappedLastErrors {
-	if v1beta1helper.IsShootSelfHosted(o.Shoot.GetInfo().Spec.Provider.Workers) {
-		return nil
-	}
-
 	flowCtx := flowContext{
 		operationType:                  operationType,
 		allowBackup:                    v1beta1helper.GetBackupConfigForShoot(o.Shoot.GetInfo(), o.GetSeed()) != nil,
@@ -141,15 +137,6 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		flowCtx.deployKubeAPIServerTaskTimeout = kubeapiserver.TimeoutWaitForDeployment
 	}
 
-	var (
-		deployExtensionAfterKAPIMsg = "Deploying extension resources after kube-apiserver"
-		waitExtensionAfterKAPIMsg   = "Waiting until extension resources handled after kube-apiserver are ready"
-	)
-	if b.Shoot.HibernationEnabled {
-		deployExtensionAfterKAPIMsg = "Hibernating extension resources before kube-apiserver hibernation"
-		waitExtensionAfterKAPIMsg = "Waiting until extension resources hibernated before kube-apiserver hibernation are ready"
-	}
-
 	if flowCtx.hasNodesCIDR {
 		if err := b.UpdateDualStackMigrationConditionIfNeeded(ctx); err != nil {
 			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
@@ -165,9 +152,78 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 	}
 
-	var (
-		g = flow.NewGraph(fmt.Sprintf("Shoot cluster %s", utils.IifString(flowCtx.isRestoring, "restoration", "reconciliation")))
+	setupFlow := r.setupReconcileHostedShootFlow
+	if b.Shoot.IsSelfHosted() {
+		setupFlow = r.setupReconcileSelfHostedShootFlow
+	}
 
+	graph := flow.NewGraph(fmt.Sprintf("Shoot cluster %s", utils.IifString(flowCtx.isRestoring, "restoration", "reconciliation")))
+	if err := setupFlow(b, flowCtx, graph); err != nil {
+		err = fmt.Errorf("setting up reconciliation flow failed: %w", err)
+		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
+	}
+	f := graph.Compile()
+
+	if err := f.Run(ctx, flow.Opts{
+		Log:              b.Logger,
+		ProgressReporter: r.newProgressReporter(b.ReportShootProgress),
+		ErrorContext:     errorContext,
+		ErrorCleaner:     b.CleanShootTaskError,
+	}); err != nil {
+		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
+	}
+
+	// TODO(rfranzke): Remove this if-condition once the Shoot controller flow has progressed.
+	if !b.Shoot.IsSelfHosted() {
+		b.Logger.Info("Cleaning no longer required secrets")
+		if err := b.SecretsManager.Cleanup(ctx); err != nil {
+			err = fmt.Errorf("failed to clean no longer required secrets: %w", err)
+			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
+		}
+	}
+
+	if !r.ShootStateControllerEnabled && b.Shoot.IsRestorePhase() {
+		b.Logger.Info("Deleting Shoot State after successful restoration")
+		if err := shootstate.Delete(ctx, b.GardenClient, b.Shoot.GetInfo()); err != nil {
+			err = fmt.Errorf("failed to delete shoot state: %w", err)
+			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
+		}
+	}
+
+	// ensure that shoot client is invalidated after it has been hibernated
+	if b.Shoot.HibernationEnabled {
+		if err := b.ShootClientMap.InvalidateClient(keys.ForShoot(b.Shoot.GetInfo())); err != nil {
+			err = fmt.Errorf("failed to invalidate shoot client: %w", err)
+			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
+		}
+	}
+
+	if _, ok := b.Shoot.GetInfo().Annotations[v1beta1constants.AnnotationShootSkipReadiness]; ok {
+		b.Logger.Info("Removing skip-readiness annotation")
+
+		if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
+			delete(shoot.Annotations, v1beta1constants.AnnotationShootSkipReadiness)
+			return nil
+		}); err != nil {
+			return nil
+		}
+	}
+
+	b.Logger.Info("Successfully reconciled Shoot cluster", "operation", utils.IifString(flowCtx.isRestoring, "restored", "reconciled"))
+	return nil
+}
+
+func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flowCtx flowContext, g *flow.Graph) error {
+	var (
+		deployExtensionAfterKAPIMsg = "Deploying extension resources after kube-apiserver"
+		waitExtensionAfterKAPIMsg   = "Waiting until extension resources handled after kube-apiserver are ready"
+	)
+	if b.Shoot.HibernationEnabled {
+		deployExtensionAfterKAPIMsg = "Hibernating extension resources before kube-apiserver hibernation"
+		waitExtensionAfterKAPIMsg = "Waiting until extension resources hibernated before kube-apiserver hibernation are ready"
+	}
+
+	var (
 		deployNamespace = g.Add(flow.Task{
 			Name: "Deploying Shoot namespace in Seed",
 			Fn:   flow.TaskFn(b.DeployControlPlaneNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -1069,51 +1125,18 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 	)
 
-	f := g.Compile()
+	return nil
+}
 
-	if err := f.Run(ctx, flow.Opts{
-		Log:              b.Logger,
-		ProgressReporter: r.newProgressReporter(b.ReportShootProgress),
-		ErrorContext:     errorContext,
-		ErrorCleaner:     b.CleanShootTaskError,
-	}); err != nil {
-		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
-	}
-
-	b.Logger.Info("Cleaning no longer required secrets")
-	if err := b.SecretsManager.Cleanup(ctx); err != nil {
-		err = fmt.Errorf("failed to clean no longer required secrets: %w", err)
-		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
-	}
-
-	if !r.ShootStateControllerEnabled && b.Shoot.IsRestorePhase() {
-		b.Logger.Info("Deleting Shoot State after successful restoration")
-		if err := shootstate.Delete(ctx, b.GardenClient, b.Shoot.GetInfo()); err != nil {
-			err = fmt.Errorf("failed to delete shoot state: %w", err)
-			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
-		}
-	}
-
-	// ensure that shoot client is invalidated after it has been hibernated
-	if b.Shoot.HibernationEnabled {
-		if err := b.ShootClientMap.InvalidateClient(keys.ForShoot(b.Shoot.GetInfo())); err != nil {
-			err = fmt.Errorf("failed to invalidate shoot client: %w", err)
-			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
-		}
-	}
-
-	if _, ok := b.Shoot.GetInfo().Annotations[v1beta1constants.AnnotationShootSkipReadiness]; ok {
-		b.Logger.Info("Removing skip-readiness annotation")
-
-		if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
-			delete(shoot.Annotations, v1beta1constants.AnnotationShootSkipReadiness)
+func (r *Reconciler) setupReconcileSelfHostedShootFlow(b *botanistpkg.Botanist, flowCtx flowContext, g *flow.Graph) error {
+	_ = g.Add(flow.Task{
+		Name: "TODO(rfranzke): Construct this flow as progress on GEP-28 progresses.",
+		Fn: func(_ context.Context) error {
+			b.Logger.Info("Hello world!", "operationType", flowCtx.operationType)
 			return nil
-		}); err != nil {
-			return nil
-		}
-	}
+		},
+	})
 
-	b.Logger.Info("Successfully reconciled Shoot cluster", "operation", utils.IifString(flowCtx.isRestoring, "restored", "reconciled"))
 	return nil
 }
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -301,13 +301,13 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		destroySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Destroying source backup entry",
 			Fn:           botanist.DestroySourceBackupEntry,
-			SkipIf:       !allowBackup || !botanist.IsRestorePhase(),
+			SkipIf:       !allowBackup || !botanist.Shoot.IsRestorePhase(),
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until source backup entry has been deleted",
 			Fn:           botanist.Shoot.Components.SourceBackupEntry.WaitCleanup,
-			SkipIf:       !allowBackup || skipReadiness || !botanist.IsRestorePhase(),
+			SkipIf:       !allowBackup || skipReadiness || !botanist.Shoot.IsRestorePhase(),
 			Dependencies: flow.NewTaskIDs(destroySourceBackupEntry),
 		})
 		waitUntilEtcdReady = g.Add(flow.Task{
@@ -1076,7 +1076,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 	}
 
-	if !r.ShootStateControllerEnabled && botanist.IsRestorePhase() {
+	if !r.ShootStateControllerEnabled && botanist.Shoot.IsRestorePhase() {
 		o.Logger.Info("Deleting Shoot State after successful restoration")
 		if err := shootstate.Delete(ctx, botanist.GardenClient, botanist.Shoot.GetInfo()); err != nil {
 			err = fmt.Errorf("failed to delete shoot state: %w", err)

--- a/pkg/gardenlet/operation/botanist/backupentry.go
+++ b/pkg/gardenlet/operation/botanist/backupentry.go
@@ -51,7 +51,7 @@ func (b *Botanist) DefaultCoreBackupEntry() corebackupentry.Interface {
 // DeployBackupEntry deploys the BackupEntry resource in the Garden cluster and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployBackupEntry(ctx context.Context) error {
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		return b.Shoot.Components.BackupEntry.Restore(ctx, b.Shoot.GetShootState())
 	}
 	return b.Shoot.Components.BackupEntry.Deploy(ctx)

--- a/pkg/gardenlet/operation/botanist/botanist.go
+++ b/pkg/gardenlet/operation/botanist/botanist.go
@@ -88,9 +88,9 @@ func (b *Botanist) RequiredExtensionsReady(ctx context.Context) error {
 	if err := b.GardenClient.List(ctx, controllerRegistrationList); err != nil {
 		return err
 	}
-	requiredExtensions := gardenerutils.ComputeRequiredExtensionsForShoot(b.Shoot.GetInfo(), b.Seed.GetInfo(), controllerRegistrationList, b.Garden.InternalDomain, b.Shoot.ExternalDomain)
+	requiredExtensions := gardenerutils.ComputeRequiredExtensionsForShoot(b.Shoot.GetInfo(), b.GetSeed(), controllerRegistrationList, b.Garden.InternalDomain, b.Shoot.ExternalDomain)
 
-	return gardenerutils.RequiredExtensionsReady(ctx, b.GardenClient, b.Seed.GetInfo().Name, requiredExtensions)
+	return gardenerutils.RequiredExtensionsReady(ctx, b.GardenClient, b.GetSeed(), b.Shoot.GetInfo(), requiredExtensions)
 }
 
 // outOfClusterAPIServerFQDN returns the Fully Qualified Domain Name of the apiserver

--- a/pkg/gardenlet/operation/botanist/containerruntime.go
+++ b/pkg/gardenlet/operation/botanist/containerruntime.go
@@ -32,7 +32,7 @@ func (b *Botanist) DefaultContainerRuntime() containerruntime.Interface {
 // DeployContainerRuntime deploys the ContainerRuntime custom resources and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration
 func (b *Botanist) DeployContainerRuntime(ctx context.Context) error {
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.ContainerRuntime.Restore(ctx, b.Shoot.GetShootState())
 	}
 	return b.Shoot.Components.Extensions.ContainerRuntime.Deploy(ctx)

--- a/pkg/gardenlet/operation/botanist/controlplane.go
+++ b/pkg/gardenlet/operation/botanist/controlplane.go
@@ -187,7 +187,7 @@ func (b *Botanist) DeployControlPlane(ctx context.Context) error {
 }
 
 func (b *Botanist) deployOrRestoreControlPlane(ctx context.Context, controlPlane extensionscontrolplane.Interface) error {
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		return controlPlane.Restore(ctx, b.Shoot.GetShootState())
 	}
 	return controlPlane.Deploy(ctx)

--- a/pkg/gardenlet/operation/botanist/dnsrecord.go
+++ b/pkg/gardenlet/operation/botanist/dnsrecord.go
@@ -22,7 +22,7 @@ func (b *Botanist) DefaultExternalDNSRecord() extensionsdnsrecord.Interface {
 		SecretName:        DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + v1beta1constants.DNSRecordExternalName,
 		Namespace:         b.Shoot.ControlPlaneNamespace,
 		TTL:               b.dnsRecordTTLSeconds(),
-		AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordExternal) || b.IsRestorePhase(),
+		AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordExternal) || b.Shoot.IsRestorePhase(),
 		IPStack:           gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
 		Labels: map[string]string{
 			v1beta1constants.LabelRole:  v1beta1constants.LabelDNSRecordExternal,
@@ -62,7 +62,7 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 		ReconcileOnlyOnChangeOrError: b.Shoot.GetInfo().DeletionTimestamp != nil,
 		AnnotateOperation: b.Shoot.GetInfo().DeletionTimestamp != nil ||
 			controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordInternal) ||
-			b.IsRestorePhase(),
+			b.Shoot.IsRestorePhase(),
 		IPStack: gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
 		Labels: map[string]string{
 			v1beta1constants.LabelRole:  v1beta1constants.LabelDNSRecordInternal,
@@ -157,7 +157,7 @@ func (b *Botanist) MigrateInternalDNSRecord(ctx context.Context) error {
 }
 
 func (b *Botanist) deployOrRestoreDNSRecord(ctx context.Context, dnsRecord component.DeployMigrateWaiter) error {
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		return dnsRecord.Restore(ctx, b.Shoot.GetShootState())
 	}
 	return dnsRecord.Deploy(ctx)

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -201,7 +201,7 @@ func (b *Botanist) deployOrRestoreEtcd(ctx context.Context) error {
 }
 
 func (b *Botanist) isRestorationOfMultiNodeMainEtcdRequired(ctx context.Context) (bool, error) {
-	if !b.IsRestorePhase() || !v1beta1helper.IsHAControlPlaneConfigured(b.Shoot.GetInfo()) {
+	if !b.Shoot.IsRestorePhase() || !v1beta1helper.IsHAControlPlaneConfigured(b.Shoot.GetInfo()) {
 		return false, nil
 	}
 

--- a/pkg/gardenlet/operation/botanist/extension.go
+++ b/pkg/gardenlet/operation/botanist/extension.go
@@ -20,7 +20,7 @@ func (b *Botanist) DefaultExtension(ctx context.Context) (extension.Interface, e
 // DeployExtensionsAfterKubeAPIServer deploys the Extension custom resources and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployExtensionsAfterKubeAPIServer(ctx context.Context) error {
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.Extension.RestoreAfterKubeAPIServer(ctx, b.Shoot.GetShootState())
 	}
 	return b.Shoot.Components.Extensions.Extension.DeployAfterKubeAPIServer(ctx)
@@ -29,7 +29,7 @@ func (b *Botanist) DeployExtensionsAfterKubeAPIServer(ctx context.Context) error
 // DeployExtensionsAfterWorker deploys the Extension custom resources and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployExtensionsAfterWorker(ctx context.Context) error {
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.Extension.RestoreAfterWorker(ctx, b.Shoot.GetShootState())
 	}
 	return b.Shoot.Components.Extensions.Extension.DeployAfterWorker(ctx)
@@ -38,7 +38,7 @@ func (b *Botanist) DeployExtensionsAfterWorker(ctx context.Context) error {
 // DeployExtensionsBeforeKubeAPIServer deploys the Extension custom resources and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployExtensionsBeforeKubeAPIServer(ctx context.Context) error {
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.Extension.RestoreBeforeKubeAPIServer(ctx, b.Shoot.GetShootState())
 	}
 	return b.Shoot.Components.Extensions.Extension.DeployBeforeKubeAPIServer(ctx)

--- a/pkg/gardenlet/operation/botanist/infrastructure.go
+++ b/pkg/gardenlet/operation/botanist/infrastructure.go
@@ -33,7 +33,7 @@ func (b *Botanist) DefaultInfrastructure() infrastructure.Interface {
 			Type:              b.Shoot.GetInfo().Spec.Provider.Type,
 			ProviderConfig:    b.Shoot.GetInfo().Spec.Provider.InfrastructureConfig,
 			Region:            b.Shoot.GetInfo().Spec.Region,
-			AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployInfrastructure) || b.IsRestorePhase(),
+			AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployInfrastructure) || b.Shoot.IsRestorePhase(),
 		},
 		infrastructure.DefaultInterval,
 		infrastructure.DefaultSevereThreshold,
@@ -52,7 +52,7 @@ func (b *Botanist) DeployInfrastructure(ctx context.Context) error {
 		b.Shoot.Components.Extensions.Infrastructure.SetSSHPublicKey(sshKeypairSecret.Data[secrets.DataKeySSHAuthorizedKeys])
 	}
 
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.Infrastructure.Restore(ctx, b.Shoot.GetShootState())
 	}
 

--- a/pkg/gardenlet/operation/botanist/machinecontrollermanager.go
+++ b/pkg/gardenlet/operation/botanist/machinecontrollermanager.go
@@ -73,7 +73,7 @@ func (b *Botanist) DeployMachineControllerManager(ctx context.Context) error {
 	// This is required so that the Machine and MachineSet objects can be restored from the ShootState before
 	// MCM is started. The worker actuator is responsible for scaling MCM to 1 replica after the Machine and MachineSet
 	// objects are restored and before the worker resource is reconciled.
-	case b.IsRestorePhase():
+	case b.Shoot.IsRestorePhase():
 		replicas = 0
 	}
 	b.Shoot.Components.ControlPlane.MachineControllerManager.SetReplicas(replicas)

--- a/pkg/gardenlet/operation/botanist/migration.go
+++ b/pkg/gardenlet/operation/botanist/migration.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -71,7 +69,7 @@ func (b *Botanist) runParallelTaskForEachComponent(ctx context.Context, componen
 
 // IsCopyOfBackupsRequired check if etcd backups need to be copied between seeds.
 func (b *Botanist) IsCopyOfBackupsRequired(ctx context.Context) (bool, error) {
-	if b.Seed.GetInfo().Spec.Backup == nil || !b.IsRestorePhase() {
+	if b.Seed.GetInfo().Spec.Backup == nil || !b.Shoot.IsRestorePhase() {
 		return false, nil
 	}
 
@@ -106,11 +104,6 @@ func (b *Botanist) IsCopyOfBackupsRequired(ctx context.Context) (bool, error) {
 	}
 
 	return true, nil
-}
-
-// IsRestorePhase returns true when the shoot is in phase 'restore'.
-func (b *Botanist) IsRestorePhase() bool {
-	return v1beta1helper.ShootHasOperationType(b.Shoot.GetInfo().Status.LastOperation, gardencorev1beta1.LastOperationTypeRestore)
 }
 
 // ShallowDeleteMachineResources deletes all machine-related resources by forcefully removing their finalizers.

--- a/pkg/gardenlet/operation/botanist/migration.go
+++ b/pkg/gardenlet/operation/botanist/migration.go
@@ -69,7 +69,7 @@ func (b *Botanist) runParallelTaskForEachComponent(ctx context.Context, componen
 
 // IsCopyOfBackupsRequired check if etcd backups need to be copied between seeds.
 func (b *Botanist) IsCopyOfBackupsRequired(ctx context.Context) (bool, error) {
-	if b.Seed.GetInfo().Spec.Backup == nil || !b.Shoot.IsRestorePhase() {
+	if b.Shoot.IsSelfHosted() || b.Seed.GetInfo().Spec.Backup == nil || !b.Shoot.IsRestorePhase() {
 		return false, nil
 	}
 

--- a/pkg/gardenlet/operation/botanist/migration_test.go
+++ b/pkg/gardenlet/operation/botanist/migration_test.go
@@ -338,12 +338,12 @@ var _ = Describe("migration", func() {
 	Describe("#IsRestorePhase", func() {
 		It("should return true", func() {
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{Status: gardencorev1beta1.ShootStatus{LastOperation: &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeRestore}}})
-			Expect(botanist.IsRestorePhase()).To(BeTrue())
+			Expect(botanist.Shoot.IsRestorePhase()).To(BeTrue())
 		})
 
 		It("should return false", func() {
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{Status: gardencorev1beta1.ShootStatus{LastOperation: &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeCreate}}})
-			Expect(botanist.IsRestorePhase()).To(BeFalse())
+			Expect(botanist.Shoot.IsRestorePhase()).To(BeFalse())
 		})
 	})
 

--- a/pkg/gardenlet/operation/botanist/network.go
+++ b/pkg/gardenlet/operation/botanist/network.go
@@ -44,7 +44,7 @@ func (b *Botanist) DeployNetwork(ctx context.Context) error {
 	b.Shoot.Components.Extensions.Network.SetPodCIDRs(b.Shoot.Networks.Pods)
 	b.Shoot.Components.Extensions.Network.SetServiceCIDRs(b.Shoot.Networks.Services)
 
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.Network.Restore(ctx, b.Shoot.GetShootState())
 	}
 

--- a/pkg/gardenlet/operation/botanist/nginxingress.go
+++ b/pkg/gardenlet/operation/botanist/nginxingress.go
@@ -114,7 +114,7 @@ func (b *Botanist) DefaultIngressDNSRecord() extensionsdnsrecord.Interface {
 		SecretName:        DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + v1beta1constants.DNSRecordExternalName,
 		Namespace:         b.Shoot.ControlPlaneNamespace,
 		TTL:               b.dnsRecordTTLSeconds(),
-		AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordIngress) || b.IsRestorePhase(),
+		AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordIngress) || b.Shoot.IsRestorePhase(),
 		IPStack:           gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
 		Labels: map[string]string{
 			v1beta1constants.LabelRole:  v1beta1constants.LabelDNSRecordIngress,

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -172,7 +172,7 @@ func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
 	}
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetClusterDNSAddresses(clusterDNSAddresses)
 
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.OperatingSystemConfig.Restore(ctx, b.Shoot.GetShootState())
 	}
 

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	shootstate "github.com/gardener/gardener/pkg/utils/gardener/shootstate"
+	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 	"github.com/gardener/gardener/pkg/utils/gardener/tokenrequest"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -41,7 +41,7 @@ func (b *Botanist) InitializeSecretsManagement(ctx context.Context) error {
 	// create corresponding secrets in the shoot namespace in the seed before initializing it. Note that this is
 	// explicitly only done in case of restoration to prevent split-brain situations as described in
 	// https://github.com/gardener/gardener/issues/5377.
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		if err := b.restoreSecretsFromShootState(ctx); err != nil {
 			return err
 		}

--- a/pkg/gardenlet/operation/botanist/worker.go
+++ b/pkg/gardenlet/operation/botanist/worker.go
@@ -74,7 +74,7 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 	b.Shoot.Components.Extensions.Worker.SetInfrastructureProviderStatus(b.Shoot.Components.Extensions.Infrastructure.ProviderStatus())
 	b.Shoot.Components.Extensions.Worker.SetWorkerPoolNameToOperatingSystemConfigsMap(b.Shoot.Components.Extensions.OperatingSystemConfig.WorkerPoolNameToOperatingSystemConfigsMap())
 
-	if b.IsRestorePhase() {
+	if b.Shoot.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.Worker.Restore(ctx, b.Shoot.GetShootState())
 	}
 

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -727,3 +727,8 @@ func (s *Shoot) HasManagedInfrastructure() bool {
 func (s *Shoot) HasExtensionExposure() bool {
 	return v1beta1helper.HasExtensionExposure(s.GetInfo())
 }
+
+// IsRestorePhase returns true when the shoot is in phase 'restore'.
+func (s *Shoot) IsRestorePhase() bool {
+	return v1beta1helper.ShootHasOperationType(s.GetInfo().Status.LastOperation, gardencorev1beta1.LastOperationTypeRestore)
+}

--- a/pkg/gardenlet/operation/shoot/shoot_test.go
+++ b/pkg/gardenlet/operation/shoot/shoot_test.go
@@ -327,6 +327,22 @@ var _ = Describe("shoot", func() {
 			})
 		})
 
+		Describe("#IsRestorePhase", func() {
+			It("should return false when last operation is nil", func() {
+				Expect(shoot.IsRestorePhase()).To(BeFalse())
+			})
+
+			It("should return false when last operation type is not Restore", func() {
+				shoot.SetInfo(&gardencorev1beta1.Shoot{Status: gardencorev1beta1.ShootStatus{LastOperation: &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeReconcile}}})
+				Expect(shoot.IsRestorePhase()).To(BeFalse())
+			})
+
+			It("should return true when last operation type is Restore", func() {
+				shoot.SetInfo(&gardencorev1beta1.Shoot{Status: gardencorev1beta1.ShootStatus{LastOperation: &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeRestore}}})
+				Expect(shoot.IsRestorePhase()).To(BeTrue())
+			})
+		})
+
 		Describe("#SortByIPFamilies", func() {
 			var (
 				ipv4CIDR1 = net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}

--- a/pkg/utils/gardener/seed.go
+++ b/pkg/utils/gardener/seed.go
@@ -115,11 +115,16 @@ func ExtensionKindAndTypeForID(extensionID string) (extensionKind string, extens
 }
 
 // RequiredExtensionsReady checks if all required extensions for a seed exist and are ready.
-func RequiredExtensionsReady(ctx context.Context, gardenClient client.Client, seedName string, requiredExtensions sets.Set[string]) error {
+func RequiredExtensionsReady(ctx context.Context, gardenClient client.Client, seed *gardencorev1beta1.Seed, shoot *gardencorev1beta1.Shoot, requiredExtensions sets.Set[string]) error {
+	var fieldSelector client.ListOption
+	if seed != nil {
+		fieldSelector = client.MatchingFields{core.SeedRefName: seed.Name}
+	} else if shoot != nil {
+		fieldSelector = client.MatchingFields{core.ShootRefName: shoot.Name, core.ShootRefNamespace: shoot.Namespace}
+	}
+
 	controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
-	if err := gardenClient.List(ctx, controllerInstallationList, client.MatchingFields{
-		core.SeedRefName: seedName,
-	}); err != nil {
+	if err := gardenClient.List(ctx, controllerInstallationList, fieldSelector); err != nil {
 		return err
 	}
 

--- a/pkg/utils/gardener/seed_test.go
+++ b/pkg/utils/gardener/seed_test.go
@@ -576,7 +576,8 @@ var _ = Describe("utils", func() {
 
 			seedProvider       string
 			dnsProvider        string
-			seedName           string
+			seed               *gardencorev1beta1.Seed
+			shoot              *gardencorev1beta1.Shoot
 			requiredExtensions sets.Set[string]
 		)
 
@@ -590,12 +591,23 @@ var _ = Describe("utils", func() {
 					core.SeedRefName,
 					indexer.ControllerInstallationSeedRefNameIndexerFunc,
 				).
+				WithIndex(
+					&gardencorev1beta1.ControllerInstallation{},
+					core.ShootRefName,
+					indexer.ControllerInstallationShootRefNameIndexerFunc,
+				).
+				WithIndex(
+					&gardencorev1beta1.ControllerInstallation{},
+					core.ShootRefNamespace,
+					indexer.ControllerInstallationShootRefNamespaceIndexerFunc,
+				).
 				Build()
 
 			seedProvider = "seedProvider"
 			dnsProvider = "dnsProvider"
 
-			seedName = "seed"
+			seed = &gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: "seed"}}
+			shoot = &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: "shoot", Namespace: "garden-project"}}
 
 			requiredExtensions = sets.New(
 				"DNSRecord/"+dnsProvider,
@@ -616,7 +628,7 @@ var _ = Describe("utils", func() {
 
 		Context("when required ControllerInstallations are missing", func() {
 			It("should fail checking all required extensions", func() {
-				Expect(RequiredExtensionsReady(ctx, fakeClient, seedName, requiredExtensions)).To(MatchError("extension controllers missing or unready: map[ControlPlane/seedProvider:{} DNSRecord/dnsProvider:{} Infrastructure/seedProvider:{} Worker/seedProvider:{}]"))
+				Expect(RequiredExtensionsReady(ctx, fakeClient, seed, nil, requiredExtensions)).To(MatchError("extension controllers missing or unready: map[ControlPlane/seedProvider:{} DNSRecord/dnsProvider:{} Infrastructure/seedProvider:{} Worker/seedProvider:{}]"))
 			})
 		})
 
@@ -632,7 +644,7 @@ var _ = Describe("utils", func() {
 								Name: "foo",
 							},
 							SeedRef: &corev1.ObjectReference{
-								Name: seedName,
+								Name: seed.Name,
 							},
 						},
 						Status: gardencorev1beta1.ControllerInstallationStatus{
@@ -647,7 +659,7 @@ var _ = Describe("utils", func() {
 			})
 
 			It("should fail checking all required extensions", func() {
-				Expect(RequiredExtensionsReady(ctx, fakeClient, seedName, requiredExtensions)).To(MatchError("controllerregistrations.core.gardener.cloud \"foo\" not found"))
+				Expect(RequiredExtensionsReady(ctx, fakeClient, seed, nil, requiredExtensions)).To(MatchError("controllerregistrations.core.gardener.cloud \"foo\" not found"))
 			})
 		})
 
@@ -687,7 +699,11 @@ var _ = Describe("utils", func() {
 								Name: controllerRegistrations[0].Name,
 							},
 							SeedRef: &corev1.ObjectReference{
-								Name: seedName,
+								Name: seed.Name,
+							},
+							ShootRef: &corev1.ObjectReference{
+								Name:      shoot.Name,
+								Namespace: shoot.Namespace,
 							},
 						},
 						Status: gardencorev1beta1.ControllerInstallationStatus{
@@ -707,7 +723,11 @@ var _ = Describe("utils", func() {
 								Name: controllerRegistrations[1].Name,
 							},
 							SeedRef: &corev1.ObjectReference{
-								Name: seedName,
+								Name: seed.Name,
+							},
+							ShootRef: &corev1.ObjectReference{
+								Name:      shoot.Name,
+								Namespace: shoot.Namespace,
 							},
 						},
 					},
@@ -727,8 +747,12 @@ var _ = Describe("utils", func() {
 					}
 				})
 
-				It("should succeed checking all required extensions", func() {
-					Expect(RequiredExtensionsReady(ctx, fakeClient, seedName, requiredExtensions)).To(Succeed())
+				It("should succeed checking all required extensions filtered by seed", func() {
+					Expect(RequiredExtensionsReady(ctx, fakeClient, seed, nil, requiredExtensions)).To(Succeed())
+				})
+
+				It("should succeed checking all required extensions filtered by shoot", func() {
+					Expect(RequiredExtensionsReady(ctx, fakeClient, nil, shoot, requiredExtensions)).To(Succeed())
 				})
 			})
 
@@ -743,8 +767,12 @@ var _ = Describe("utils", func() {
 					}
 				})
 
-				It("should fail checking all required extensions", func() {
-					Expect(RequiredExtensionsReady(ctx, fakeClient, seedName, requiredExtensions)).To(MatchError("extension controllers missing or unready: map[DNSRecord/dnsProvider:{}]"))
+				It("should fail checking all required extensions filtered by seed", func() {
+					Expect(RequiredExtensionsReady(ctx, fakeClient, seed, nil, requiredExtensions)).To(MatchError("extension controllers missing or unready: map[DNSRecord/dnsProvider:{}]"))
+				})
+
+				It("should fail checking all required extensions filtered by shoot", func() {
+					Expect(RequiredExtensionsReady(ctx, fakeClient, nil, shoot, requiredExtensions)).To(MatchError("extension controllers missing or unready: map[DNSRecord/dnsProvider:{}]"))
 				})
 			})
 		})

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -733,7 +733,7 @@ var _ = Describe("Seed controller tests", func() {
 
 				// Wait for extension resources to be ready
 				Eventually(func() error {
-					return gardenerutils.RequiredExtensionsReady(ctx, testClient, seed.Name, gardenerutils.ComputeRequiredExtensionsForSeed(seed, controllerRegistrationList))
+					return gardenerutils.RequiredExtensionsReady(ctx, testClient, seed, nil, gardenerutils.ComputeRequiredExtensionsForSeed(seed, controllerRegistrationList))
 				}).WithTimeout(time.Minute).Should(Succeed())
 
 				By("Verify seed has extension label")
@@ -1103,7 +1103,7 @@ var _ = Describe("Seed controller tests", func() {
 					Expect(testClient.List(ctx, controllerRegistrationList)).To(Succeed())
 
 					Eventually(func() error {
-						return gardenerutils.RequiredExtensionsReady(ctx, testClient, seed.Name, gardenerutils.ComputeRequiredExtensionsForSeed(seed, controllerRegistrationList))
+						return gardenerutils.RequiredExtensionsReady(ctx, testClient, seed, nil, gardenerutils.ComputeRequiredExtensionsForSeed(seed, controllerRegistrationList))
 					}).WithTimeout(time.Minute).Should(Succeed())
 
 					By("Verify that seed system components have been deployed (without components managed by shoot gardenlet)")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR prepares the `Shoot` controller in `gardenlet` to run a separate flow for self-hosted `Shoot`s (compared to the existing flow for hosted `Shoot`s).

In the course of GEP-28, the goal is to harmonize them as much as possible.

The next step is to make this self-hosted flow run the same steps as `gardenadm init` (except for the only-bootstrapping-related tasks), though, this requires #15311.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
All authenticated users are now allowed to read `ControllerRegistration`s in the garden cluster (these resources contain metadata information about the registered extensions in the system).
```
