### PR TITLE
Fix sporadic stale secret reference in `istio-basic-auth-server` during credential rotation

### DIFF
--- a/pkg/component/networking/istiobasicauthserver/istiobasicauthserver.go
+++ b/pkg/component/networking/istiobasicauthserver/istiobasicauthserver.go
@@ -202,6 +202,11 @@ func (i *istioBasicAuthServer) calculateConfiguration(
 	)
 
 	for _, virtualService := range virtualServiceList.Items {
+		secretName := virtualService.Labels[v1beta1constants.LabelBasicAuthSecretName]
+		if secret, found := i.secretsManager.Get(secretName); found {
+			secretName = secret.Name
+		}
+
 		for _, host := range virtualService.Spec.Hosts {
 			// Use the first subdomain as the filename for the basic authentication data. Domains without '.' are ignored.
 			// The full domain is used to identify the filter chain via SNI in the EnvoyFilter configuration patch.
@@ -214,7 +219,7 @@ func (i *istioBasicAuthServer) calculateConfiguration(
 				Name: subdomain,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: virtualService.Labels[v1beta1constants.LabelBasicAuthSecretName],
+						SecretName: secretName,
 						Items: []corev1.KeyToPath{
 							{
 								Key:  secretsutils.DataKeyAuth,

--- a/pkg/component/observability/monitoring/alertmanager/component.go
+++ b/pkg/component/observability/monitoring/alertmanager/component.go
@@ -30,8 +30,8 @@ const (
 // Interface contains functions for an alertmanager deployer.
 type Interface interface {
 	component.DeployWaiter
-	// SetIngressAuthSecret sets the ingress authentication secret name.
-	SetIngressAuthSecret(*corev1.Secret)
+	// SetIngressAuthSecretName sets the ingress authentication secret name.
+	SetIngressAuthSecretName(string)
 	// SetIngressWildcardCertSecret sets the ingress wildcard certificate secret name.
 	SetIngressWildcardCertSecret(*corev1.Secret)
 }
@@ -149,9 +149,9 @@ func (a *alertManager) WaitCleanup(ctx context.Context) error {
 	return managedresources.WaitUntilDeleted(timeoutCtx, a.client, a.namespace, a.name())
 }
 
-func (a *alertManager) SetIngressAuthSecret(secret *corev1.Secret) {
-	if a.values.ExternalExposure != nil && secret != nil {
-		a.values.ExternalExposure.AuthSecretName = secret.Name
+func (a *alertManager) SetIngressAuthSecretName(name string) {
+	if a.values.ExternalExposure != nil {
+		a.values.ExternalExposure.AuthSecretName = name
 	}
 }
 

--- a/pkg/component/observability/monitoring/alertmanager/mock/mocks.go
+++ b/pkg/component/observability/monitoring/alertmanager/mock/mocks.go
@@ -69,16 +69,16 @@ func (mr *MockInterfaceMockRecorder) Destroy(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), ctx)
 }
 
-// SetIngressAuthSecret mocks base method.
-func (m *MockInterface) SetIngressAuthSecret(arg0 *v1.Secret) {
+// SetIngressAuthSecretName mocks base method.
+func (m *MockInterface) SetIngressAuthSecretName(arg0 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetIngressAuthSecret", arg0)
+	m.ctrl.Call(m, "SetIngressAuthSecretName", arg0)
 }
 
-// SetIngressAuthSecret indicates an expected call of SetIngressAuthSecret.
-func (mr *MockInterfaceMockRecorder) SetIngressAuthSecret(arg0 any) *gomock.Call {
+// SetIngressAuthSecretName indicates an expected call of SetIngressAuthSecretName.
+func (mr *MockInterfaceMockRecorder) SetIngressAuthSecretName(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIngressAuthSecret", reflect.TypeOf((*MockInterface)(nil).SetIngressAuthSecret), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIngressAuthSecretName", reflect.TypeOf((*MockInterface)(nil).SetIngressAuthSecretName), arg0)
 }
 
 // SetIngressWildcardCertSecret mocks base method.

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -64,8 +64,8 @@ func ServicePorts() struct {
 // Interface contains functions for a Prometheus deployer.
 type Interface interface {
 	component.DeployWaiter
-	// SetIngressAuthSecret sets the ingress authentication secret name.
-	SetIngressAuthSecret(*corev1.Secret)
+	// SetIngressAuthSecretName sets the ingress authentication secret name.
+	SetIngressAuthSecretName(string)
 	// SetIngressWildcardCertSecret sets the ingress wildcard certificate secret name.
 	SetIngressWildcardCertSecret(*corev1.Secret)
 	// SetCentralScrapeConfigs sets the central scrape configs.
@@ -349,9 +349,9 @@ func (p *prometheus) WaitCleanup(ctx context.Context) error {
 	return managedresources.WaitUntilDeleted(timeoutCtx, p.client, p.namespace, p.name())
 }
 
-func (p *prometheus) SetIngressAuthSecret(secret *corev1.Secret) {
-	if p.values.Ingress != nil && secret != nil {
-		p.values.Ingress.AuthSecretName = secret.Name
+func (p *prometheus) SetIngressAuthSecretName(name string) {
+	if p.values.Ingress != nil {
+		p.values.Ingress.AuthSecretName = name
 	}
 }
 

--- a/pkg/component/observability/monitoring/prometheus/mock/mocks.go
+++ b/pkg/component/observability/monitoring/prometheus/mock/mocks.go
@@ -108,16 +108,16 @@ func (mr *MockInterfaceMockRecorder) SetCentralScrapeConfigs(arg0 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCentralScrapeConfigs", reflect.TypeOf((*MockInterface)(nil).SetCentralScrapeConfigs), arg0)
 }
 
-// SetIngressAuthSecret mocks base method.
-func (m *MockInterface) SetIngressAuthSecret(arg0 *v10.Secret) {
+// SetIngressAuthSecretName mocks base method.
+func (m *MockInterface) SetIngressAuthSecretName(arg0 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetIngressAuthSecret", arg0)
+	m.ctrl.Call(m, "SetIngressAuthSecretName", arg0)
 }
 
-// SetIngressAuthSecret indicates an expected call of SetIngressAuthSecret.
-func (mr *MockInterfaceMockRecorder) SetIngressAuthSecret(arg0 any) *gomock.Call {
+// SetIngressAuthSecretName indicates an expected call of SetIngressAuthSecretName.
+func (mr *MockInterfaceMockRecorder) SetIngressAuthSecretName(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIngressAuthSecret", reflect.TypeOf((*MockInterface)(nil).SetIngressAuthSecret), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIngressAuthSecretName", reflect.TypeOf((*MockInterface)(nil).SetIngressAuthSecretName), arg0)
 }
 
 // SetIngressWildcardCertSecret mocks base method.

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -956,7 +956,7 @@ honor_labels: true`
 					BeforeEach(func() {
 						values.Ingress = &IngressValues{Host: ingressHost, IstioIngressGatewayNamespace: ingressNamespace}
 						deployer = New(logr.Discard(), fakeClient, namespace, values)
-						deployer.SetIngressAuthSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: ingressAuthSecretName}})
+						deployer.SetIngressAuthSecretName(ingressAuthSecretName)
 						deployer.SetIngressWildcardCertSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: ingressWildcardSecretName}})
 					})
 

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -797,23 +797,13 @@ func (p *plutono) getIstioResources(ctx context.Context) ([]client.Object, error
 	)
 
 	if p.values.IsGardenCluster {
-		credentialsSecret, found := p.secretsManager.Get(v1beta1constants.SecretNameObservabilityIngress)
-		if !found {
-			return nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngress)
-		}
-
-		credentialsSecretName = credentialsSecret.Name
+		credentialsSecretName = v1beta1constants.SecretNameObservabilityIngress
 		caName = operatorv1alpha1.SecretNameCARuntime
 		gatewayName = fmt.Sprintf("%s%s-%s", operatorv1alpha1.VirtualGardenNamePrefix, gatewayName, v1beta1constants.GardenNamespace)
 	}
 
 	if p.values.ClusterType == component.ClusterTypeShoot {
-		credentialsSecret, found := p.secretsManager.Get(v1beta1constants.SecretNameObservabilityIngressUsers)
-		if !found {
-			return nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngressUsers)
-		}
-
-		credentialsSecretName = credentialsSecret.Name
+		credentialsSecretName = v1beta1constants.SecretNameObservabilityIngressUsers
 		caName = v1beta1constants.SecretNameCACluster
 		gatewayName = fmt.Sprintf("%s-%s", gatewayName, p.namespace)
 	}

--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -64,12 +64,7 @@ func (b *Botanist) DeployAlertManager(ctx context.Context) error {
 		return b.Shoot.Components.ControlPlane.Alertmanager.Destroy(ctx)
 	}
 
-	ingressAuthSecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameObservabilityIngressUsers)
-	if !found {
-		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngressUsers)
-	}
-
-	b.Shoot.Components.ControlPlane.Alertmanager.SetIngressAuthSecret(ingressAuthSecret)
+	b.Shoot.Components.ControlPlane.Alertmanager.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngressUsers)
 	b.Shoot.Components.ControlPlane.Alertmanager.SetIngressWildcardCertSecret(b.ControlPlaneWildcardCert)
 
 	return b.Shoot.Components.ControlPlane.Alertmanager.Deploy(ctx)
@@ -187,12 +182,7 @@ func (b *Botanist) DeployPrometheus(ctx context.Context) error {
 		return fmt.Errorf("failed reconciling access secret for prometheus: %w", err)
 	}
 
-	ingressAuthSecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameObservabilityIngressUsers)
-	if !found {
-		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngressUsers)
-	}
-
-	b.Shoot.Components.ControlPlane.Prometheus.SetIngressAuthSecret(ingressAuthSecret)
+	b.Shoot.Components.ControlPlane.Prometheus.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngressUsers)
 	b.Shoot.Components.ControlPlane.Prometheus.SetIngressWildcardCertSecret(b.ControlPlaneWildcardCert)
 	b.Shoot.Components.ControlPlane.Prometheus.SetNamespaceUID(b.SeedNamespaceObject.UID)
 

--- a/pkg/gardenlet/operation/botanist/monitoring_test.go
+++ b/pkg/gardenlet/operation/botanist/monitoring_test.go
@@ -104,9 +104,7 @@ var _ = Describe("Monitoring", func() {
 
 		Context("deployment", func() {
 			It("should successfully deploy", func() {
-				alertManager.EXPECT().SetIngressAuthSecret(gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(s *corev1.Secret) {
-					Expect(s.Name).To(Equal(ingressAuthSecret.Name))
-				})
+				alertManager.EXPECT().SetIngressAuthSecretName(ingressAuthSecret.Name)
 				alertManager.EXPECT().SetIngressWildcardCertSecret(gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(s *corev1.Secret) {
 					Expect(s.Name).To(Equal(ingressWildcardSecret.Name))
 				})

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -1136,7 +1136,6 @@ func (r *Reconciler) deployGardenPrometheus(ctx context.Context, prometheus prom
 		return fmt.Errorf("failed reconciling access secret for garden prometheus: %w", err)
 	}
 
-	// fetch auth secret for ingress
 	prometheus.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngress)
 
 	// fetch global monitoring secret for prometheus-aggregate scrape config
@@ -1301,7 +1300,6 @@ func (r *Reconciler) deployGardenerDashboard(ctx context.Context, dashboard gard
 }
 
 func (r *Reconciler) deployLongTermPrometheus(ctx context.Context, prometheus prometheus.Interface) error {
-	// fetch auth secret for ingress
 	prometheus.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngress)
 	return prometheus.Deploy(ctx)
 }

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -658,12 +658,7 @@ func (r *Reconciler) reconcile(
 		deployAlertmanager = g.Add(flow.Task{
 			Name: "Deploying Alertmanager",
 			Fn: func(ctx context.Context) error {
-				credentialsSecret, found := secretsManager.Get(v1beta1constants.SecretNameObservabilityIngress)
-				if !found {
-					return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngress)
-				}
-
-				c.alertManager.SetIngressAuthSecret(credentialsSecret)
+				c.alertManager.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngress)
 				return c.alertManager.Deploy(ctx)
 			},
 			Dependencies: flow.NewTaskIDs(generateObservabilityIngressPassword),
@@ -682,7 +677,7 @@ func (r *Reconciler) reconcile(
 				}
 				discoveryServerEnabled := garden.Spec.VirtualCluster.Gardener.DiscoveryServer != nil
 				dashboardDomain := helper.PrimaryDashboardDomain(garden)
-				return r.deployGardenPrometheus(ctx, secretsManager, c.prometheusGarden, virtualClusterClient, aggregatePrometheusHost, dashboardDomain, discoveryServerEnabled)
+				return r.deployGardenPrometheus(ctx, c.prometheusGarden, virtualClusterClient, aggregatePrometheusHost, dashboardDomain, discoveryServerEnabled)
 			},
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerAPIServerReady, initializeVirtualClusterClient, generateAndReplicateGlobalObservabilityIngressPassword),
 		})
@@ -694,7 +689,7 @@ func (r *Reconciler) reconcile(
 		deployPrometheusLongTerm = g.Add(flow.Task{
 			Name: "Deploying long-term Prometheus",
 			Fn: func(ctx context.Context) error {
-				return r.deployLongTermPrometheus(ctx, secretsManager, c.prometheusLongTerm)
+				return r.deployLongTermPrometheus(ctx, c.prometheusLongTerm)
 			},
 			Dependencies: flow.NewTaskIDs(deployPrometheusGarden),
 		})
@@ -1136,17 +1131,13 @@ func (r *Reconciler) deployGardenerAPIServerFunc(garden *operatorv1alpha1.Garden
 	}
 }
 
-func (r *Reconciler) deployGardenPrometheus(ctx context.Context, secretsManager secretsmanager.Interface, prometheus prometheus.Interface, virtualGardenClient client.Client, aggregatePrometheusHost string, dashboardDomain string, discoveryServerEnabled bool) error {
+func (r *Reconciler) deployGardenPrometheus(ctx context.Context, prometheus prometheus.Interface, virtualGardenClient client.Client, aggregatePrometheusHost string, dashboardDomain string, discoveryServerEnabled bool) error {
 	if err := gardenerutils.NewShootAccessSecret(gardenprometheus.AccessSecretName, r.GardenNamespace).Reconcile(ctx, r.RuntimeClientSet.Client()); err != nil {
 		return fmt.Errorf("failed reconciling access secret for garden prometheus: %w", err)
 	}
 
 	// fetch auth secret for ingress
-	credentialsSecret, found := secretsManager.Get(v1beta1constants.SecretNameObservabilityIngress)
-	if !found {
-		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngress)
-	}
-	prometheus.SetIngressAuthSecret(credentialsSecret)
+	prometheus.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngress)
 
 	// fetch global monitoring secret for prometheus-aggregate scrape config
 	globalMonitoringSecretRuntime, err := r.getGlobalObservabilitySecret(ctx)
@@ -1309,13 +1300,9 @@ func (r *Reconciler) deployGardenerDashboard(ctx context.Context, dashboard gard
 	return component.OpWait(dashboard).Deploy(ctx)
 }
 
-func (r *Reconciler) deployLongTermPrometheus(ctx context.Context, secretsManager secretsmanager.Interface, prometheus prometheus.Interface) error {
+func (r *Reconciler) deployLongTermPrometheus(ctx context.Context, prometheus prometheus.Interface) error {
 	// fetch auth secret for ingress
-	credentialsSecret, found := secretsManager.Get(v1beta1constants.SecretNameObservabilityIngress)
-	if !found {
-		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngress)
-	}
-	prometheus.SetIngressAuthSecret(credentialsSecret)
+	prometheus.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngress)
 	return prometheus.Deploy(ctx)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

The observability ingress `VirtualServices` are deployed by GRM as part of each observability component `ManagedResource`. For example, the shoot Prometheus `ManagedResource` includes the corresponding `VirtualService` for its ingress. However, the `istio-basic-auth-server` is deployed independently of the observability `ManagedResources`. Each `VirtualService` is labeled with `reference.gardener.cloud/basic-auth-secret-name` to indicate which secret needs to be configured for each ingress. Subsequently, the `istio-basic-auth-server` pods need to mount those secrets to provide the basic authentication mechanism.

Such a setup might sporadically lead to issues when the observability credentials are rotated, which happens in-place, if the following occurs:

1. The `SecretsManager` generates a new secret.
2. The `gardenlet` deploys the updated `ManagedResource` for the observability component, referencing the new secret in the `VirtualService` label.
3. The GRM deploys the `ManagedResource` with the new `VirtualService`.
4. When the `gardenlet` deploys the `ManagedResource` for the `istio-basic-auth-server`, it reads the `VirtualService` from its cache, which may not yet reflect the label update applied by the GRM.

This PR changes the `VirtualService` label to reference the secret name as per `SecretsManager`, e.g., `observability-ingress-users` instead of the generated name `observability-ingress-users-<hash>`. The `istio-basic-auth-server` component then resolves the reference to the current secret via `SecretsManager` at deploy time, which eliminates the dependency on cache freshness.

**Special notes for your reviewer**:

/cc @ScheererJ 

**Release note**:

```other operator
A sporadic issue with stale secrets in the `istio-basic-auth-server` after credential rotation has been fixed.
```
