### PR TITLE
Fix `waitUntilWantedMachineDeploymentsAvailable` to return an error when Rolling Updates are in-progress

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -452,9 +452,14 @@ func (a *genericActuator) waitUntilWantedMachineDeploymentsAvailable(ctx context
 		case !extensionscontroller.IsHibernationEnabled(cluster):
 			// numUpdated == numberOfAwakeMachines waits until the old machine is deleted in the case of a rolling update with maxUnavailability = 0
 			// numUnavailable == 0 makes sure that every machine joined the cluster (during creation & in the case of a rolling update with maxUnavailability > 0)
-			if numUnavailable == 0 && (numUpdated+numNeedUpdateManualInPlace) == numberOfAwakeMachines && int(numHealthyDeployments) == len(wantedMachineDeployments) &&
+			// When there are preserved failed machines in the cluster, if numUnavailable <= numPreservedFailed,
+			// it would mean all unavailable machines are preserved failed machines.
+			// In such cases, shoot reconciliation must be allowed to progress.
+			if (numUpdated+numNeedUpdateManualInPlace) == numberOfAwakeMachines && int(numHealthyDeployments) == len(wantedMachineDeployments) &&
 				numOldMachinesNotUpdateCandidateManualInPlace == 0 {
-				return retryutils.Ok()
+				if numUnavailable == 0 || (numPreservedFailed > 0 && numUnavailable <= numPreservedFailed) {
+					return retryutils.Ok()
+				}
 			}
 
 			if numUnavailable == 0 && numAvailable == numDesired && (numUpdated+numNeedUpdateManualInPlace) < numberOfAwakeMachines {
@@ -469,11 +474,7 @@ func (a *genericActuator) waitUntilWantedMachineDeploymentsAvailable(ctx context
 				msg += fmt.Sprintf("Waiting until %d old machines are updated...", numOldMachinesNotUpdateCandidateManualInPlace)
 				break
 			}
-			if numUnavailable <= numPreservedFailed && (int(numHealthyDeployments) == len(wantedMachineDeployments)) {
-				// if the number of unavailable machines is not greater than the number of preserved failed machines, it means that all unavailable machines are preserved failed machines,
-				// hence we can exempt them from this check and allow shoot reconciliation to progress
-				return retryutils.Ok()
-			}
+
 			msg = fmt.Sprintf("Waiting until machines are available (%d/%d desired machine(s) available, %d/%d machine(s) updated, %d machine(s) pending, %d preserved failed machine(s), %d/%d machinedeployments available)...",
 				numAvailable, numDesired, numUpdated+numNeedUpdateManualInPlace, numDesired, numUnavailable, numPreservedFailed, numHealthyDeployments, len(wantedMachineDeployments))
 

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,6 +28,9 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
+	retryutils "github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("ActuatorReconcile", func() {
@@ -639,5 +643,214 @@ var _ = Describe("ActuatorReconcile", func() {
 				"pool2": "04863233bf6b9bb0",
 			}))
 		})
