### PR TITLE
Add a Github action to validate release-notes from PRs

### DIFF
--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -1,0 +1,18 @@
+name: Validate release-notes from PRs
+on:
+  pull_request:
+    types:
+    - opened
+    - edited
+    - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-release-notes:
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1
+    permissions:
+      pull-requests: read
+    with:
+      pull-request-body: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adds a Github action to validate release-notes from PRs. The same action is used in [GLK repo](https://github.com/gardener/gardener-landscape-kit/blob/main/.github/workflows/pr-release-notes-validation.yaml).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
