### PR TITLE
Promote `DisableNginxIngressInGarden` and `DisableNginxIngressInSeed` feature gates to beta

### DIFF
--- a/dev-setup/gardenlet/base/gardenlet.yaml
+++ b/dev-setup/gardenlet/base/gardenlet.yaml
@@ -15,7 +15,6 @@ spec:
       VPNBondingModeRoundRobin: true
       PrometheusHealthChecks: true
       VictoriaLogsBackend: true
-      DisableNginxIngressInSeed: true
       RemoveHTTPProxyLegacyPort: true
     controllers:
       shoot:

--- a/dev-setup/skaffold-operator.yaml
+++ b/dev-setup/skaffold-operator.yaml
@@ -944,7 +944,6 @@ deploy:
           replicaCount: 2
           config.featureGates.PrometheusHealthChecks: true
           config.featureGates.VictoriaLogsBackend: true
-          config.featureGates.DisableNginxIngressInGarden: true
           config.controllers.garden.etcdConfig.featureGates.UpgradeEtcdVersion: true
         createNamespace: true
         wait: true

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -34,7 +34,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | PrometheusHealthChecks         | `false` | `Alpha` | `1.135` |         |
 | RemoveVali                     | `false` | `Alpha` | `1.140` |         |
 | VersionClassificationLifecycle | `false` | `Alpha` | `1.137` |         |
-| DisableNginxIngressInGarden    | `false` | `Alpha` | `1.142` |         |
+| DisableNginxIngressInGarden    | `false` | `Alpha` | `1.142` | `1.147` |
+| DisableNginxIngressInGarden    | `true`  | `Beta`  | `1.148` |         |
 | DisableNginxIngressInSeed      | `false` | `Alpha` | `1.142` |         |
 | DisableNginxIngressInShoot     | `false` | `Alpha` | `1.142` |         |
 | LiveControlPlaneMigration      | `false` | `Alpha` | `1.142` |         |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -36,7 +36,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | VersionClassificationLifecycle | `false` | `Alpha` | `1.137` |         |
 | DisableNginxIngressInGarden    | `false` | `Alpha` | `1.142` | `1.147` |
 | DisableNginxIngressInGarden    | `true`  | `Beta`  | `1.148` |         |
-| DisableNginxIngressInSeed      | `false` | `Alpha` | `1.142` |         |
+| DisableNginxIngressInSeed      | `false` | `Alpha` | `1.142` | `1.147` |
+| DisableNginxIngressInSeed      | `true`  | `Beta`  | `1.148` |         |
 | DisableNginxIngressInShoot     | `false` | `Alpha` | `1.142` |         |
 | LiveControlPlaneMigration      | `false` | `Alpha` | `1.142` |         |
 | BackupEntryForGarden           | `false` | `Alpha` | `1.142` | `1.146` |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -34,10 +34,10 @@ The following tables are a summary of the feature gates that you can set on diff
 | PrometheusHealthChecks         | `false` | `Alpha` | `1.135` |         |
 | RemoveVali                     | `false` | `Alpha` | `1.140` |         |
 | VersionClassificationLifecycle | `false` | `Alpha` | `1.137` |         |
