### PR TITLE
[GEP-28] Validate control plane worker pool constraints for highly-available self-hosted shoots

### DIFF
--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -399,6 +399,8 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, opts shootV
 		if meta.Namespace != v1beta1constants.GardenNamespace {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "namespace"), meta.Namespace, fmt.Sprintf("self-hosted shoots must be in the %q namespace", v1beta1constants.GardenNamespace)))
 		}
+
+		allErrs = append(allErrs, validateSelfHostedShootControlPlane(spec, fldPath)...)
 	}
 
 	if spec.SchedulerName != nil {
@@ -2375,8 +2377,8 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, shootNamespa
 	}
 
 	if worker.ControlPlane != nil {
-		if worker.Minimum != worker.Maximum || worker.Minimum != 1 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("minimum"), worker.Minimum, "self-hosted shoots only support minimum=maximum=1 for the control plane worker pool (might change in the future)"))
+		if worker.Minimum != worker.Maximum {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("minimum"), worker.Minimum, "minimum must be equal to maximum for the control plane worker pool of self-hosted shoots"))
 		}
 
 		allErrs = append(allErrs, ValidateWorkerControlPlane(worker.ControlPlane, shootNamespace, shootProviderType, fldPath.Child("controlPlane"))...)
@@ -3594,6 +3596,43 @@ func ValidateShootHAConfig(shoot *core.Shoot) field.ErrorList {
 func ValidateShootHAConfigUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validateShootHAControlPlaneSpecUpdate(newShoot, oldShoot, field.NewPath("spec.controlPlane"))...)
+	return allErrs
+}
+
+func validateSelfHostedShootControlPlane(spec *core.ShootSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	controlPlaneWorker := helper.ControlPlaneWorkerPoolForShoot(spec.Provider.Workers)
+	if controlPlaneWorker == nil {
+		return allErrs
+	}
+
+	controlPlaneWorkerIdx := slices.IndexFunc(spec.Provider.Workers, func(w core.Worker) bool { return w.ControlPlane != nil })
+	workerPath := fldPath.Child("provider", "workers").Index(controlPlaneWorkerIdx)
+
+	if spec.ControlPlane == nil || spec.ControlPlane.HighAvailability == nil {
+		if controlPlaneWorker.Maximum != 1 {
+			allErrs = append(allErrs, field.Invalid(workerPath.Child("maximum"), controlPlaneWorker.Maximum, "control plane worker pool must have maximum=1 when high availability is not configured"))
+		}
+		return allErrs
+	}
+
+	if controlPlaneWorker.Maximum != 3 {
+		allErrs = append(allErrs, field.Invalid(workerPath.Child("maximum"), controlPlaneWorker.Maximum, "control plane worker pool must have maximum=3 when high availability is configured"))
+	}
+
+	if controlPlaneWorker.MaxSurge == nil || controlPlaneWorker.MaxSurge.IntValue() != 1 {
+		allErrs = append(allErrs, field.Invalid(workerPath.Child("maxSurge"), controlPlaneWorker.MaxSurge, "control plane worker pool must have maxSurge=1 when high availability is configured"))
+	}
+
+	if controlPlaneWorker.MaxUnavailable == nil || controlPlaneWorker.MaxUnavailable.IntValue() != 1 {
+		allErrs = append(allErrs, field.Invalid(workerPath.Child("maxUnavailable"), controlPlaneWorker.MaxUnavailable, "control plane worker pool must have maxUnavailable=1 when high availability is configured"))
+	}
+
+	if spec.ControlPlane.HighAvailability.FailureTolerance.Type == core.FailureToleranceTypeZone && len(controlPlaneWorker.Zones) != 3 {
+		allErrs = append(allErrs, field.Invalid(workerPath.Child("zones"), controlPlaneWorker.Zones, "control plane worker pool must have exactly 3 zones when failure tolerance type is zone"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -2377,10 +2377,6 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, shootNamespa
 	}
 
 	if worker.ControlPlane != nil {
-		if worker.Minimum != worker.Maximum {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("minimum"), worker.Minimum, "minimum must be equal to maximum for the control plane worker pool of self-hosted shoots"))
-		}
-
 		allErrs = append(allErrs, ValidateWorkerControlPlane(worker.ControlPlane, shootNamespace, shootProviderType, fldPath.Child("controlPlane"))...)
 	}
 
@@ -3609,6 +3605,11 @@ func validateSelfHostedShootControlPlane(spec *core.ShootSpec, fldPath *field.Pa
 
 	controlPlaneWorkerIdx := slices.IndexFunc(spec.Provider.Workers, func(w core.Worker) bool { return w.ControlPlane != nil })
 	workerPath := fldPath.Child("provider", "workers").Index(controlPlaneWorkerIdx)
+
+	// TODO(scheererj): Remove restriction controlPlaneWorker.Minimum != 1 with support for high availability
+	if controlPlaneWorker.Minimum != controlPlaneWorker.Maximum || controlPlaneWorker.Minimum != 1 {
+		allErrs = append(allErrs, field.Invalid(workerPath.Child("minimum"), controlPlaneWorker.Minimum, "self-hosted shoots only support minimum=maximum=1 for the control plane worker pool (might change in the future)"))
+	}
 
 	if spec.ControlPlane == nil || spec.ControlPlane.HighAvailability == nil {
 		if controlPlaneWorker.Maximum != 1 {

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -1612,16 +1612,23 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))))
 				})
 
