### PR TITLE
fix: update envoy-distroless scanning hints to v1.39.0

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -974,28 +974,28 @@ images:
             teamname: 'gardener/gardener-core-networking-maintainers'
       - name: 'cloud.gardener.cnudie/dso/scanning-hints/package-versions'
         value:
-          # https://www.envoyproxy.io/docs/envoy/v1.37.0/intro/arch_overview/security/external_deps
+          # https://www.envoyproxy.io/docs/envoy/v1.39.0/intro/arch_overview/security/external_deps
           - name: 'v8'
-            version: '13.8.258.26'
+            version: '14.6.202.10'
           - name: 'grpc'
-            version: '1.76.0'
+            version: '1.81.1'
           - name: 'luajit'
             version: '871db2c'
           - name: 'nghttp2'
             version: '1.66.0'
           - name: 'protobuf'
-            version: '33.2'
+            version: '35.1'
           - name: 'fmt'
             version: '12.1.0'
           - name: 'boringssl'
-            version: '0.20250514.0'
+            version: '0.20260413.0'
           # lua version is unclear. lua runtime is luajit.
           # luajit is compatible with lua 5.1 but contains feature of lua 5.2 and 5.3
           # https://luajit.org/extensions.html
           - name: 'lua'
             version: '5.1'
           - name: 'yaml-cpp'
-            version: '0.8.0'
+            version: '0.9.0'
           - name: 'c-ares'
             version: '1.34.6'
   - name: apiserver-proxy-sidecar


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
- Updates scanning hints for distroless envoy-proxy to match the new version v1.39.0

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