-| DisableNginxIngressInGarden    | `false` | `Alpha` | `1.142` | `1.147` |
-| DisableNginxIngressInGarden    | `true`  | `Beta`  | `1.148` |         |
-| DisableNginxIngressInSeed      | `false` | `Alpha` | `1.142` | `1.147` |
-| DisableNginxIngressInSeed      | `true`  | `Beta`  | `1.148` |         |
+| DisableNginxIngressInGarden    | `false` | `Alpha` | `1.142` | `1.148` |
+| DisableNginxIngressInGarden    | `true`  | `Beta`  | `1.149` |         |
+| DisableNginxIngressInSeed      | `false` | `Alpha` | `1.142` | `1.148` |
+| DisableNginxIngressInSeed      | `true`  | `Beta`  | `1.149` |         |
 | DisableNginxIngressInShoot     | `false` | `Alpha` | `1.142` |         |
 | LiveControlPlaneMigration      | `false` | `Alpha` | `1.142` |         |
 | BackupEntryForGarden           | `false` | `Alpha` | `1.142` | `1.146` |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -97,14 +97,14 @@ const (
 	// and removes the nginx ingress controller (if existing) from the Garden runtime cluster.
 	// owner: @ScheererJ
 	// alpha: v1.142.0
-	// beta: v1.148.0
+	// beta: v1.149.0
 	DisableNginxIngressInGarden featuregate.Feature = "DisableNginxIngressInGarden"
 
 	// DisableNginxIngressInSeed disables the deployment of the nginx ingress controller in the Seed cluster
 	// and removes the nginx ingress controller (if existing) from the Seed cluster.
 	// owner: @ScheererJ
 	// alpha: v1.142.0
-	// beta: v1.148.0
+	// beta: v1.149.0
 	DisableNginxIngressInSeed featuregate.Feature = "DisableNginxIngressInSeed"
 
 	// DisableNginxIngressInShoot disables the deployment of the nginx ingress controller in the Shoot cluster

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -104,6 +104,7 @@ const (
 	// and removes the nginx ingress controller (if existing) from the Seed cluster.
 	// owner: @ScheererJ
 	// alpha: v1.142.0
+	// beta: v1.148.0
 	DisableNginxIngressInSeed featuregate.Feature = "DisableNginxIngressInSeed"
 
 	// DisableNginxIngressInShoot disables the deployment of the nginx ingress controller in the Shoot cluster
@@ -174,7 +175,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	VersionClassificationLifecycle: {Default: false, PreRelease: featuregate.Alpha},
 	RemoveVali:                     {Default: false, PreRelease: featuregate.Alpha},
 	DisableNginxIngressInGarden:    {Default: true, PreRelease: featuregate.Beta},
-	DisableNginxIngressInSeed:      {Default: false, PreRelease: featuregate.Alpha},
+	DisableNginxIngressInSeed:      {Default: true, PreRelease: featuregate.Beta},
 	DisableNginxIngressInShoot:     {Default: false, PreRelease: featuregate.Alpha},
 	LiveControlPlaneMigration:      {Default: false, PreRelease: featuregate.Alpha},
 	BackupEntryForGarden:           {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -97,6 +97,7 @@ const (
 	// and removes the nginx ingress controller (if existing) from the Garden runtime cluster.
 	// owner: @ScheererJ
 	// alpha: v1.142.0
+	// beta: v1.148.0
 	DisableNginxIngressInGarden featuregate.Feature = "DisableNginxIngressInGarden"
 
 	// DisableNginxIngressInSeed disables the deployment of the nginx ingress controller in the Seed cluster
@@ -172,7 +173,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	PrometheusHealthChecks:         {Default: false, PreRelease: featuregate.Alpha},
 	VersionClassificationLifecycle: {Default: false, PreRelease: featuregate.Alpha},
 	RemoveVali:                     {Default: false, PreRelease: featuregate.Alpha},
-	DisableNginxIngressInGarden:    {Default: false, PreRelease: featuregate.Alpha},
+	DisableNginxIngressInGarden:    {Default: true, PreRelease: featuregate.Beta},
 	DisableNginxIngressInSeed:      {Default: false, PreRelease: featuregate.Alpha},
 	DisableNginxIngressInShoot:     {Default: false, PreRelease: featuregate.Alpha},
 	LiveControlPlaneMigration:      {Default: false, PreRelease: featuregate.Alpha},

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/extension"
 	"github.com/gardener/gardener/pkg/component/gardener/resourcemanager"
 	"github.com/gardener/gardener/pkg/component/networking/istio"
-	"github.com/gardener/gardener/pkg/component/networking/nginxingress"
 	"github.com/gardener/gardener/pkg/component/observability/logging/fluentoperator"
 	victoriaoperator "github.com/gardener/gardener/pkg/component/observability/logging/victoria/operator"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/persesoperator"
@@ -407,7 +406,6 @@ var _ = Describe("Seed controller tests", func() {
 				test.WithVars(
 					&dnsrecord.WaitUntilExtensionObjectReady, waitUntilExtensionObjectReadyInTest,
 					&extension.WaitUntilExtensionObjectReady, waitUntilExtensionObjectReadyInTest,
-					&nginxingress.WaitUntilHealthy, waitUntilHealthyInTest,
 					&resourcemanager.Until, untilInTest,
 					&resourcemanager.TimeoutWaitForDeployment, 50*time.Millisecond,
 					&seedcontroller.WaitUntilLoadBalancerIsReady, waitUntilLoadBalancerIsReadyInTest,
@@ -758,7 +756,6 @@ var _ = Describe("Seed controller tests", func() {
 					expectedManagedResources = append(expectedManagedResources,
 						"vpa",
 						"etcd-druid",
-						"nginx-ingress",
 						"plutono",
 						"vali",
 						"fluent-bit",
@@ -776,7 +773,6 @@ var _ = Describe("Seed controller tests", func() {
 					}
 				} else {
 					expectedManagedResources = append(expectedManagedResources,
-						"nginx-ingress-seed",
 						"plutono-seed-config-only",
 					)
 				}
@@ -1120,7 +1116,6 @@ var _ = Describe("Seed controller tests", func() {
 						"referenced-resources-" + seedName,
 						// Components not skipped for self-hosted shoots (only for garden):
 						"vpa",
-						"nginx-ingress",
 						"plutono",
 						"vali",
 						"fluent-bit",
@@ -1182,10 +1177,6 @@ var _ = Describe("Seed controller tests", func() {
 })
 
 func untilInTest(_ context.Context, _ time.Duration, _ retry.Func) error {
-	return nil
-}
-
-func waitUntilHealthyInTest(_ context.Context, _ client.Reader, _, _ string) error {
 	return nil
 }
 

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -52,7 +52,6 @@ import (
 	kubeapiserverexposure "github.com/gardener/gardener/pkg/component/kubernetes/apiserverexposure"
 	kubecontrollermanager "github.com/gardener/gardener/pkg/component/kubernetes/controllermanager"
 	"github.com/gardener/gardener/pkg/component/networking/istio"
-	"github.com/gardener/gardener/pkg/component/networking/nginxingress"
 	"github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardencontroller "github.com/gardener/gardener/pkg/operator/controller/garden/garden"
@@ -104,7 +103,6 @@ var _ = Describe("Garden controller tests", func() {
 			&kubecontrollermanager.IntervalWaitForDeployment, 100*time.Millisecond,
 			&kubecontrollermanager.TimeoutWaitForDeployment, 500*time.Millisecond,
 			&kubecontrollermanager.Until, untilInTest,
-			&nginxingress.TimeoutWaitForManagedResource, 2*time.Second,
 			&resourcemanager.SkipWebhookDeployment, true,
 			&resourcemanager.IntervalWaitForDeployment, 100*time.Millisecond,
 			&resourcemanager.TimeoutWaitForDeployment, 500*time.Millisecond,
@@ -582,7 +580,6 @@ spec:
 			"garden-system",
 			"vpa",
 			"etcd-druid",
-			"nginx-ingress",
 			"fluent-operator",
 			"fluent-bit",
 			"fluent-operator-custom-resources-garden",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/area networking
/area security
/kind enhancement

**What this PR does / why we need it**:

`DisableNginxIngressInGarden` and `DisableNginxIngressInSeed` feature gates have been successfully tested in different landscapes for a while now. Thus, they can be promoted to beta.

**Which issue(s) this PR fixes**:
Part of #13448

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `DisableNginxIngressInGarden` and `DisableNginxIngressInSeed` feature gates have been promoted to beta.
```
