### PR TITLE
fix misdirected request detection logic for envoy

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/misdirected-requests-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/misdirected-requests-envoy-filter.yaml
@@ -34,19 +34,19 @@ spec:
           inlineCode: |
             function envoy_on_request(request_handle)
               local streamInfo = request_handle:streamInfo()
-              if streamInfo:requestedServerName() ~= "" then
-                -- Handle wildcard in the requested server name
-                if (string.sub(streamInfo:requestedServerName(), 1, 2) == "*." and not string.find(request_handle:headers():get(":authority"), string.sub(streamInfo:requestedServerName(), 2), 1, true)) then
-                  request_handle:respond({[":status"] = "421"}, "Misdirected Request")
-                end
-                -- Handle mismatch between requested server name and :authority header
-                if (string.sub(streamInfo:requestedServerName(), 1, 2) ~= "*." and streamInfo:requestedServerName() ~= request_handle:headers():get(":authority")) then
-                  -- Check if the difference is just the port (443) as suffix in the :authority header
-                  local portSuffix = ":443"
-                  local portSuffixLen = string.len(portSuffix)
-                  if (not(string.find(string.sub(request_handle:headers():get(":authority"), -portSuffixLen), portSuffix, 1, true) and streamInfo:requestedServerName() == string.sub(request_handle:headers():get(":authority"), 1, -portSuffixLen - 1))) then
-                    request_handle:respond({[":status"] = "421"}, "Misdirected Request")
-                  end
-                end
+              local rsn = streamInfo:requestedServerName()
+              if rsn == "" then return end
+
+              local authority = request_handle:headers():get(":authority")
+              if authority == nil then return end
+
+              -- Strip trailing :443
+              local portSuffix = ":443"
+              if authority:sub(-#portSuffix) == portSuffix then
+                authority = authority:sub(1, -(#portSuffix + 1))
+              end
+
+              if rsn ~= authority then
+                request_handle:respond({[":status"] = "421"}, "Misdirected Request")
               end
             end

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/misdirected-requests-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/misdirected-requests-envoy-filter.yaml
@@ -35,16 +35,19 @@ spec:
             function envoy_on_request(request_handle)
               local streamInfo = request_handle:streamInfo()
               local rsn = streamInfo:requestedServerName()
-              if rsn == "" then return end
+
+              if rsn == nil or rsn == "" then
+                return
+              end
 
               local authority = request_handle:headers():get(":authority")
-              if authority == nil then return end
-
-              -- Strip trailing :443
-              local portSuffix = ":443"
-              if authority:sub(-#portSuffix) == portSuffix then
-                authority = authority:sub(1, -(#portSuffix + 1))
+              if authority == nil then
+                return
               end
+
+              -- Dynamically strip any trailing port (e.g. :443, :9443, etc.)
+              -- :%d+$ matches a colon followed by digits at the end of the string
+              authority = authority:gsub(":%d+$", "")
 
               if rsn ~= authority then
                 request_handle:respond({[":status"] = "421"}, "Misdirected Request")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:

The Lua filter in `misdirected-requests-envoy-filter.yaml` contains flawed logic that can never work as intended.

`streamInfo:requestedServerName()` returns the **SNI value sent by the client** in the TLS ClientHello (e.g., `foo.example.com`). Clients never send wildcard patterns like `*.example.com` as SNI, the wildcard is a property of the server's certificate, not the client's request. See [RFC 6066 Section 3](https://datatracker.ietf.org/doc/html/rfc6066#section-3).

This has two consequences:

1. The wildcard branch is dead code: The condition `string.sub(streamInfo:requestedServerName(), 1, 2) == "*."` can never evaluate to `true` for real traffic. (At least not that I know of, or is this some kind of special case?)
2. All traffic hits the second branch, which compares SNI against `:authority` (with `:443` stripped). The filter effectively rejects any request where `:authority` differs from SNI regardless of whether the authority is covered by the same certificate. Coalescing with multi-SAN certificates is therefore not supported. 

The suggested change replaces the current logic with a drastically simplified one. The outcome is the same. No behavioral change.

I've  considered a solution that inspects the local certificate's SANs via `ssl_info:dnsSansLocalCertificate()` to allow coalescing when `:authority` is covered by the same certificate. A fast path (SNI == authority) would cover the common case, with SAN iteration only on coalesced requests.

**Which issue(s) this PR fixes**:
Fixes #15332

**Special notes for your reviewer**:



**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Requests with a wrong host header are not longer detected as HTTP/2 coalescing attempt and receive a 404 instead of a 421
```