-				It("should prevent minimum != maximum for the control plane worker pool", func() {
+				It("should prevent setting other values than min=max=1", func() {
 					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
-					shoot.Spec.Provider.Workers[0].Minimum = 1
+					shoot.Spec.Provider.Workers[0].Minimum = 3
 					shoot.Spec.Provider.Workers[0].Maximum = 3
 
-					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeInvalid),
-						"Field":  Equal("spec.provider.workers[0].minimum"),
-						"Detail": ContainSubstring("minimum must be equal to maximum for the control plane worker pool of self-hosted shoots"),
-					}))))
+					Expect(ValidateShoot(shoot)).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeInvalid),
+							"Field":  Equal("spec.provider.workers[0].minimum"),
+							"Detail": ContainSubstring("self-hosted shoots only support minimum=maximum=1 for the control plane worker pool (might change in the future)"),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeInvalid),
+							"Field":  Equal("spec.provider.workers[0].maximum"),
+							"Detail": ContainSubstring("control plane worker pool must have maximum=1 when high availability is not configured"),
+						})),
+					))
 				})
 
 				It("should prevent maximum != 1 without high availability", func() {
@@ -1636,7 +1643,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))))
 				})
 
-				It("should allow maximum=3 with high availability failure tolerance type node", func() {
+				It("should allow maximum=3 with high availability failure tolerance type node except for HA restriction", func() {
 					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
 					shoot.Spec.Provider.Workers[0].Minimum = 3
 					shoot.Spec.Provider.Workers[0].Maximum = 3
@@ -1650,7 +1657,11 @@ var _ = Describe("Shoot Validation Tests", func() {
 						},
 					}
 
-					Expect(ValidateShoot(shoot)).To(BeEmpty())
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.provider.workers[0].minimum"),
+						"Detail": ContainSubstring("self-hosted shoots only support minimum=maximum=1 for the control plane worker pool (might change in the future)"),
+					}))))
 				})
 
 				It("should prevent maximum != 3 with high availability", func() {
@@ -1738,7 +1749,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))))
 				})
 
-				It("should allow zone failure tolerance with 3 zones", func() {
+				It("should allow zone failure tolerance with 3 zones except for HA restriction", func() {
 					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
 					shoot.Spec.Provider.Workers[0].Minimum = 3
 					shoot.Spec.Provider.Workers[0].Maximum = 3
@@ -1753,7 +1764,11 @@ var _ = Describe("Shoot Validation Tests", func() {
 						},
 					}
 
-					Expect(ValidateShoot(shoot)).To(BeEmpty())
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.provider.workers[0].minimum"),
+						"Detail": ContainSubstring("self-hosted shoots only support minimum=maximum=1 for the control plane worker pool (might change in the future)"),
+					}))))
 				})
 
 				It("should prevent marking a shoot as 'self-hosted' after creation", func() {

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -1612,16 +1612,148 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))))
 				})
 
-				It("should prevent setting other values than min=max=1", func() {
+				It("should prevent minimum != maximum for the control plane worker pool", func() {
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					shoot.Spec.Provider.Workers[0].Minimum = 1
+					shoot.Spec.Provider.Workers[0].Maximum = 3
+
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.provider.workers[0].minimum"),
+						"Detail": ContainSubstring("minimum must be equal to maximum for the control plane worker pool of self-hosted shoots"),
+					}))))
+				})
+
+				It("should prevent maximum != 1 without high availability", func() {
 					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
 					shoot.Spec.Provider.Workers[0].Minimum = 3
 					shoot.Spec.Provider.Workers[0].Maximum = 3
 
 					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
-						"Field":  Equal("spec.provider.workers[0].minimum"),
-						"Detail": ContainSubstring("self-hosted shoots only support minimum=maximum=1 for the control plane worker pool (might change in the future)"),
+						"Field":  Equal("spec.provider.workers[0].maximum"),
+						"Detail": ContainSubstring("control plane worker pool must have maximum=1 when high availability is not configured"),
 					}))))
