### PR TITLE
Safely disable IstioTLSTermination feature gate

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/sni.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -422,17 +421,15 @@ func (s *sni) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutForManagedResource)
 	defer cancel()
 
-	var errs error
-
 	if s.valuesFunc().IstioTLSTermination {
 		if err := managedresources.WaitUntilHealthy(timeoutCtx, s.client, s.namespace, managedResourceName); err != nil {
-			errs = errors.Join(err)
+			return err
 		}
 		if err := managedresources.WaitUntilHealthy(timeoutCtx, s.client, s.namespace, managedResourceNameIstioTLSSecrets); err != nil {
-			errs = errors.Join(err)
+			return err
 		}
 	}
-	return errs
+	return nil
 }
 
 func (s *sni) WaitCleanup(_ context.Context) error { return nil }

--- a/pkg/component/kubernetes/apiserverexposure/sni.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -415,7 +416,25 @@ func (s *sni) Destroy(ctx context.Context) error {
 	)
 }
 
-func (s *sni) Wait(_ context.Context) error        { return nil }
+const timeoutForManagedResource = 2 * time.Minute
+
+func (s *sni) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutForManagedResource)
+	defer cancel()
+
+	var errs error
+
+	if s.valuesFunc().IstioTLSTermination {
+		if err := managedresources.WaitUntilHealthy(timeoutCtx, s.client, s.namespace, managedResourceName); err != nil {
+			errs = errors.Join(err)
+		}
+		if err := managedresources.WaitUntilHealthy(timeoutCtx, s.client, s.namespace, managedResourceNameIstioTLSSecrets); err != nil {
+			errs = errors.Join(err)
+		}
+	}
+	return errs
+}
+
 func (s *sni) WaitCleanup(_ context.Context) error { return nil }
 
 func (s *sni) emptyDestinationRule() *istionetworkingv1beta1.DestinationRule {

--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -845,7 +845,7 @@ var _ = Describe("#SNI", func() {
 					Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
 				})
 
-				It("should fail because the ManagedResource doesn't become healthy", func() {
+				It("should fail because the SNI ManagedResource doesn't become healthy", func() {
 					fakeOps.MaxAttempts = 2
 
 					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
@@ -864,6 +864,54 @@ var _ = Describe("#SNI", func() {
 								{
 									Type:   resourcesv1alpha1.ResourcesHealthy,
 									Status: gardencorev1beta1.ConditionFalse,
+								},
+							},
+						},
+					})).To(Succeed())
+
+					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       expectedManagedResourceTLSSecrets.Name,
+							Namespace:  expectedManagedResourceTLSSecrets.Namespace,
+							Generation: 1,
+						},
+						Status: resourcesv1alpha1.ManagedResourceStatus{
+							ObservedGeneration: 1,
+							Conditions: []gardencorev1beta1.Condition{
+								{
+									Type:   resourcesv1alpha1.ResourcesApplied,
+									Status: gardencorev1beta1.ConditionTrue,
+								},
+								{
+									Type:   resourcesv1alpha1.ResourcesHealthy,
+									Status: gardencorev1beta1.ConditionTrue,
+								},
+							},
+						},
+					})).To(Succeed())
+
+					Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+				})
+
+				It("should fail because the Istio TLS Secrets ManagedResource doesn't become healthy", func() {
+					fakeOps.MaxAttempts = 2
+
+					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       expectedManagedResourceSNI.Name,
+							Namespace:  expectedManagedResourceSNI.Namespace,
+							Generation: 1,
+						},
+						Status: resourcesv1alpha1.ManagedResourceStatus{
+							ObservedGeneration: 1,
+							Conditions: []gardencorev1beta1.Condition{
+								{
+									Type:   resourcesv1alpha1.ResourcesApplied,
+									Status: gardencorev1beta1.ConditionTrue,
+								},
+								{
+									Type:   resourcesv1alpha1.ResourcesHealthy,
+									Status: gardencorev1beta1.ConditionTrue,
 								},
 							},
 						},

--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -29,6 +30,8 @@ import (
 	. "github.com/gardener/gardener/pkg/component/kubernetes/apiserverexposure"
 	comptest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -781,12 +784,6 @@ var _ = Describe("#SNI", func() {
 		Expect(c.Get(ctx, client.ObjectKey{Namespace: expectedManagedResourceTLSSecrets.Namespace, Name: managedResourceTLSSecretName}, &corev1.Secret{})).To(BeNotFoundError())
 	})
 
-	Describe("#Wait", func() {
-		It("should succeed because it's not implemented", func() {
-			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed())
-		})
-	})
-
 	Describe("#WaitCleanup", func() {
 		It("should succeed because it's not implemented", func() {
 			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(Succeed())
@@ -807,6 +804,143 @@ var _ = Describe("#SNI", func() {
 
 			Expect(ReconcileIstioInternalLoadBalancingConfigMap(ctx, c, namespace, "", []string{}, false)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "istio-internal-load-balancing"}, configMap)).To(BeNotFoundError())
+		})
+	})
+
+	Context("waiting functions", func() {
+		var (
+			fakeOps   *retryfake.Ops
+			resetVars func()
+		)
+
+		BeforeEach(func() {
+			fakeOps = &retryfake.Ops{MaxAttempts: 1}
+			resetVars = test.WithVars(
+				&retry.Until, fakeOps.Until,
+				&retry.UntilTimeout, fakeOps.UntilTimeout,
+			)
+		})
+
+		AfterEach(func() {
+			resetVars()
+		})
+
+		Describe("#Wait", func() {
+			Context("when IstioTLSTermination is disabled", func() {
+				BeforeEach(func() {
+					istioTLSTermination = false
+				})
+
+				It("should succeed immediately", func() {
+					Expect(defaultDepWaiter.Wait(ctx)).To(Succeed())
+				})
+			})
+
+			Context("when IstioTLSTermination is enabled", func() {
+				BeforeEach(func() {
+					istioTLSTermination = true
+				})
+
+				It("should fail because reading the ManagedResource fails", func() {
+					Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+				})
+
+				It("should fail because the ManagedResource doesn't become healthy", func() {
+					fakeOps.MaxAttempts = 2
+
+					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       expectedManagedResourceSNI.Name,
+							Namespace:  expectedManagedResourceSNI.Namespace,
+							Generation: 1,
+						},
+						Status: resourcesv1alpha1.ManagedResourceStatus{
+							ObservedGeneration: 1,
+							Conditions: []gardencorev1beta1.Condition{
+								{
+									Type:   resourcesv1alpha1.ResourcesApplied,
+									Status: gardencorev1beta1.ConditionFalse,
+								},
+								{
+									Type:   resourcesv1alpha1.ResourcesHealthy,
+									Status: gardencorev1beta1.ConditionFalse,
+								},
+							},
+						},
+					})).To(Succeed())
+
+					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       expectedManagedResourceTLSSecrets.Name,
+							Namespace:  expectedManagedResourceTLSSecrets.Namespace,
+							Generation: 1,
+						},
+						Status: resourcesv1alpha1.ManagedResourceStatus{
+							ObservedGeneration: 1,
+							Conditions: []gardencorev1beta1.Condition{
+								{
+									Type:   resourcesv1alpha1.ResourcesApplied,
+									Status: gardencorev1beta1.ConditionFalse,
+								},
+								{
+									Type:   resourcesv1alpha1.ResourcesHealthy,
+									Status: gardencorev1beta1.ConditionFalse,
+								},
+							},
+						},
+					})).To(Succeed())
+
+					Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+				})
+
+				It("should successfully wait for the managed resource to become healthy", func() {
+					fakeOps.MaxAttempts = 2
+
+					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       expectedManagedResourceSNI.Name,
+							Namespace:  expectedManagedResourceSNI.Namespace,
+							Generation: 1,
+						},
+						Status: resourcesv1alpha1.ManagedResourceStatus{
+							ObservedGeneration: 1,
+							Conditions: []gardencorev1beta1.Condition{
+								{
+									Type:   resourcesv1alpha1.ResourcesApplied,
+									Status: gardencorev1beta1.ConditionTrue,
+								},
+								{
+									Type:   resourcesv1alpha1.ResourcesHealthy,
+									Status: gardencorev1beta1.ConditionTrue,
+								},
+							},
+						},
+					})).To(Succeed())
+
+					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       expectedManagedResourceTLSSecrets.Name,
+							Namespace:  expectedManagedResourceTLSSecrets.Namespace,
+							Generation: 1,
+						},
+						Status: resourcesv1alpha1.ManagedResourceStatus{
+							ObservedGeneration: 1,
+							Conditions: []gardencorev1beta1.Condition{
+								{
+									Type:   resourcesv1alpha1.ResourcesApplied,
+									Status: gardencorev1beta1.ConditionTrue,
+								},
+								{
+									Type:   resourcesv1alpha1.ResourcesHealthy,
+									Status: gardencorev1beta1.ConditionTrue,
+								},
+							},
+						},
+					})).To(Succeed())
+
+					Expect(defaultDepWaiter.Wait(ctx)).To(Succeed())
+				})
+			})
 		})
 	})
 

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -343,7 +343,7 @@ func (r *Reconciler) newGardenerResourceManager(seed *gardencorev1beta1.Seed, se
 		SecretNameServerCA:                        v1beta1constants.SecretNameCASeed,
 		Zones:                                     seed.Spec.Provider.Zones,
 		PodKubeAPIServerLoadBalancingWebhook: resourcemanager.PodKubeAPIServerLoadBalancingWebhook{
-			Enabled: features.DefaultFeatureGate.Enabled(features.IstioTLSTermination),
+			Enabled: true,
 			Configs: []resourcemanager.PodKubeAPIServerLoadBalancingWebhookConfig{
 				{
 					NamespaceSelector: map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot},

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -23,7 +23,6 @@ import (
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
 	"github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot/helper"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
@@ -423,7 +422,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 		_ = g.Add(flow.Task{
 			Name:         "Cleaning up stale Kubernetes API server services in the Seed cluster",
 			Fn:           flow.TaskFn(b.CleanupKubeAPIServerLoadBalancingServices).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && b.ShootUsesIstioTLSTermination(),
+			SkipIf:       b.ShootUsesIstioTLSTermination(),
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerServiceSNISettings),
 		})
 		scaleEtcdAfterRestore = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -416,13 +416,14 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServer),
 		})
 		deployKubeAPIServerServiceSNISettings = g.Add(flow.Task{
-			Name:         "Deploying Kubernetes API server service SNI settings in the Seed cluster",
+			Name:         "Deploying and waiting for Kubernetes API server service SNI settings in the Seed cluster",
 			Fn:           flow.TaskFn(b.DeployKubeAPIServerSNI).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
 		})
