### PR TITLE
[GEP-28] Fixes for managed scenario

### DIFF
--- a/dev-setup/gardenadm/resources/overlays/managed-infra/kustomization.yaml
+++ b/dev-setup/gardenadm/resources/overlays/managed-infra/kustomization.yaml
@@ -25,3 +25,7 @@ patches:
       path: /spec/provider/workers/0/controlPlane/exposure
       value:
         extension: {}
+    - op: add
+      path: /spec/provider/workers/0/zones
+      value:
+        - local

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -59,7 +59,6 @@ type GardenadmBotanist struct {
 	Extensions []Extension
 	// Zone is the availability zone in which the new node is being added. This is used to set the
 	// topology.kubernetes.io/zone label on the node resource.
-	// This field is only relevant for shoot with unmanaged infrastructure.
 	Zone *string
 
 	operatingSystemConfigSecret *corev1.Secret

--- a/pkg/gardenadm/botanist/machines.go
+++ b/pkg/gardenadm/botanist/machines.go
@@ -11,6 +11,7 @@ import (
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -39,9 +40,9 @@ func (b *GardenadmBotanist) GetMachineByIndex(index int) (*machinev1alpha1.Machi
 // ZoneForMachine returns the availability zone for the given machine by looking up its MachineClass.
 // Returns an empty string if the MachineClass has no NodeTemplate or zone set.
 func (b *GardenadmBotanist) ZoneForMachine(ctx context.Context, machine *machinev1alpha1.Machine) (string, error) {
-	machineClass := &machinev1alpha1.MachineClass{}
-	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Name: machine.Spec.Class.Name, Namespace: b.Shoot.ControlPlaneNamespace}, machineClass); err != nil {
-		return "", fmt.Errorf("failed getting machine class %q: %w", machine.Spec.Class.Name, err)
+	machineClass := &machinev1alpha1.MachineClass{ObjectMeta: metav1.ObjectMeta{Name: machine.Spec.Class.Name, Namespace: machine.Namespace}}
+	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKeyFromObject(machineClass), machineClass); err != nil {
+		return "", fmt.Errorf("failed getting machine class %s: %w", client.ObjectKeyFromObject(machineClass), err)
 	}
 	if machineClass.NodeTemplate == nil {
 		return "", nil

--- a/pkg/gardenadm/botanist/machines.go
+++ b/pkg/gardenadm/botanist/machines.go
@@ -36,6 +36,19 @@ func (b *GardenadmBotanist) GetMachineByIndex(index int) (*machinev1alpha1.Machi
 	return &b.controlPlaneMachines[index], nil
 }
 
+// ZoneForMachine returns the availability zone for the given machine by looking up its MachineClass.
+// Returns an empty string if the MachineClass has no NodeTemplate or zone set.
+func (b *GardenadmBotanist) ZoneForMachine(ctx context.Context, machine *machinev1alpha1.Machine) (string, error) {
+	machineClass := &machinev1alpha1.MachineClass{}
+	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Name: machine.Spec.Class.Name, Namespace: b.Shoot.ControlPlaneNamespace}, machineClass); err != nil {
+		return "", fmt.Errorf("failed getting machine class %q: %w", machine.Spec.Class.Name, err)
+	}
+	if machineClass.NodeTemplate == nil {
+		return "", nil
+	}
+	return machineClass.NodeTemplate.Zone, nil
+}
+
 // addressTypePreference when picking a node/machine address. Higher value means higher priority.
 // Unknown address types have the lowest priority (0).
 var addressTypePreference = map[corev1.NodeAddressType]int{

--- a/pkg/gardenadm/botanist/machines_test.go
+++ b/pkg/gardenadm/botanist/machines_test.go
@@ -5,14 +5,107 @@
 package botanist_test
 
 import (
+	"context"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/gardenadm/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 )
 
 var _ = Describe("Machines", func() {
+	Describe("#ZoneForMachine", func() {
+		var (
+			ctx          context.Context
+			b            *GardenadmBotanist
+			machine      *machinev1alpha1.Machine
+			machineClass *machinev1alpha1.MachineClass
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			machineClass = &machinev1alpha1.MachineClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-class",
+					Namespace: "test-ns",
+				},
+			}
+			machine = &machinev1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-machine",
+					Namespace: "test-ns",
+				},
+				Spec: machinev1alpha1.MachineSpec{
+					Class: machinev1alpha1.ClassSpec{
+						Name: "my-class",
+					},
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			seedClient := fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.SeedScheme).
+				WithObjects(machineClass).
+				Build()
+			clientSet := fakekubernetes.NewClientSetBuilder().
+				WithClient(seedClient).
+				Build()
+			b = &GardenadmBotanist{
+				Botanist: &botanistpkg.Botanist{
+					Operation: &operation.Operation{
+						SeedClientSet: clientSet,
+					},
+				},
+			}
+		})
+
+		It("should return an error if the MachineClass does not exist", func() {
+			machine.Spec.Class.Name = "non-existent-class"
+			_, err := b.ZoneForMachine(ctx, machine)
+			Expect(err).To(MatchError(ContainSubstring("failed getting machine class")))
+		})
+
+		It("should return an empty string if the MachineClass has no NodeTemplate", func() {
+			zone, err := b.ZoneForMachine(ctx, machine)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(zone).To(BeEmpty())
+		})
+
+		When("the MachineClass has a NodeTemplate", func() {
+			BeforeEach(func() {
+				machineClass.NodeTemplate = &machinev1alpha1.NodeTemplate{}
+			})
+
+			It("should return an empty string if no zone is set", func() {
+				zone, err := b.ZoneForMachine(ctx, machine)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(zone).To(BeEmpty())
+			})
+
+			When("with a zone", func() {
+				BeforeEach(func() {
+					machineClass.NodeTemplate.Zone = "eu-west-1a"
+				})
+
+				It("should return the zone", func() {
+					zone, err := b.ZoneForMachine(ctx, machine)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(zone).To(Equal("eu-west-1a"))
+				})
+			})
+		})
+	})
+
 	Describe("#PreferredNodeAddress", func() {
 		var addresses []corev1.NodeAddress
 

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -231,12 +231,26 @@ func run(ctx context.Context, opts *Options) error {
 		bootstrapControlPlane = g.Add(flow.Task{
 			Name: "Bootstrapping control plane on the first control plane machine",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
+				machine, err := b.GetMachineByIndex(0)
+				if err != nil {
+					return fmt.Errorf("failed getting first control plane machine: %w", err)
+				}
+
+				zone, err := b.ZoneForMachine(ctx, machine)
+				if err != nil {
+					return fmt.Errorf("failed getting zone for first control plane machine: %w", err)
+				}
+
+				zoneFlag := ""
+				if zone != "" {
+					zoneFlag = fmt.Sprintf(" --zone=%q", zone)
+				}
 				return b.SSHConnection().
 					WithSignalProcess(nodeinit.GardenadmBinaryName).
 					RunWithStreams(ctx, nil, opts.Out, opts.ErrOut,
-						fmt.Sprintf("%s%s init -d %q --log-level=%s",
+						fmt.Sprintf("%s%s init -d %q --log-level=%s %s",
 							gardenadmbotanist.ImageVectorOverrideEnv(),
-							nodeinit.GardenadmBinaryPath, gardenadmbotanist.ManifestsDir, opts.LogLevel,
+							nodeinit.GardenadmBinaryPath, gardenadmbotanist.ManifestsDir, opts.LogLevel, zoneFlag,
 						),
 					)
 			}).Timeout(30 * time.Minute),

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -59,13 +59,6 @@ func (o *Options) validateZone() error {
 		return fmt.Errorf("failed loading resources for zone validation: %w", err)
 	}
 
-	if v1beta1helper.HasManagedInfrastructure(resources.Shoot) {
-		if o.Zone != "" {
-			return fmt.Errorf("zone can't be configured for shoot with managed infrastructure")
-		}
-		return nil
-	}
-
 	if resources.Shoot == nil {
 		return fmt.Errorf("zone validation failed shoot resource is missing in the manifests")
 	}

--- a/pkg/gardenadm/cmd/init/options_test.go
+++ b/pkg/gardenadm/cmd/init/options_test.go
@@ -120,20 +120,13 @@ spec:`)
 
 		When("zone validation with managed infrastructure", func() {
 			BeforeEach(func() {
-				createShootManifest("test-credentials", nil, true)
+				createShootManifest("test-credentials", []string{"us-east-1a"}, true)
 			})
 
-			It("should reject zone when provided for managed infrastructure", func() {
+			It("should allow zone when provided for managed infrastructure", func() {
 				options.Zone = "us-east-1a"
 
-				Expect(options.Validate()).To(MatchError(ContainSubstring("zone can't be configured for shoot with managed infrastructure")))
-			})
-
-			It("should allow empty zone for managed infrastructure", func() {
-				options.Zone = ""
-
 				Expect(options.Validate()).To(Succeed())
-				Expect(options.Zone).To(BeEmpty())
 			})
 		})
 

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -269,6 +269,7 @@ func (b *Botanist) ReconcileControlPlaneTaskGroup() flow.TaskGroup {
 			TaskGroupInitializeSecretsManagement,
 			TaskGroupDeployCloudProviderSecret,
 			TaskGroupReconcileGardenerResourceManager,
+			TaskGroupReconcileInfrastructure,
 		)
 
 		deployControlPlane = g.Add(flow.Task{

--- a/pkg/gardenlet/operation/botanist/namespaces.go
+++ b/pkg/gardenlet/operation/botanist/namespaces.go
@@ -94,7 +94,7 @@ func (b *Botanist) DeployControlPlaneNamespace(ctx context.Context) error {
 			zones                   []string
 		)
 
-		if b.Shoot.IsSelfHosted() {
+		if b.Shoot.IsSelfHosted() && b.Shoot.RunsControlPlane() {
 			zones = v1beta1helper.ControlPlaneWorkerPoolForShoot(b.Shoot.GetInfo().Spec.Provider.Workers).Zones
 		} else if seedZones := b.Seed.GetInfo().Spec.Provider.Zones; len(seedZones) > 0 &&
 			(!failureToleranceTypeExisting || existingFailureToleranceType != newFailureToleranceType) {

--- a/pkg/gardenlet/operation/botanist/namespaces.go
+++ b/pkg/gardenlet/operation/botanist/namespaces.go
@@ -97,6 +97,7 @@ func (b *Botanist) DeployControlPlaneNamespace(ctx context.Context) error {
 		if b.Shoot.IsSelfHosted() && b.Shoot.RunsControlPlane() {
 			zones = v1beta1helper.ControlPlaneWorkerPoolForShoot(b.Shoot.GetInfo().Spec.Provider.Workers).Zones
 		} else if seedZones := b.Seed.GetInfo().Spec.Provider.Zones; len(seedZones) > 0 &&
+			!b.Shoot.IsSelfHosted() &&
 			(!failureToleranceTypeExisting || existingFailureToleranceType != newFailureToleranceType) {
 			zones, err = calculateShootZones(ctx, b.SeedClientSet.Client(), b.Logger, namespace, shootFailureToleranceType, seedZones, allShootZones(b.Shoot.GetInfo().Spec.Provider.Workers), v1beta1helper.SeedSettingZoneSelectionMode(b.Seed.GetInfo().Spec.Settings))
 			if err != nil {

--- a/pkg/gardenlet/operation/botanist/namespaces_test.go
+++ b/pkg/gardenlet/operation/botanist/namespaces_test.go
@@ -115,6 +115,8 @@ var _ = Describe("Namespaces", func() {
 		)
 
 		BeforeEach(func() {
+			botanist.Shoot.ControlPlaneNamespace = metav1.NamespaceSystem
+			obj.Name = metav1.NamespaceSystem
 			defaultSeedInfo = &gardencorev1beta1.Seed{
 				Spec: gardencorev1beta1.SeedSpec{
 					Provider: gardencorev1beta1.SeedProvider{
@@ -145,7 +147,7 @@ var _ = Describe("Namespaces", func() {
 		})
 
 		defaultExpectations := func(failureToleranceType gardencorev1beta1.FailureToleranceType, numberOfZones int) {
-			ExpectWithOffset(1, botanist.SeedNamespaceObject.Name).To(Equal(namespace))
+			ExpectWithOffset(1, botanist.SeedNamespaceObject.Name).To(Equal(metav1.NamespaceSystem))
 			ExpectWithOffset(1, botanist.SeedNamespaceObject.Annotations).To(And(
 				HaveKeyWithValue("shoot.gardener.cloud/uid", string(uid)),
 				HaveKeyWithValue("high-availability-config.resources.gardener.cloud/failure-tolerance-type", string(failureToleranceType)),
@@ -341,7 +343,7 @@ var _ = Describe("Namespaces", func() {
 						pvc := &corev1.PersistentVolumeClaim{
 							ObjectMeta: metav1.ObjectMeta{
 								GenerateName: "pvc-",
-								Namespace:    namespace,
+								Namespace:    metav1.NamespaceSystem,
 							},
 							Spec: corev1.PersistentVolumeClaimSpec{
 								VolumeName: pv.Name,
@@ -387,7 +389,7 @@ var _ = Describe("Namespaces", func() {
 				It("should use zone information from namespace and find existing ones via persistent volumes", func() {
 					Expect(seedClient.Create(ctx, &corev1.Namespace{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: namespace,
+							Name: metav1.NamespaceSystem,
 							Annotations: map[string]string{
 								"high-availability-config.resources.gardener.cloud/zones": "a",
 							},
@@ -432,7 +434,7 @@ var _ = Describe("Namespaces", func() {
 				It("should not amend zone information if failure tolerance is unchanged", func() {
 					Expect(seedClient.Create(ctx, &corev1.Namespace{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: namespace,
+							Name: metav1.NamespaceSystem,
 							Annotations: map[string]string{
 								"high-availability-config.resources.gardener.cloud/zones": "1,2,a,b",
 								"high-availability-config.resources.gardener.cloud/type":  "zone",
@@ -463,7 +465,7 @@ var _ = Describe("Namespaces", func() {
 					pvc := &corev1.PersistentVolumeClaim{
 						ObjectMeta: metav1.ObjectMeta{
 							GenerateName: "pvc-",
-							Namespace:    namespace,
+							Namespace:    metav1.NamespaceSystem,
 						},
 						Spec: corev1.PersistentVolumeClaimSpec{},
 					}
@@ -600,7 +602,7 @@ var _ = Describe("Namespaces", func() {
 
 			Expect(seedClient.Create(ctx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: namespace,
+					Name: metav1.NamespaceSystem,
 					Annotations: map[string]string{
 						"shoot.gardener.cloud/uid": string(uid),
 					},
@@ -631,7 +633,7 @@ var _ = Describe("Namespaces", func() {
 		It("should not overwrite other annotations or labels", func() {
 			Expect(seedClient.Create(ctx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        namespace,
+					Name:        metav1.NamespaceSystem,
 					Annotations: map[string]string{"foo": "bar"},
 					Labels:      map[string]string{"bar": "foo"},
 				},

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -214,6 +215,7 @@ func (b *Botanist) DeployOperatingSystemConfigWithStaticPods(ctx context.Context
 	patch := client.MergeFrom(osc.DeepCopy())
 	osc.Spec.Files = append(osc.Spec.Files, files...)
 	metav1.SetMetaDataAnnotation(&osc.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+	metav1.SetMetaDataAnnotation(&osc.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().Format(time.RFC3339Nano))
 	if err := b.SeedClientSet.Client().Patch(ctx, osc, patch); err != nil {
 		return nil, "", fmt.Errorf("failed patching OperatingSystemConfig with additional files for static control plane pods: %w", err)
 	}

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -184,7 +184,7 @@ func (b *Botanist) populateStaticAdminTokenToAccessTokenSecret(ctx context.Conte
 	return b.SeedClientSet.Client().Update(ctx, secret)
 }
 
-// DeployOperatingSystemConfigWithStaticPods deploys the OperatingSystemConfig containing the files for the control
+// DeployOperatingSystemConfigWithStaticPods deploys and waits for the OperatingSystemConfig containing the files for the control
 // plane components running as static pods.
 func (b *Botanist) DeployOperatingSystemConfigWithStaticPods(ctx context.Context, useBootstrapEtcd bool) (*operatingsystemconfig.Data, string, error) {
 	pods, err := b.staticControlPlanePods(ctx, useBootstrapEtcd)
@@ -218,6 +218,12 @@ func (b *Botanist) DeployOperatingSystemConfigWithStaticPods(ctx context.Context
 	metav1.SetMetaDataAnnotation(&osc.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().Format(time.RFC3339Nano))
 	if err := b.SeedClientSet.Client().Patch(ctx, osc, patch); err != nil {
 		return nil, "", fmt.Errorf("failed patching OperatingSystemConfig with additional files for static control plane pods: %w", err)
+	}
+
+	if !useBootstrapEtcd {
+		if err := b.Shoot.Components.Extensions.OperatingSystemConfig.Wait(ctx); err != nil {
+			return nil, "", fmt.Errorf("failed waiting for OperatingSystemConfig to be ready: %w", err)
+		}
 	}
 
 	return &oscData.Original, controlPlaneWorkerPool.Name, nil

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -213,6 +213,7 @@ func (b *Botanist) DeployOperatingSystemConfigWithStaticPods(ctx context.Context
 
 	patch := client.MergeFrom(osc.DeepCopy())
 	osc.Spec.Files = append(osc.Spec.Files, files...)
+	metav1.SetMetaDataAnnotation(&osc.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
 	if err := b.SeedClientSet.Client().Patch(ctx, osc, patch); err != nil {
 		return nil, "", fmt.Errorf("failed patching OperatingSystemConfig with additional files for static control plane pods: %w", err)
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:

This PR fixes two small issues that occurred to me when trying to use `gardenadm bootstrap`.

---

**Pass `--zone` flag to `gardenadm init` from first controlplane machine**

I noticed an issue where the bootstrapping on the controlplane machine could not continue, because no `topology.kubernetes.io/zone` label was present on the node.

The `kube-system` namespace is labeled with the `high-availability-config.resources.gardener.cloud/consider=true` label, which leads to pods in the namespace getting node affinity based on the `zone` label.

The cloud-controller-manager, which is responsible for adding this label is also scheduled in this namespace, leading to a chicken-egg-problem.

For the unmanaged scenario there is already a solution to this problem, which we can reuse by getting the zone from the first controlplane machine and then passing it to the `gardenadm init` on the machine.

---

**Put `reconcile` annotation on OSC patch**

I noticed an issue where the bootstrapping on the controlplane machine could not continue, because the OSC observed generation would not catch up:
```
[shoot--i549599ls--root-control-plane-z1-67b55-dhfjb] 2026-07-27T14:24:53.344Z    DEBUG    Finished    {"flow": "init", "task": "Restoring external DNSRecord", "duration": "10.055203963s"}
[shoot--i549599ls--root-control-plane-z1-67b55-dhfjb] 2026-07-27T14:24:53.344Z    INFO    Succeeded    {"flow": "init", "task": "Restoring external DNSRecord"}
[shoot--i549599ls--root-control-plane-z1-67b55-dhfjb] 2026-07-27T14:24:58.161Z    DEBUG    Finished    {"flow": "init", "task": "Waiting until main and event ETCDs have been reconciled", "duration": "10.022013966s"}
[shoot--i549599ls--root-control-plane-z1-67b55-dhfjb] 2026-07-27T14:24:58.162Z    INFO    Succeeded    {"flow": "init", "task": "Waiting until main and event ETCDs have been reconciled"}
[shoot--i549599ls--root-control-plane-z1-67b55-dhfjb] 2026-07-27T14:24:58.162Z    DEBUG    Started    {"flow": "init", "task": "Deploying control plane components as Deployments/StatefulSets and updating gardener-node-agent Secret"}
[shoot--i549599ls--root-control-plane-z1-67b55-dhfjb] 2026-07-27T14:24:59.420Z    INFO    Object did not get ready yet    {"object": {"name":"gardener-node-agent-control-plane-6f49e2a060e4e2c3-original","namespace":"kube-system"}, "kind": "OperatingSystemConfig", "reason": "observed generation outdated (1/2)"}
```

My assumption is that this happens because the OSC is patched, but the extension controller ignores it, because of the `DefaultControllerPredicates` (example `gardenlinux`):

[`gardenlinux` OSC controller registration](https://github.com/gardener/gardener-extension-os-gardenlinux/blob/d6934ffdc6b7a58a74997a55b42e5da4ab31e2a0/pkg/controller/operatingsystemconfig/add.go#L37): 

```go
func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddOptions) error {
	return operatingsystemconfig.Add(mgr, operatingsystemconfig.AddArgs{
		Actuator:          NewActuator(mgr),
		Predicates:        operatingsystemconfig.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),
...
```

[operatingsystem extension `DefaultPredicates`](https://github.com/gardener/gardener/blob/ed333b8aa4efdff7851b2c1c10ecd568f41da2c6/extensions/pkg/controller/operatingsystemconfig/controller.go#L68-L71): 

```go
// DefaultPredicates returns the default predicates for an operatingsystemconfig reconciler.
func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperationAnnotation bool) []predicate.Predicate {
	return extensionspredicate.DefaultControllerPredicates(ignoreOperationAnnotation, extensionspredicate.ShootNotFailedPredicate(ctx, mgr))
}
```

[generic extension `DefaultControllerPredicates` (`UpdateFunc`)](https://github.com/gardener/gardener/blob/485c25124ea536e4610c627109017dd34d434921/extensions/pkg/predicate/default.go#L59-L78):

```go
UpdateFunc: func(e event.UpdateEvent) bool {
		// If a relevant operation annotation is present then we admit reconciliation. The OperationAnnotationWrapper
		// ensures that this annotation is removed right after the reconciler has picked up the object. This prevents
		// that both the OperationAnnotationWrapper and the reconciler endlessly trigger further events when removing
		// the annotation or updating the status.
		if hasOperationAnnotation(e.ObjectNew) {
			return true
		}

		// If the object's deletion timestamp is set and the status has not changed then we admit reconciliation. This
		// covers the actual delete request (which once increases the generation) and further updates (e.g., when
		// gardenlet updates the timestamp annotation). It prevents that the controller triggers itself endlessly when
		// updating the status while the deletion timestamp is set.
		if e.ObjectNew.GetDeletionTimestamp() != nil && statusEqual(e.ObjectOld, e.ObjectNew) {
			return true
		}

		// If none of the above conditions applies then reconciliation is not allowed.
		return false
	},
```

My proposed solution is adding the `reconcile` annotation with the patch, so that the OSC gets reconciled.

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:
/cc @rfranzke @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```