### PR TITLE
🧹  Cleanup TODO related to hash versioning secrets

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -523,7 +523,7 @@ func (g *garden) Start(ctx context.Context) error {
 		return err
 	}
 
-	if err := g.runMigrations(ctx, log, gardenCluster.GetClient()); err != nil {
+	if err := g.runMigrations(ctx, gardenCluster.GetClient()); err != nil {
 		return err
 	}
 

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -9,29 +9,15 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig"
 	"github.com/gardener/gardener/pkg/features"
-	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
-func (g *garden) runMigrations(ctx context.Context, log logr.Logger, gardenClient client.Client) error {
-	seedClient := g.mgr.GetClient()
-
-	// TODO(shafeeqes): Remove this function in gardener v1.148
-	log.Info("Cleaning up OSC hash versioning secrets in shoot namespaces")
-	if err := CleanupHashVersioningSecrets(ctx, seedClient); err != nil {
-		return fmt.Errorf("failed to clean up OSC hash versioning secrets: %w", err)
-	}
-
+func (g *garden) runMigrations(ctx context.Context, gardenClient client.Client) error {
 	if features.DefaultFeatureGate.Enabled(features.RemoveHTTPProxyLegacyPort) {
 		if err := VerifyRemoveHTTPProxyLegacyPortMigration(ctx, gardenClient, g.config.SeedConfig.Name); err != nil {
 			return fmt.Errorf("failed to verify migration for RemoveHTTPProxyLegacyPort feature gate: %w", err)
@@ -72,30 +58,4 @@ func VerifyRemoveHTTPProxyLegacyPortMigration(ctx context.Context, gardenClient 
 	}
 
 	return nil
-}
-
-// CleanupHashVersioningSecrets removes the OSC hash versioning secrets in shoot namespaces.
-func CleanupHashVersioningSecrets(ctx context.Context, seedClient client.Client) error {
-	shootNamespaceList := &corev1.NamespaceList{}
-	if err := seedClient.List(ctx, shootNamespaceList, client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot}); err != nil {
-		return err
-	}
-
-	var taskFns []flow.TaskFn
-
-	for _, ns := range shootNamespaceList.Items {
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name, Name: operatingsystemconfig.WorkerPoolHashesSecretName},
-		}
-
-		taskFns = append(taskFns, func(ctx context.Context) error {
-			if err := client.IgnoreNotFound(seedClient.Delete(ctx, secret)); err != nil {
-				return fmt.Errorf("failed deleting secret %s in namespace %s: %w", secret.Name, secret.Namespace, err)
-			}
-
-			return nil
-		})
-	}
-
-	return flow.Parallel(taskFns...)(ctx)
 }

--- a/cmd/gardenlet/app/migration_test.go
+++ b/cmd/gardenlet/app/migration_test.go
@@ -9,80 +9,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/gardener/gardener/cmd/gardenlet/app"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Migration", func() {
-	Describe("#CleanupHashVersioningSecrets", func() {
-		var (
-			ctx        = context.Background()
-			fakeClient client.Client
-		)
-
-		BeforeEach(func() {
-			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
-		})
-
-		It("should do nothing when there are no shoot namespaces", func() {
-			Expect(CleanupHashVersioningSecrets(ctx, fakeClient)).To(Succeed())
-		})
-
-		It("should not error when shoot namespaces exist but the secret is absent", func() {
-			ns := shootNamespace("shoot--foo--bar")
-			Expect(fakeClient.Create(ctx, ns)).To(Succeed())
-
-			Expect(CleanupHashVersioningSecrets(ctx, fakeClient)).To(Succeed())
-		})
-
-		It("should delete the secret in a shoot namespace", func() {
-			ns := shootNamespace("shoot--foo--bar")
-			Expect(fakeClient.Create(ctx, ns)).To(Succeed())
-
-			secret := oscHashSecret("shoot--foo--bar")
-			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
-
-			Expect(CleanupHashVersioningSecrets(ctx, fakeClient)).To(Succeed())
-
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(MatchError(ContainSubstring("not found")))
-		})
-
-		It("should delete secrets across multiple shoot namespaces", func() {
-			for _, name := range []string{"shoot--p--a", "shoot--p--b", "shoot--p--c"} {
-				Expect(fakeClient.Create(ctx, shootNamespace(name))).To(Succeed())
-				Expect(fakeClient.Create(ctx, oscHashSecret(name))).To(Succeed())
-			}
-
-			Expect(CleanupHashVersioningSecrets(ctx, fakeClient)).To(Succeed())
-
-			for _, name := range []string{"shoot--p--a", "shoot--p--b", "shoot--p--c"} {
-				secret := oscHashSecret(name)
-				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(BeNotFoundError())
-			}
-		})
-
-		It("should handle a mix of namespaces with and without the secret", func() {
-			for _, name := range []string{"shoot--p--a", "shoot--p--b"} {
-				Expect(fakeClient.Create(ctx, shootNamespace(name))).To(Succeed())
-			}
-			Expect(fakeClient.Create(ctx, oscHashSecret("shoot--p--a"))).To(Succeed())
-
-			Expect(CleanupHashVersioningSecrets(ctx, fakeClient)).To(Succeed())
-
-			secretA := oscHashSecret("shoot--p--a")
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretA), secretA)).To(BeNotFoundError())
-		})
-	})
-
 	Describe("#VerifyRemoveHTTPProxyLegacyPortMigration", func() {
 		const seedName = "seed"
 
@@ -243,24 +178,6 @@ func shootUsingUnifiedPort(name, seedName string) *gardencorev1beta1.Shoot {
 				Type:   gardencorev1beta1.ShootUsesUnifiedHTTPProxyPort,
 				Status: gardencorev1beta1.ConditionTrue,
 			}},
-		},
-	}
-}
-
-func shootNamespace(name string) *corev1.Namespace {
-	return &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot},
-		},
-	}
-}
-
-func oscHashSecret(namespace string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      operatingsystemconfig.WorkerPoolHashesSecretName,
-			Namespace: namespace,
 		},
 	}
 }

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -56,8 +56,6 @@ const (
 	// DefaultTimeout is the default timeout and defines how long Gardener should wait for a successful reconciliation
 	// of an OperatingSystemConfig resource.
 	DefaultTimeout = 3 * time.Minute
-	// WorkerPoolHashesSecretName is the name of the secret that tracks the OSC key calculation version used for each worker pool.
-	WorkerPoolHashesSecretName = "worker-pools-operatingsystemconfig-hashes" // #nosec G101 -- No credential.
 )
 
 // TimeNow returns the current time. Exposed for testing.
@@ -339,14 +337,7 @@ func (o *operatingSystemConfig) WaitMigrate(ctx context.Context) error {
 
 // Destroy deletes all the OperatingSystemConfig resources.
 func (o *operatingSystemConfig) Destroy(ctx context.Context) error {
-	if err := o.deleteOperatingSystemConfigResources(ctx, sets.New[string]()); err != nil {
-		return err
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Namespace: o.values.Namespace, Name: WorkerPoolHashesSecretName},
-	}
-	return client.IgnoreNotFound(o.client.Delete(ctx, secret))
+	return o.deleteOperatingSystemConfigResources(ctx, sets.New[string]())
 }
 
 func (o *operatingSystemConfig) deleteOperatingSystemConfigResources(ctx context.Context, wantedOSCNames sets.Set[string]) error {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
Cleanup the migration steps introduced with https://github.com/gardener/gardener/pull/14918

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