+				})
+
+				It("should allow maximum=3 with high availability failure tolerance type node", func() {
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					shoot.Spec.Provider.Workers[0].Minimum = 3
+					shoot.Spec.Provider.Workers[0].Maximum = 3
+					shoot.Spec.Provider.Workers[0].MaxSurge = new(intstr.FromInt32(1))
+					shoot.Spec.Provider.Workers[0].MaxUnavailable = new(intstr.FromInt32(1))
+					shoot.Spec.ControlPlane = &core.ControlPlane{
+						HighAvailability: &core.HighAvailability{
+							FailureTolerance: core.FailureTolerance{
+								Type: core.FailureToleranceTypeNode,
+							},
+						},
+					}
+
+					Expect(ValidateShoot(shoot)).To(BeEmpty())
+				})
+
+				It("should prevent maximum != 3 with high availability", func() {
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					shoot.Spec.Provider.Workers[0].Minimum = 5
+					shoot.Spec.Provider.Workers[0].Maximum = 5
+					shoot.Spec.Provider.Workers[0].MaxSurge = new(intstr.FromInt32(1))
+					shoot.Spec.Provider.Workers[0].MaxUnavailable = new(intstr.FromInt32(1))
+					shoot.Spec.ControlPlane = &core.ControlPlane{
+						HighAvailability: &core.HighAvailability{
+							FailureTolerance: core.FailureTolerance{
+								Type: core.FailureToleranceTypeNode,
+							},
+						},
+					}
+
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.provider.workers[0].maximum"),
+						"Detail": ContainSubstring("control plane worker pool must have maximum=3 when high availability is configured"),
+					}))))
+				})
+
+				It("should prevent maxSurge != 1 with high availability", func() {
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					shoot.Spec.Provider.Workers[0].Minimum = 3
+					shoot.Spec.Provider.Workers[0].Maximum = 3
+					shoot.Spec.Provider.Workers[0].MaxSurge = new(intstr.FromInt32(2))
+					shoot.Spec.Provider.Workers[0].MaxUnavailable = new(intstr.FromInt32(1))
+					shoot.Spec.ControlPlane = &core.ControlPlane{
+						HighAvailability: &core.HighAvailability{
+							FailureTolerance: core.FailureTolerance{
+								Type: core.FailureToleranceTypeNode,
+							},
+						},
+					}
+
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.provider.workers[0].maxSurge"),
+						"Detail": ContainSubstring("control plane worker pool must have maxSurge=1 when high availability is configured"),
+					}))))
+				})
+
+				It("should prevent maxUnavailable != 1 with high availability", func() {
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					shoot.Spec.Provider.Workers[0].Minimum = 3
+					shoot.Spec.Provider.Workers[0].Maximum = 3
+					shoot.Spec.Provider.Workers[0].MaxSurge = new(intstr.FromInt32(1))
+					shoot.Spec.Provider.Workers[0].MaxUnavailable = new(intstr.FromInt32(0))
+					shoot.Spec.ControlPlane = &core.ControlPlane{
+						HighAvailability: &core.HighAvailability{
+							FailureTolerance: core.FailureTolerance{
+								Type: core.FailureToleranceTypeNode,
+							},
+						},
+					}
+
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.provider.workers[0].maxUnavailable"),
+						"Detail": ContainSubstring("control plane worker pool must have maxUnavailable=1 when high availability is configured"),
+					}))))
+				})
+
+				It("should prevent zone failure tolerance without 3 zones", func() {
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					shoot.Spec.Provider.Workers[0].Minimum = 3
+					shoot.Spec.Provider.Workers[0].Maximum = 3
+					shoot.Spec.Provider.Workers[0].MaxSurge = new(intstr.FromInt32(1))
+					shoot.Spec.Provider.Workers[0].MaxUnavailable = new(intstr.FromInt32(1))
+					shoot.Spec.Provider.Workers[0].Zones = []string{"a", "b"}
+					shoot.Spec.ControlPlane = &core.ControlPlane{
+						HighAvailability: &core.HighAvailability{
+							FailureTolerance: core.FailureTolerance{
+								Type: core.FailureToleranceTypeZone,
+							},
+						},
+					}
+
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.provider.workers[0].zones"),
+						"Detail": ContainSubstring("control plane worker pool must have exactly 3 zones when failure tolerance type is zone"),
+					}))))
+				})
+
+				It("should allow zone failure tolerance with 3 zones", func() {
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					shoot.Spec.Provider.Workers[0].Minimum = 3
+					shoot.Spec.Provider.Workers[0].Maximum = 3
+					shoot.Spec.Provider.Workers[0].MaxSurge = new(intstr.FromInt32(1))
+					shoot.Spec.Provider.Workers[0].MaxUnavailable = new(intstr.FromInt32(1))
+					shoot.Spec.Provider.Workers[0].Zones = []string{"a", "b", "c"}
+					shoot.Spec.ControlPlane = &core.ControlPlane{
+						HighAvailability: &core.HighAvailability{
+							FailureTolerance: core.FailureTolerance{
+								Type: core.FailureToleranceTypeZone,
+							},
+						},
+					}
+
+					Expect(ValidateShoot(shoot)).To(BeEmpty())
 				})
 
 				It("should prevent marking a shoot as 'self-hosted' after creation", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Validate control plane worker pool constraints for highly-available self-hosted shoots.

- Without high availability: control plane worker pool must have `maximum=1`
- With high availability (`node`): must have `maximum=3`, `maxSurge=1`, `maxUnavailable=1`
- With high availability (`zone`): same as `node`, plus exactly 3 zones

**Which issue(s) this PR fixes**:
Part of #2906 and #15298

**Special notes for your reviewer**:

Based on https://github.com/gardener/gardener/pull/14589/changes/2edeebfb50ddff356db4833687bb223fafb83542.

/cc @rfranzke @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