-		waitUntilKubeAPIServerSNISettingsReady = g.Add(flow.Task{
-			Name:         "Waiting until Kubernetes API server service SNI settings are ready",
-			Fn:           b.Shoot.Components.ControlPlane.KubeAPIServerSNI.Wait,
+		_ = g.Add(flow.Task{
+			Name:         "Cleaning up stale Kubernetes API server services in the Seed cluster",
+			Fn:           flow.TaskFn(b.CleanupKubeAPIServerLoadBalancingServices).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && b.ShootUsesIstioTLSTermination(),
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerServiceSNISettings),
 		})
 		scaleEtcdAfterRestore = g.Add(flow.Task{
@@ -1129,12 +1130,6 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 			}),
 			SkipIf:       !flowCtx.requestControlPlanePodsRestart,
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager, deployControlPlane),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Cleaning up kube-apiserver TLS services",
-			Fn:           flow.TaskFn(b.DestroyKubeAPIServerTLSServices).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
-			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerSNISettingsReady),
 		})
 	)
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -23,6 +23,7 @@ import (
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
 	"github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot/helper"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
@@ -414,10 +415,15 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServer),
 		})
-		_ = g.Add(flow.Task{
+		deployKubeAPIServerServiceSNISettings = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes API server service SNI settings in the Seed cluster",
 			Fn:           flow.TaskFn(b.DeployKubeAPIServerSNI).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
+		})
+		waitUntilKubeAPIServerSNISettingsReady = g.Add(flow.Task{
+			Name:         "Waiting until Kubernetes API server service SNI settings are ready",
+			Fn:           botanist.Shoot.Components.ControlPlane.KubeAPIServerSNI.Wait,
+			Dependencies: flow.NewTaskIDs(deployKubeAPIServerServiceSNISettings),
 		})
 		scaleEtcdAfterRestore = g.Add(flow.Task{
 			Name:         "Scaling main and events etcd after kube-apiserver is ready",
@@ -1123,6 +1129,12 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 			}),
 			SkipIf:       !flowCtx.requestControlPlanePodsRestart,
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager, deployControlPlane),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Cleaning up kube-apiserver TLS services",
+			Fn:           flow.TaskFn(botanist.DestroyKubeAPIServerTLSServices).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(o.Shoot.GetInfo()),
+			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerSNISettingsReady),
 		})
 	)
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -422,7 +422,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 		})
 		waitUntilKubeAPIServerSNISettingsReady = g.Add(flow.Task{
 			Name:         "Waiting until Kubernetes API server service SNI settings are ready",
-			Fn:           botanist.Shoot.Components.ControlPlane.KubeAPIServerSNI.Wait,
+			Fn:           b.Shoot.Components.ControlPlane.KubeAPIServerSNI.Wait,
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerServiceSNISettings),
 		})
 		scaleEtcdAfterRestore = g.Add(flow.Task{
@@ -1132,8 +1132,8 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Cleaning up kube-apiserver TLS services",
-			Fn:           flow.TaskFn(botanist.DestroyKubeAPIServerTLSServices).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(o.Shoot.GetInfo()),
+			Fn:           flow.TaskFn(b.DestroyKubeAPIServerTLSServices).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerSNISettingsReady),
 		})
 	)

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -28,8 +28,6 @@ func (b *Botanist) DefaultKubeAPIServerService() component.DeployWaiter {
 	if b.ShootUsesIstioTLSTermination() {
 		deployer = append(deployer, mutualTLSService)
 		deployer = append(deployer, upgradeService)
-	} else {
-		deployer = append(deployer, component.OpDestroy(mutualTLSService))
 	}
 	return component.OpWait(deployer...)
 }
