### PR TITLE
Run `make tidy` before `make generate` in Renovate API package rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -136,12 +136,15 @@
     },
     {
       // Run make generate when Go API packages have been changed because CRDs might have changed.
+      // Updates that match both this rule and the gomod make tidy rule above would run make generate only and
+      // silently skip make tidy, so this also runs make tidy.
       matchDatasources: [
         'go',
         'github-releases', // Required for the gardener groups.
       ],
       postUpgradeTasks: {
         commands: [
+          '/bin/bash -c "PATH=$PATH:$(go env GOROOT)/bin make tidy"',
           '/bin/bash -c "PATH=$PATH:$(go env GOROOT)/bin make generate MODE=sequential"',
         ],
         executionMode: 'branch',


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
The `packageRule` that runs `make generate` for Go API package updates did not run `make tidy` first. Because Renovate's `postUpgradeTasks` is [not a mergeable config option](https://github.com/renovatebot/renovate/blob/d4d3c5501cddf45e42e2b2bad7a1108a6ba1d88d/lib/config/options/index.ts#L167-L178), when a dependency matches multiple `packageRules` that define separate `postUpgradeTasks`, the last matching rule's tasks override earlier ones rather than accumulating. 

As a result, updates matching both the `gomod` `make tidy` rule and `make generate` rule ran `make generate` only and silently skipped `make tidy`, leading to additional commits by maintainers, for example https://github.com/gardener/gardener/pull/15307/changes/261385b09767f35d479c3f66cf6fbf7e48a59858 and https://github.com/gardener/gardener/pull/15315/changes/5b2efe15ec219f335b7793fcd6323f4d32b2ff18. This PR includes `make tidy` in the `make generate` rule's commands so both run. `make tidy` runs first so module resolution is settled before code/CRD generation.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/cc @ialidzhikov @plkokanov @LucaBernstein 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