+	})
+
+	Describe("#waitUntilWantedMachineDeploymentsAvailable", func() {
+		const (
+			namespace        = "test-namespace"
+			deploymentName   = "test-deployment"
+			machineClassName = "test-machine-class"
+			machineSetName   = "test-machine-set"
+		)
+
+		var (
+			ctx                       context.Context
+			seedClient                client.Client
+			actuator                  *genericActuator
+			cluster                   *extensionscontroller.Cluster
+			worker                    *extensionsv1alpha1.Worker
+			wantedMachineDeployments  extensionsworkercontroller.MachineDeployments
+			existingMachineClassNames sets.Set[string]
+
+			// healthyConditions makes a MachineDeployment pass CheckMachineDeployment
+			healthyConditions = []machinev1alpha1.MachineDeploymentCondition{
+				{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionTrue},
+				{Type: machinev1alpha1.MachineDeploymentProgressing, Status: machinev1alpha1.ConditionTrue},
+			}
+		)
+
+		buildMachineDeployment := func(status machinev1alpha1.MachineDeploymentStatus) {
+			mcd := &machinev1alpha1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deploymentName,
+					Namespace: namespace,
+				},
+				Spec: machinev1alpha1.MachineDeploymentSpec{
+					Replicas: status.Replicas,
+					Template: machinev1alpha1.MachineTemplateSpec{
+						Spec: machinev1alpha1.MachineSpec{
+							Class: machinev1alpha1.ClassSpec{
+								Name: machineClassName,
+							},
+						},
+					},
+				},
+				Status: status,
+			}
+			Expect(seedClient.Create(ctx, mcd)).To(Succeed())
+			Expect(seedClient.Status().Update(ctx, mcd)).To(Succeed())
+		}
+
+		buildMachineSet := func(name, className string) {
+			ms := &machinev1alpha1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						{Name: deploymentName, Kind: "MachineDeployment"},
+					},
+				},
+				Spec: machinev1alpha1.MachineSetSpec{
+					Template: machinev1alpha1.MachineTemplateSpec{
+						Spec: machinev1alpha1.MachineSpec{
+							Class: machinev1alpha1.ClassSpec{Name: className},
+						},
+					},
+				},
+			}
+			Expect(seedClient.Create(ctx, ms)).To(Succeed())
+		}
+
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			fakeOps := &retryfake.Ops{MaxAttempts: 1}
+			DeferCleanup(test.WithVars(
+				&retryutils.Until, fakeOps.Until,
+				&retryutils.UntilTimeout, fakeOps.UntilTimeout,
+			))
+
+			seedClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.SeedScheme).
+				WithStatusSubresource(&machinev1alpha1.MachineDeployment{}).
+				WithObjectTracker(testing.NewObjectTracker(kubernetes.SeedScheme, scheme.Codecs.UniversalDecoder())).
+				Build()
+
+			actuator = &genericActuator{seedClient: seedClient}
+
+			worker = &extensionsv1alpha1.Worker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "worker",
+					Namespace: namespace,
+				},
+			}
+
+			cluster = &extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{},
+			}
+
+			wantedMachineDeployments = extensionsworkercontroller.MachineDeployments{
+				{
+					Name:      deploymentName,
+					ClassName: machineClassName,
+				},
+			}
+
+			existingMachineClassNames = sets.New[string]()
+		})
+
+		It("should succeed when all machines are available and none are unavailable", func() {
+			buildMachineDeployment(machinev1alpha1.MachineDeploymentStatus{
+				Replicas:            3,
+				UpdatedReplicas:     3,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+				Conditions:          healthyConditions,
+			})
+			buildMachineSet(machineSetName, machineClassName)
+
+			Expect(actuator.waitUntilWantedMachineDeploymentsAvailable(ctx, logr.Discard(), cluster, worker,
+				&machinev1alpha1.MachineDeploymentList{}, existingMachineClassNames, wantedMachineDeployments)).To(Succeed())
+		})
+
+		It("should succeed when all unavailable machines are preserved failed machines", func() {
+			buildMachineDeployment(machinev1alpha1.MachineDeploymentStatus{
+				Replicas:                3,
+				UpdatedReplicas:         3,
+				AvailableReplicas:       2,
+				UnavailableReplicas:     1,
+				PreservedFailedReplicas: 1,
+				Conditions:              healthyConditions,
+			})
+			buildMachineSet(machineSetName, machineClassName)
+
+			Expect(actuator.waitUntilWantedMachineDeploymentsAvailable(ctx, logr.Discard(), cluster, worker,
+				&machinev1alpha1.MachineDeploymentList{}, existingMachineClassNames, wantedMachineDeployments)).To(Succeed())
+		})
+
+		It("should not succeed when more machines are unavailable than preserved failed machines", func() {
+			buildMachineDeployment(machinev1alpha1.MachineDeploymentStatus{
+				Replicas:                3,
+				UpdatedReplicas:         3,
+				AvailableReplicas:       1,
+				UnavailableReplicas:     2,
+				PreservedFailedReplicas: 1,
+				Conditions:              healthyConditions,
+			})
+			buildMachineSet(machineSetName, machineClassName)
+
+			Expect(actuator.waitUntilWantedMachineDeploymentsAvailable(ctx, logr.Discard(), cluster, worker,
+				&machinev1alpha1.MachineDeploymentList{}, existingMachineClassNames, wantedMachineDeployments)).To(MatchError(ContainSubstring("Waiting until machines are available")))
+		})
+
+		It("should not succeed when rolling update is still in progress", func() {
+			buildMachineDeployment(machinev1alpha1.MachineDeploymentStatus{
+				Replicas:                3,
+				UpdatedReplicas:         2,
+				AvailableReplicas:       3,
+				UnavailableReplicas:     0,
+				PreservedFailedReplicas: 0,
+				Conditions:              healthyConditions,
+			})
+			buildMachineSet(machineSetName, machineClassName)
+
+			Expect(actuator.waitUntilWantedMachineDeploymentsAvailable(ctx, logr.Discard(), cluster, worker,
+				&machinev1alpha1.MachineDeploymentList{}, existingMachineClassNames, wantedMachineDeployments)).To(MatchError(ContainSubstring("Waiting until machines are available")))
+		})
+
+		It("should not succeed when preserved failed machines exist but rolling update is still in progress", func() {
+			buildMachineDeployment(machinev1alpha1.MachineDeploymentStatus{
+				Replicas:                3,
+				UpdatedReplicas:         2,
+				AvailableReplicas:       2,
+				UnavailableReplicas:     1,
+				PreservedFailedReplicas: 1,
+				Conditions:              healthyConditions,
+			})
+			buildMachineSet(machineSetName, machineClassName)
+
+			Expect(actuator.waitUntilWantedMachineDeploymentsAvailable(ctx, logr.Discard(), cluster, worker,
+				&machinev1alpha1.MachineDeploymentList{}, existingMachineClassNames, wantedMachineDeployments)).To(MatchError(ContainSubstring("Waiting until machines are available")))
+		})
+
+		It("should not succeed when the machine deployment is not healthy", func() {
+			buildMachineDeployment(machinev1alpha1.MachineDeploymentStatus{
+				Replicas:                3,
+				UpdatedReplicas:         3,
+				AvailableReplicas:       2,
+				UnavailableReplicas:     1,
+				PreservedFailedReplicas: 1,
+				// no conditions → CheckMachineDeployment returns error
+			})
+			buildMachineSet(machineSetName, machineClassName)
+
+			Expect(actuator.waitUntilWantedMachineDeploymentsAvailable(ctx, logr.Discard(), cluster, worker,
+				&machinev1alpha1.MachineDeploymentList{}, existingMachineClassNames, wantedMachineDeployments)).To(MatchError(ContainSubstring("Waiting until machines are available")))
+		})
+
+		It("should not succeed when there are no preserved failed machines and some machines are unavailable", func() {
+			buildMachineDeployment(machinev1alpha1.MachineDeploymentStatus{
+				Replicas:            3,
+				UpdatedReplicas:     3,
+				AvailableReplicas:   2,
+				UnavailableReplicas: 1,
+				Conditions:          healthyConditions,
+			})
+			buildMachineSet(machineSetName, machineClassName)
+
+			Expect(actuator.waitUntilWantedMachineDeploymentsAvailable(ctx, logr.Discard(), cluster, worker,
+				&machinev1alpha1.MachineDeploymentList{}, existingMachineClassNames, wantedMachineDeployments)).To(MatchError(ContainSubstring("Waiting until machines are available")))
+		})
+
 	})
 })


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:

PR https://github.com/gardener/gardener/pull/14767 integrated the machines preservation into gardener, and to ensure preserved failed machines do not interfere with normal shoot operations, some of the health checks were modified.

The changes also introduced a regression  in `waitUntilWantedMachineDeploymentsAvailable` causing shoot reconciliation to proceed even when there is a rolling update in-progress.

This expression:
```
 numUnavailable <= numPreservedFailed && (int(numHealthyDeployments) == len(wantedMachineDeployments))
```
evaluates to `true` when a rolling update is ongoing, all the machines are available (though all have not been rolled yet), there are no preserved failed machines and all the machine deployments are healthy. 

This PR fixes the logic in so that the function no longer returns early when a Rolling Update is in progress.

The PR also introduces tests to verify the behaviour of `waitUntilWantedMachineDeploymentsAvailable`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix `waitUntilWantedMachineDeploymentsAvailable` logic so that the function returns an error when rolling updates are still in-progress.
```
