### PR TITLE
Fix tools to be installed from the `GARDENER_TOOL_DIR` instead of `GARDENER_HACK_DIR`

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -13,6 +13,7 @@ IS_GARDENER := $(shell go list -f '{{.Main}}' -m github.com/gardener/gardener)
 
 ifeq ($(IS_GARDENER),true)
 GARDENER_HACK_DIR          := ./hack
+GARDENER_TOOL_DIR          := ./hack/tools
 GARDENER_LOGCHECK_DIR      := ./hack/tools/logcheck
 else
 # dependency on github.com/gardener/gardener is optional.
@@ -226,17 +227,17 @@ $(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION)) $(GOLANGC
 endif
 
 $(PROMTOOL): $(call tool_version_file,$(PROMTOOL),$(PROMTOOL_VERSION))
-	@PROMTOOL_VERSION=$(PROMTOOL_VERSION) $(GARDENER_HACK_DIR)/tools/install-promtool.sh
+	@PROMTOOL_VERSION=$(PROMTOOL_VERSION) $(GARDENER_TOOL_DIR)/install-promtool.sh
 
 $(PROTOC): $(call tool_version_file,$(PROTOC),$(PROTOC_VERSION))
-	@PROTOC_VERSION=$(PROTOC_VERSION) $(GARDENER_HACK_DIR)/tools/install-protoc.sh
+	@PROTOC_VERSION=$(PROTOC_VERSION) $(GARDENER_TOOL_DIR)/install-protoc.sh
 
 $(TYPOS): $(call tool_version_file,$(TYPOS),$(TYPOS_VERSION))
-	@TYPOS_VERSION=$(TYPOS_VERSION) bash $(GARDENER_HACK_DIR)/tools/install-typos.sh
+	@TYPOS_VERSION=$(TYPOS_VERSION) bash $(GARDENER_TOOL_DIR)/install-typos.sh
 
 ifeq ($(IS_GARDENER),true)
-$(REPORT_COLLECTOR): $(GARDENER_HACK_DIR)/tools/report-collector/*.go
-	go build -o $(REPORT_COLLECTOR) $(GARDENER_HACK_DIR)/tools/report-collector
+$(REPORT_COLLECTOR): $(GARDENER_TOOL_DIR)/report-collector/*.go
+	go build -o $(REPORT_COLLECTOR) $(GARDENER_TOOL_DIR)/report-collector
 else
 $(REPORT_COLLECTOR): go.mod
 	go build -o $(REPORT_COLLECTOR) github.com/gardener/gardener/hack/tools/report-collector


### PR DESCRIPTION
**How to categorize this PR?**
/area delivery
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Fix tools to be installed from the `GARDENER_TOOL_DIR` instead of `GARDENER_HACK_DIR`

**Which issue(s) this PR fixes**:
Follow-up on https://github.com/gardener/gardener/pull/15218

**Special notes for your reviewer**:

This is fixing installation errors for components depending on tools from g/g like:

```bash
$ make check
...
bash: $(go env GOMODCACHE)/github.com/gardener/gardener@v1.147.1/hack/tools/install-typos.sh: No such file or directory
make: *** [hack/tools/bin/darwin-arm64/typos] Error 127
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Components that have added workarounds to call install scripts for tools from `GARDENER_TOOL_DIR` can now be removed. 
```
