### PR TITLE
Add flag to specify validity in `generate-kubeconfig.sh`

### DIFF
--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -376,7 +376,7 @@ For convenience a [helper script](../../hack/usage/generate-kubeconfig.sh) is pr
 By default, the script will generate an admin kubeconfig for a `Shoot` named "local" in the `garden-local` namespace valid for one hour.
 
 > [!NOTE]
-> If you want to extend the validity of the generated kubeconfig, you can use the `--expirationMinutes <minutes>` flag to specify the desired validity in minutes.
+> If you want to extend the validity of the generated kubeconfig, you can use the `--expiration-minutes <minutes>` flag to specify the desired validity in minutes.
 
 ```bash
 ./hack/usage/generate-kubeconfig.sh > admin-kubeconf.yaml

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -375,6 +375,9 @@ To access the `Shoot`, you can acquire a `kubeconfig` by using the [`shoots/admi
 For convenience a [helper script](../../hack/usage/generate-kubeconfig.sh) is provided in the `hack` directory.
 By default, the script will generate an admin kubeconfig for a `Shoot` named "local" in the `garden-local` namespace valid for one hour.
 
+> [!NOTE]
+> If you want to extend the validity of the generated kubeconfig, you can use the `--expirationMinutes <minutes>` flag to specify the desired validity in minutes.
+
 ```bash
 ./hack/usage/generate-kubeconfig.sh > admin-kubeconf.yaml
 ```

--- a/hack/usage/generate-kubeconfig.sh
+++ b/hack/usage/generate-kubeconfig.sh
@@ -30,6 +30,7 @@ cmd_shoot() {
   local namespace="garden-local"
   local shoot_name="local"
   local kubeconfig_type="admin"
+  local expiration_minutes=60
 
   while test $# -gt 0; do
     case "$1" in
@@ -41,6 +42,8 @@ cmd_shoot() {
         kubeconfig_type="admin" ;;
       --viewer)
         kubeconfig_type="viewer" ;;
+      --expirationMinutes)
+        shift; expiration_minutes="${1:-$expiration_minutes}" ;;
       --help|-h)
         cat <<EOF
 Usage: $(basename "$0") shoot [flags]
@@ -48,10 +51,11 @@ Usage: $(basename "$0") shoot [flags]
 Generate admin/viewer kubeconfig for a hosted shoot via the Gardener API.
 
 Flags:
-  --namespace <ns>      Shoot namespace (default: garden-local)
-  --shoot-name <name>   Shoot name (default: local)
-  --admin               Generate admin kubeconfig (default)
-  --viewer              Generate viewer kubeconfig
+  --namespace <ns>                Shoot namespace (default: garden-local)
+  --shoot-name <name>             Shoot name (default: local)
+  --admin                         Generate admin kubeconfig (default)
+  --viewer                        Generate viewer kubeconfig
+  --expirationMinutes <minutes>   kubeconfig validity in minutes (default: 60)
 EOF
         exit 0 ;;
       *)
@@ -73,7 +77,7 @@ EOF
     "apiVersion": "authentication.gardener.cloud/v1alpha1",
     "kind": "${kind}",
     "spec": {
-        "expirationSeconds": 3600
+        "expirationSeconds": $(( expiration_minutes * 60 ))
     }
 }
 EOF

--- a/hack/usage/generate-kubeconfig.sh
+++ b/hack/usage/generate-kubeconfig.sh
@@ -42,7 +42,7 @@ cmd_shoot() {
         kubeconfig_type="admin" ;;
       --viewer)
         kubeconfig_type="viewer" ;;
-      --expirationMinutes)
+      --expiration-minutes)
         shift; expiration_minutes="${1:-$expiration_minutes}" ;;
       --help|-h)
         cat <<EOF
@@ -55,7 +55,7 @@ Flags:
   --shoot-name <name>             Shoot name (default: local)
   --admin                         Generate admin kubeconfig (default)
   --viewer                        Generate viewer kubeconfig
-  --expirationMinutes <minutes>   kubeconfig validity in minutes (default: 60)
+  --expiration-minutes <minutes>  kubeconfig validity in minutes (default: 60)
 EOF
         exit 0 ;;
       *)
@@ -106,7 +106,7 @@ Flags:
   --garden-name <name>            Garden name (default: local, env: GARDEN_NAME)
   --runtime-kubeconfig <path>     Path to runtime cluster kubeconfig
                                   (default: dev-setup/kubeconfigs/runtime/kubeconfig,
-                                   env: RUNTIME_CLUSTER_KUBECONFIG)
+                                  env: RUNTIME_CLUSTER_KUBECONFIG)
 EOF
         exit 0 ;;
       *)
@@ -158,7 +158,7 @@ Flags:
                                   generate a client-cert kubeconfig
   --runtime-kubeconfig <path>     Path to the bootstrap cluster kubeconfig
                                   (default: dev-setup/kubeconfigs/runtime/kubeconfig,
-                                   env: KUBECONFIG_RUNTIME_CLUSTER)
+                                  env: KUBECONFIG_RUNTIME_CLUSTER)
 EOF
         exit 0 ;;
       *)


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Add the possibility to get a `kubeconfig` with a longer validity by supplying the `--expiration-minutes <minutes>` flag to the `generate-kubeconfig.sh` script for `Shoots`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The generate-kubeconfig.sh script now allows to specify the validity of the requested kubeconfig for shoots by passing the --expiration-minutes flag.
```