@@ -78,6 +76,16 @@ func (b *Botanist) ShootUsesDNS() bool {
 // ShootUsesIstioTLSTermination returns true if the shoot uses Istio TLS termination aka L7 load-balancing.
 func (b *Botanist) ShootUsesIstioTLSTermination() bool {
 	return features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo())
+}
+
+// DestroyKubeAPIServerTLSServices destroys the MutualTLS and ConnectionUpgrade services if Istio TLS termination is disabled.
+func (b *Botanist) DestroyKubeAPIServerTLSServices(ctx context.Context) error {
+	mutualTLSService := b.defaultKubeAPIServerServiceWithSuffix(kubeapiserverexposure.MutualTLSServiceNameSuffix, false)
+	upgradeService := b.defaultKubeAPIServerServiceWithSuffix(kubeapiserverexposure.ConnectionUpgradeServiceNameSuffix, false)
+	return component.OpWait(
+		component.OpDestroy(mutualTLSService),
+		component.OpDestroy(upgradeService),
+	).Deploy(ctx)
 }
 
 // DefaultKubeAPIServerSNI returns a deployer for the kube-apiserver SNI.

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -78,8 +78,8 @@ func (b *Botanist) ShootUsesIstioTLSTermination() bool {
 	return features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo())
 }
 
