### PR TITLE
Include `VPA` for `OpenTelemetry Collector` in the `Seed` and `Garden` clusters

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -15,7 +15,6 @@ import (
 	istioapiannotation "istio.io/api/annotation"
 	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
-
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -15,10 +15,13 @@ import (
 	istioapiannotation "istio.io/api/annotation"
 	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -201,6 +204,7 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 	seedObjects = append(seedObjects, o.openTelemetryCollector(o.namespace, o.values.LokiEndpoint, genericTokenKubeconfigSecretName))
 	seedObjects = append(seedObjects, o.serviceMonitor())
 	seedObjects = append(seedObjects, o.serviceAccount())
+	seedObjects = append(seedObjects, o.vpa())
 
 	seedRegistry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 	serializedResources, err := seedRegistry.AddAllAndSerialize(seedObjects...)
@@ -257,6 +261,41 @@ func (o *otelCollector) WaitCleanup(ctx context.Context) error {
 	defer cancel()
 
 	return managedresources.WaitUntilDeleted(timeoutCtx, o.client, o.namespace, managedResourceName)
+}
+
+func (o *otelCollector) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
+	return &vpaautoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      managedResourceName,
+			Namespace: o.namespace,
+			Labels:    getLabels(),
+		},
+		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
+			TargetRef: &autoscalingv1.CrossVersionObjectReference{
+				APIVersion: otelv1beta1.GroupVersion.String(),
+				Kind:       "OpenTelemetryCollector",
+				Name:       collectorconstants.OpenTelemetryCollectorResourceName,
+			},
+			UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
+				UpdateMode: new(vpaautoscalingv1.UpdateModeInPlaceOrRecreate),
+			},
+			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+					{
+						ContainerName: collectorconstants.ContainerName,
+						MinAllowed: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
+						},
+						ControlledValues: new(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+					},
+					{
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						Mode:          new(vpaautoscalingv1.ContainerScalingModeOff),
+					},
+				},
+			},
+		},
+	}
 }
 
 func (o *otelCollector) serviceAccount() *corev1.ServiceAccount {

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -48,6 +48,7 @@ const (
 	managedResourceNameTarget  = "logging-target"
 	managedResourceName        = "opentelemetry-collector"
 	serviceMonitorName         = "opentelemetry-collector"
+	vpaName                    = "opentelemetry-collector"
 	openTelemetryCollectorName = "gardener-opentelemetry-collector"
 
 	kubeRBACProxyName = "rbac-proxy"
@@ -266,7 +267,7 @@ func (o *otelCollector) WaitCleanup(ctx context.Context) error {
 func (o *otelCollector) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 	return &vpaautoscalingv1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      managedResourceName,
+			Name:      vpaName,
 			Namespace: o.namespace,
 			Labels:    getLabels(),
 		},

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -397,7 +397,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("10m"),
-						corev1.ResourceMemory: resource.MustParse("50Mi"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
 					},
 				},
 				SecurityContext: &corev1.SecurityContext{

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -17,11 +17,13 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -31,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	. "github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector"
+	collectorconstants "github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector/constants"
 	comptest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -77,6 +80,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 
 		volume                  corev1.Volume
 		volumeMount             corev1.VolumeMount
+		vpa                     *vpaautoscalingv1.VerticalPodAutoscaler
 		managedResourceTarget   *resourcesv1alpha1.ManagedResource
 		openTelemetryCollector  *otelv1beta1.OpenTelemetryCollector
 		serviceMonitor          *monitoringv1.ServiceMonitor
@@ -525,6 +529,39 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			},
 		}
 
+		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      customResourcesManagedResourceName,
+				Namespace: namespace,
+				Labels:    getLabels(),
+			},
+			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
+				TargetRef: &autoscalingv1.CrossVersionObjectReference{
+					APIVersion: otelv1beta1.GroupVersion.String(),
+					Kind:       "OpenTelemetryCollector",
+					Name:       collectorconstants.OpenTelemetryCollectorResourceName,
+				},
+				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
+					UpdateMode: new(vpaautoscalingv1.UpdateModeInPlaceOrRecreate),
+				},
+				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+						{
+							ContainerName: collectorconstants.ContainerName,
+							MinAllowed: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+							ControlledValues: new(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+						},
+						{
+							ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+							Mode:          new(vpaautoscalingv1.ContainerScalingModeOff),
+						},
+					},
+				},
+			},
+		}
+
 		openTelemetryCollector.Spec.AdditionalContainers = []corev1.Container{kubeRBACProxyValiContainer, kubeRBACProxyOTLPContainer}
 		openTelemetryCollector.Spec.Volumes = []corev1.Volume{volume}
 		openTelemetryCollector.Spec.Ports = append(openTelemetryCollector.Spec.Ports, otelv1beta1.PortsSpec{
@@ -587,6 +624,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				getVirtualService(),
 				getDestinationRule(),
 				getTLSSecret(tlsSecret),
+				vpa,
 				serviceMonitor,
 				serviceAccount,
 			))
@@ -644,6 +682,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				getVirtualService(),
 				getDestinationRule(),
 				getTLSSecret(tlsSecret),
+				vpa,
 				serviceMonitor,
 				serviceAccount,
 			))
@@ -733,6 +772,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				getVirtualService(),
 				getDestinationRule(),
 				getTLSSecret(tlsSecret),
+				vpa,
 				serviceMonitor,
 				serviceAccount,
 			))
@@ -768,6 +808,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				getVirtualService(),
 				getDestinationRule(),
 				getTLSSecret(tlsSecret),
+				vpa,
 				serviceMonitor,
 				serviceAccount,
 			))

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -356,7 +356,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("10m"),
-							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
 						},
 					},
 					ServiceAccount: "opentelemetry-collector",

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	. "github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector"
-	collectorconstants "github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector/constants"
 	comptest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -531,7 +530,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 
 		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      customResourcesManagedResourceName,
+				Name:      "opentelemetry-collector",
 				Namespace: namespace,
 				Labels:    getLabels(),
 			},
@@ -539,7 +538,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				TargetRef: &autoscalingv1.CrossVersionObjectReference{
 					APIVersion: otelv1beta1.GroupVersion.String(),
 					Kind:       "OpenTelemetryCollector",
-					Name:       collectorconstants.OpenTelemetryCollectorResourceName,
+					Name:       "opentelemetry-collector",
 				},
 				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
 					UpdateMode: new(vpaautoscalingv1.UpdateModeInPlaceOrRecreate),
@@ -547,7 +546,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
-							ContainerName: collectorconstants.ContainerName,
+							ContainerName: "otc-container",
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("64Mi"),
 							},

--- a/pkg/component/observability/opentelemetry/collector/constants/constants.go
+++ b/pkg/component/observability/opentelemetry/collector/constants/constants.go
@@ -10,6 +10,9 @@ const (
 	// DeploymentName is the name that the OpenTelemetry Operator will for the Collector deployment.
 	// Note: Currently, the OpenTelemetry Operator hardcodes the deployment name to be the same as the resource name with a '-collector' suffix.
 	DeploymentName = OpenTelemetryCollectorResourceName + "-collector"
+	// ContainerName is the name of the main container in the OpenTelemetry Collector deployment.
+	// Note: Currently, the OpenTelemetry Operator hardcodes the container name to 'otc-container'.
+	ContainerName = "otc-container"
 	// ServiceName is the name the OpenTelemetry Operator will use for the Collector service.
 	// Note: Currently, the OpenTelemetry Operator hardcodes the service name to be the same as the resource name with a '-collector' suffix.
 	ServiceName = OpenTelemetryCollectorResourceName + "-collector"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
`OpenTelemetry Collector` instances memory usage varies and now they can automatically scale vertically using `VPA`.

**Which issue(s) this PR fixes**:
https://github.com/gardener/observability/issues/88

**Special notes for your reviewer**:
NONE

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`OpenTelemetry Collector` instances in the `Seed` and `Garden` clusters can now scale vertically by using `VPA`.
```