-// DestroyKubeAPIServerTLSServices destroys the MutualTLS and ConnectionUpgrade services if Istio TLS termination is disabled.
-func (b *Botanist) DestroyKubeAPIServerTLSServices(ctx context.Context) error {
+// CleanupKubeAPIServerLoadBalancingServices destroys the MutualTLS and ConnectionUpgrade services.
+func (b *Botanist) CleanupKubeAPIServerLoadBalancingServices(ctx context.Context) error {
 	mutualTLSService := b.defaultKubeAPIServerServiceWithSuffix(kubeapiserverexposure.MutualTLSServiceNameSuffix, false)
 	upgradeService := b.defaultKubeAPIServerServiceWithSuffix(kubeapiserverexposure.ConnectionUpgradeServiceNameSuffix, false)
 	return component.OpWait(
@@ -127,7 +127,7 @@ func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 
 // DeployKubeAPIServerSNI deploys the kube-apiserver SNI resources.
 func (b *Botanist) DeployKubeAPIServerSNI(ctx context.Context) error {
-	return b.Shoot.Components.ControlPlane.KubeAPIServerSNI.Deploy(ctx)
+	return component.OpWait(b.Shoot.Components.ControlPlane.KubeAPIServerSNI).Deploy(ctx)
 }
 
 func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -108,7 +108,7 @@ func (b *Botanist) DefaultRuntimeGardenerResourceManager() (resourcemanager.Inte
 		SecretNameServerCA:                   v1beta1constants.SecretNameCACluster,
 		SystemComponentTolerations:           gardenerutils.ExtractSystemComponentsTolerations(b.Shoot.GetInfo().Spec.Provider.Workers),
 		PodKubeAPIServerLoadBalancingWebhook: resourcemanager.PodKubeAPIServerLoadBalancingWebhook{
-			Enabled: features.DefaultFeatureGate.Enabled(features.IstioTLSTermination),
+			Enabled: true,
 			Configs: []resourcemanager.PodKubeAPIServerLoadBalancingWebhookConfig{
 				{
 					NamespaceSelector: map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot},

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,7 +121,7 @@ type components struct {
 	etcdMain                             etcd.Interface
 	etcdEvents                           etcd.Interface
 	kubeAPIServerService                 component.DeployWaiter
-	kubeAPIServerSNI                     component.Deployer
+	kubeAPIServerSNI                     component.DeployWaiter
 	kubeAPIServer                        kubeapiserver.Interface
 	kubeControllerManager                kubecontrollermanager.Interface
 	virtualGardenGardenerResourceManager resourcemanager.Interface
@@ -393,6 +394,11 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 		defaultNotReadyTolerationSeconds = nodeToleration.DefaultNotReadyTolerationSeconds
 		defaultUnreachableTolerationSeconds = nodeToleration.DefaultUnreachableTolerationSeconds
 	}
+	var ctx context.Context
+	enableWebhook, err := r.enablePodKubeAPIServerAPILoadBalanacingWebhook(ctx, features.DefaultFeatureGate.Enabled(features.IstioTLSTermination))
+	if err != nil {
+		return nil, err
+	}
 
 	return sharedcomponent.NewRuntimeGardenerResourceManager(r.RuntimeClientSet.Client(), r.GardenNamespace, secretsManager, resourcemanager.Values{
 		DefaultSeccompProfileEnabled:              features.DefaultFeatureGate.Enabled(features.DefaultSeccompProfile),
@@ -408,7 +414,7 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 		SecretNameServerCA:                        operatorv1alpha1.SecretNameCARuntime,
 		Zones:                                     garden.Spec.RuntimeCluster.Provider.Zones,
 		PodKubeAPIServerLoadBalancingWebhook: resourcemanager.PodKubeAPIServerLoadBalancingWebhook{
-			Enabled: features.DefaultFeatureGate.Enabled(features.IstioTLSTermination),
+			Enabled: enableWebhook,
 			Configs: []resourcemanager.PodKubeAPIServerLoadBalancingWebhookConfig{
 				{
 					NamespaceSelector: map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot},
@@ -430,6 +436,27 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 		VPAInPlaceUpdatesEnabled:             true,
 		SystemComponentsConfigWebhookEnabled: runtimeIsSelfHostedShoot,
 	})
+}
+
+// enablePodKubeAPIServerAPILoadBalanacingWebhook allows for the graceful disabling of the pod-kube-apiserver-load-balancing webhook.
+// The webhook is enabled immediately when IstioTLSTermination is enabled but is disabled only if no shoots are using Istio's TLS termination.
+func (r *Reconciler) enablePodKubeAPIServerAPILoadBalanacingWebhook(ctx context.Context, enableIstioTLSTermination bool) (bool, error) {
+	if enableIstioTLSTermination {
+		return true, nil
+	}
+
+	var envoyFilters networkingv1alpha3.EnvoyFilterList
+	if err := r.RuntimeClientSet.Client().List(ctx, &envoyFilters, client.InNamespace(v1beta1constants.DefaultSNIIngressNamespace)); err != nil {
+		return false, err
+	}
+
+	for _, envoyFilter := range envoyFilters.Items {
+		if strings.HasSuffix(envoyFilter.Name, kubeapiserverexposure.IstioTLSTerminationEnvoyFilterSuffix) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (r *Reconciler) newVirtualGardenGardenerResourceManager(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface) (resourcemanager.Interface, error) {
@@ -608,8 +635,6 @@ func (r *Reconciler) newKubeAPIServerService(log logr.Logger, garden *operatorv1
 	if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
 		deployer = append(deployer, mutualTLSService)
 		deployer = append(deployer, upgradeService)
-	} else {
-		deployer = append(deployer, component.OpDestroy(mutualTLSService))
 	}
 
 	return component.OpWait(deployer...), nil
@@ -938,7 +963,7 @@ func (r *Reconciler) newIstio(ctx context.Context, garden *operatorv1alpha1.Gard
 	)
 }
 
-func (r *Reconciler) newSNI(ctx context.Context, garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, ingressGatewayValues []istio.IngressGatewayValues) (component.Deployer, error) {
+func (r *Reconciler) newSNI(ctx context.Context, garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, ingressGatewayValues []istio.IngressGatewayValues) (component.DeployWaiter, error) {
 	var wildcardConfiguration *kubeapiserverexposure.WildcardConfiguration
 
 	if len(ingressGatewayValues) != 1 {

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
-	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -394,11 +393,6 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 		defaultNotReadyTolerationSeconds = nodeToleration.DefaultNotReadyTolerationSeconds
 		defaultUnreachableTolerationSeconds = nodeToleration.DefaultUnreachableTolerationSeconds
 	}
-	var ctx context.Context
-	enableWebhook, err := r.enablePodKubeAPIServerAPILoadBalanacingWebhook(ctx, features.DefaultFeatureGate.Enabled(features.IstioTLSTermination))
-	if err != nil {
-		return nil, err
-	}
 
 	return sharedcomponent.NewRuntimeGardenerResourceManager(r.RuntimeClientSet.Client(), r.GardenNamespace, secretsManager, resourcemanager.Values{
 		DefaultSeccompProfileEnabled:              features.DefaultFeatureGate.Enabled(features.DefaultSeccompProfile),
@@ -414,7 +408,7 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 		SecretNameServerCA:                        operatorv1alpha1.SecretNameCARuntime,
 		Zones:                                     garden.Spec.RuntimeCluster.Provider.Zones,
 		PodKubeAPIServerLoadBalancingWebhook: resourcemanager.PodKubeAPIServerLoadBalancingWebhook{
-			Enabled: enableWebhook,
+			Enabled: true,
 			Configs: []resourcemanager.PodKubeAPIServerLoadBalancingWebhookConfig{
 				{
 					NamespaceSelector: map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot},
@@ -436,27 +430,6 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 		VPAInPlaceUpdatesEnabled:             true,
 		SystemComponentsConfigWebhookEnabled: runtimeIsSelfHostedShoot,
 	})
-}
-
-// enablePodKubeAPIServerAPILoadBalanacingWebhook allows for the graceful disabling of the pod-kube-apiserver-load-balancing webhook.
-// The webhook is enabled immediately when IstioTLSTermination is enabled but is disabled only if no shoots are using Istio's TLS termination.
-func (r *Reconciler) enablePodKubeAPIServerAPILoadBalanacingWebhook(ctx context.Context, enableIstioTLSTermination bool) (bool, error) {
-	if enableIstioTLSTermination {
-		return true, nil
-	}
-
-	var envoyFilters networkingv1alpha3.EnvoyFilterList
-	if err := r.RuntimeClientSet.Client().List(ctx, &envoyFilters, client.InNamespace(v1beta1constants.DefaultSNIIngressNamespace)); err != nil {
-		return false, err
-	}
-
-	for _, envoyFilter := range envoyFilters.Items {
-		if strings.HasSuffix(envoyFilter.Name, kubeapiserverexposure.IstioTLSTerminationEnvoyFilterSuffix) {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }
 
 func (r *Reconciler) newVirtualGardenGardenerResourceManager(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface) (resourcemanager.Interface, error) {

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -318,10 +318,15 @@ func (r *Reconciler) reconcile(
 			Fn:           c.kubeAPIServer.Wait,
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServer),
 		})
-		_ = g.Add(flow.Task{
+		deployKubeAPIServerServiceSNI = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes API server service SNI",
 			Fn:           c.kubeAPIServerSNI.Deploy,
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
+		})
+		waitUntilKubeAPIServerServiceSNIReady = g.Add(flow.Task{
+			Name:         "Waiting until Kubernetes API server service SNI is ready",
+			Fn:           c.kubeAPIServerSNI.Wait,
+			Dependencies: flow.NewTaskIDs(deployKubeAPIServerServiceSNI),
 		})
 		deployKubeControllerManager = g.Add(flow.Task{
 			Name: "Deploying Kubernetes Controller Manager",
@@ -741,6 +746,14 @@ func (r *Reconciler) reconcile(
 		_ = g.Add(flow.Task{
 			Name: "Deploying victoria-operator",
 			Fn:   c.victoriaOperator.Deploy,
+		})
+		_ = g.Add(flow.Task{
+			Name: "Cleaning up kube-apiserver TLS services",
+			Fn: func(ctx context.Context) error {
+				return r.cleanupKubeAPIServerTLSServices(ctx, log, garden, c.istio.GetValues().IngressGateway)
+			},
+			SkipIf:       features.DefaultFeatureGate.Enabled(features.IstioTLSTermination),
+			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerServiceSNIReady),
 		})
 	)
 
@@ -1579,4 +1592,23 @@ func (r *Reconciler) getAggregatePrometheusHost(ctx context.Context) (string, er
 	}
 
 	return vs.Spec.Hosts[0], nil
+}
+
+func (r *Reconciler) cleanupKubeAPIServerTLSServices(ctx context.Context, log logr.Logger, garden *operatorv1alpha1.Garden, ingressGatewayValues []istio.IngressGatewayValues) error {
+	if len(ingressGatewayValues) != 1 {
+		return fmt.Errorf("exactly one Istio Ingress Gateway is required for the SNI config")
+	}
+
+	deployer := []component.Deployer{}
+
+	if !features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
+		mutualTLSService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.MutualTLSServiceNameSuffix)
+		upgradeService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.ConnectionUpgradeServiceNameSuffix)
+
+		deployer = append(deployer, component.OpDestroy(mutualTLSService))
+		deployer = append(deployer, component.OpDestroy(upgradeService))
+	}
+	return component.OpWait(
+		deployer...,
+	).Deploy(ctx)
 }

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -1594,15 +1594,11 @@ func (r *Reconciler) cleanupKubeAPIServerTLSServices(ctx context.Context, log lo
 		return fmt.Errorf("exactly one Istio Ingress Gateway is required for the SNI config")
 	}
 
-	deployer := []component.Deployer{}
-
 	mutualTLSService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.MutualTLSServiceNameSuffix)
 	upgradeService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.ConnectionUpgradeServiceNameSuffix)
 
-	deployer = append(deployer, component.OpDestroy(mutualTLSService))
-	deployer = append(deployer, component.OpDestroy(upgradeService))
-
 	return component.OpWait(
-		deployer...,
+		component.OpDestroy(mutualTLSService),
+		component.OpDestroy(upgradeService),
 	).Deploy(ctx)
 }

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -319,13 +319,16 @@ func (r *Reconciler) reconcile(
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServer),
 		})
 		deployKubeAPIServerServiceSNI = g.Add(flow.Task{
-			Name:         "Deploying Kubernetes API server service SNI",
-			Fn:           c.kubeAPIServerSNI.Deploy,
+			Name:         "Deploying and waiting for Kubernetes API server service SNI",
+			Fn:           component.OpWait(c.kubeAPIServerSNI).Deploy,
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
 		})
-		waitUntilKubeAPIServerServiceSNIReady = g.Add(flow.Task{
-			Name:         "Waiting until Kubernetes API server service SNI is ready",
-			Fn:           c.kubeAPIServerSNI.Wait,
+		_ = g.Add(flow.Task{
+			Name: "Cleaning up kube-apiserver TLS services",
+			Fn: func(ctx context.Context) error {
+				return r.cleanupKubeAPIServerTLSServices(ctx, log, garden, c.istio.GetValues().IngressGateway)
+			},
+			SkipIf:       features.DefaultFeatureGate.Enabled(features.IstioTLSTermination),
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerServiceSNI),
 		})
 		deployKubeControllerManager = g.Add(flow.Task{
@@ -746,14 +749,6 @@ func (r *Reconciler) reconcile(
 		_ = g.Add(flow.Task{
 			Name: "Deploying victoria-operator",
 			Fn:   c.victoriaOperator.Deploy,
-		})
-		_ = g.Add(flow.Task{
-			Name: "Cleaning up kube-apiserver TLS services",
-			Fn: func(ctx context.Context) error {
-				return r.cleanupKubeAPIServerTLSServices(ctx, log, garden, c.istio.GetValues().IngressGateway)
-			},
-			SkipIf:       features.DefaultFeatureGate.Enabled(features.IstioTLSTermination),
-			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerServiceSNIReady),
 		})
 	)
 
@@ -1601,13 +1596,12 @@ func (r *Reconciler) cleanupKubeAPIServerTLSServices(ctx context.Context, log lo
 
 	deployer := []component.Deployer{}
 
-	if !features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
-		mutualTLSService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.MutualTLSServiceNameSuffix)
-		upgradeService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.ConnectionUpgradeServiceNameSuffix)
+	mutualTLSService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.MutualTLSServiceNameSuffix)
+	upgradeService := r.newKubeAPIServerServiceWithSuffix(log, garden, ingressGatewayValues, kubeapiserverexposure.ConnectionUpgradeServiceNameSuffix)
 
-		deployer = append(deployer, component.OpDestroy(mutualTLSService))
-		deployer = append(deployer, component.OpDestroy(upgradeService))
-	}
+	deployer = append(deployer, component.OpDestroy(mutualTLSService))
+	deployer = append(deployer, component.OpDestroy(upgradeService))
+
 	return component.OpWait(
 		deployer...,
 	).Deploy(ctx)


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/area networking
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR delays the deletion of `kube-apiserver-mtls` service in the shoot reconciliation flow and always enables the `PodKubeAPIServerLoadBalancing` webhook on the Seed. This is to prevent the split-brain scenario and potential data-plane outages on shoots when IstioTLSTermination feature gate is disabled on a Seed. 

The changes are summarised below:
- The destruction of of `kube-apiserver-mtls` service is removed from the `DefaultKubeAPIServerService` method to avoid the immediate deletion of the service when the feature gate is disabled
- A new task is added in the shoot reconciliation flow that cleans up the `kube-apiserver-mtls` and `kube-apiserver-connection-upgrade` services only after the SNI configurations have been updated on a newly rolled out API server during the shoot reconciliation flow
- The PodKubeAPIServerLoadBalancing webhook is always enabled for GRMs of garden, seed and self-hosted shoot, independent of the feature gate, as it already ignores the control plane pods of shoots where the feature gate is not enabled by checking for the ConfigMap `istio-internal-load-balancing` in the shoot's CP namespace

**Which issue(s) this PR fixes**:
Part of #15103 (addresses the part about disabling the feature gate, but not the dependency-watchdog part)

**Special notes for your reviewer**:
The changes have been verified on a local Gardener setup with one seed and one shoot. The Shoot's control plane on the Seed remains accessible from the Shoot after the IstioTLSTermination feature is disabled before, during and after Shoot reconciliation. The PodKubeAPIServerLoadBalancing webhook remains enabled on the garden and seed clusters even after the IstioTLSTermination feature is disabled.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `IstioTLSTermination` feature gate can now be disabled safely, fixing the issues reported in [gardener/gardener#15103](https://github.com/gardener/gardener/issues/15103).
```
