### PR TITLE
Observability: add vitals, availability, resource usage, and request rate per response code panels to apiserver dashboard

### DIFF
--- a/pkg/component/observability/plutono/dashboards/garden-shoot/apiserver-overview.json
+++ b/pkg/component/observability/plutono/dashboards/garden-shoot/apiserver-overview.json
@@ -40,7 +40,7 @@
       },
       "id": 102,
       "panels": [],
-      "title": "API Server Vitals",
+      "title": "API Server Overview",
       "type": "row"
     },
     {
@@ -49,7 +49,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Number of instances api server is unreachable",
+      "description": "Number of unreachable API server instances",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -146,7 +146,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "kube-apiserver disruption events in the last 5 minutes.",
+      "description": "Number of kube-apiserver restarts.",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -188,7 +188,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{container=\"kube-apiserver\"}[5m])) by (pod)",
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{container=\"kube-apiserver\"}[$__rate_interval])) by (pod)",
           "interval": "",
           "legendFormat": "{{pod}} - Restarted",
           "refId": "A"
@@ -243,7 +243,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "OOM kill events on the kube-apiserver container.",
+      "description": "Number of kube-apiserver OOM events.",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -285,7 +285,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(container_oom_events_total{container=\"kube-apiserver\"}[5m])) by (pod)",
+          "expr": "sum(increase(container_oom_events_total{container=\"kube-apiserver\"}[$__rate_interval])) by (pod)",
           "interval": "",
           "legendFormat": "{{pod}} - OOM",
           "refId": "A"
@@ -340,7 +340,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Shows CPU usage in terms of percentage",
+      "description": "Shows CPU utilization as percentage",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -392,7 +392,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "API Server CPU usage",
+      "title": "API Server CPU utilization",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -437,7 +437,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Shows memory usage in terms of percentage",
+      "description": "Shows memory utilization as percentage",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -489,7 +489,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "API Server memory usage",
+      "title": "API Server memory utilization",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2112,7 +2112,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(apiserver_request_total{job=~\"$job\",pod=~\"$pod\"}[$__rate_interval])) by(code,resource,subresource)",
+          "expr": "sum(rate(apiserver_request_total{job=~\"$job\",pod=~\"$pod\"}[$__rate_interval])) by(code, resource, subresource)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2339,7 +2339,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(apiserver_request_total{verb=~\"$verb\",pod=~\"$pod\"}[$__rate_interval])) by(code,resource,verb,subresource)",
+          "expr": "sum(rate(apiserver_request_total{verb=~\"$verb\",pod=~\"$pod\"}[$__rate_interval])) by(code, resource, verb, subresource)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2353,7 +2353,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "API Server Request Rates Per Code, Verb And Resource",
+      "title": "Request Rates Per Code, Verb And Resource",
       "tooltip": {
         "msResolution": false,
         "shared": false,

--- a/pkg/component/observability/plutono/dashboards/garden-shoot/apiserver-overview.json
+++ b/pkg/component/observability/plutono/dashboards/garden-shoot/apiserver-overview.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1785002102603,
+  "iteration": 1786438450895,
   "links": [
     {
       "icon": "external link",
@@ -49,103 +49,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Number of unreachable API server instances",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 1
-      },
-      "hiddenSeries": false,
-      "id": 104,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.50",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "max_over_time(count(up{role=\"apiserver\"} == 0) by (pod)[5m:])",
-          "interval": "",
-          "legendFormat": "{{pod}} - unreachable",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "API Server Unreachable",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:408",
-          "format": "short",
-          "label": "instances",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:409",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
       "description": "Number of kube-apiserver restarts.",
       "fieldConfig": {
         "defaults": {},
@@ -156,7 +59,7 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
+        "x": 0,
         "y": 1
       },
       "hiddenSeries": false,
@@ -253,8 +156,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 9
+        "x": 12,
+        "y": 1
       },
       "hiddenSeries": false,
       "id": 106,
@@ -335,207 +238,13 @@
       }
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "description": "Shows CPU utilization as percentage",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 9
-      },
-      "hiddenSeries": false,
-      "id": 107,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.50",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "(sum(rate(container_cpu_usage_seconds_total{container=\"kube-apiserver\"}[5m])) by(pod) / sum(kube_pod_container_resource_requests{container=\"kube-apiserver\", resource=\"cpu\", unit=\"core\"}) by(pod)) * 100",
-          "interval": "",
-          "legendFormat": "{{pod}} - CPU usage",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "API Server CPU utilization",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:408",
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:409",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "description": "Shows memory utilization as percentage",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 17
-      },
-      "hiddenSeries": false,
-      "id": 108,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.50",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "(sum(container_memory_working_set_bytes{container=\"kube-apiserver\"}) by(pod) / sum(kube_pod_container_resource_requests{container=\"kube-apiserver\", resource=\"memory\", unit=\"byte\"}) by(pod)) * 100",
-          "interval": "",
-          "legendFormat": "{{pod}} - memory usage",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "API Server memory utilization",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:408",
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:409",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 9
       },
       "id": 73,
       "panels": [],
@@ -558,7 +267,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 10
       },
       "hiddenSeries": false,
       "id": 70,
@@ -665,7 +374,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 10
       },
       "hiddenSeries": false,
       "id": 71,
@@ -772,7 +481,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 16
       },
       "hiddenSeries": false,
       "id": 74,
@@ -871,7 +580,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 16
       },
       "hiddenSeries": false,
       "id": 75,
@@ -961,7 +670,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 22
       },
       "id": 91,
       "panels": [],
@@ -984,7 +693,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 23
       },
       "hiddenSeries": false,
       "id": 88,
@@ -1079,7 +788,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 23
       },
       "hiddenSeries": false,
       "id": 89,
@@ -1165,7 +874,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 28
       },
       "id": 97,
       "panels": [],
@@ -1188,7 +897,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 45
+        "y": 29
       },
       "hiddenSeries": false,
       "id": 93,
@@ -1283,7 +992,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 45
+        "y": 29
       },
       "hiddenSeries": false,
       "id": 95,
@@ -1373,7 +1082,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 34
       },
       "id": 53,
       "panels": [],
@@ -1406,7 +1115,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 35
       },
       "hiddenSeries": false,
       "id": 6,
@@ -1516,7 +1225,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 35
       },
       "hiddenSeries": false,
       "id": 7,
@@ -1630,7 +1339,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 59
+        "y": 43
       },
       "hiddenSeries": false,
       "id": 49,
@@ -1739,7 +1448,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 59
+        "y": 43
       },
       "hiddenSeries": false,
       "id": 51,
@@ -1847,7 +1556,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 51
       },
       "hiddenSeries": false,
       "id": 47,
@@ -1960,7 +1669,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 75
+        "y": 59
       },
       "hiddenSeries": false,
       "id": 48,
@@ -2073,7 +1782,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 83
+        "y": 67
       },
       "hiddenSeries": false,
       "id": 99,
@@ -2187,7 +1896,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 91
+        "y": 75
       },
       "hiddenSeries": false,
       "id": 45,
@@ -2300,7 +2009,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 101
+        "y": 85
       },
       "hiddenSeries": false,
       "id": 100,
@@ -2405,7 +2114,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 111
+        "y": 95
       },
       "hiddenSeries": false,
       "id": 67,
@@ -2504,7 +2213,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 111
+        "y": 95
       },
       "hiddenSeries": false,
       "id": 68,
@@ -2599,7 +2308,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 119
+        "y": 103
       },
       "hiddenSeries": false,
       "id": 63,
@@ -2707,7 +2416,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 119
+        "y": 103
       },
       "hiddenSeries": false,
       "id": 65,
@@ -2807,7 +2516,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 127
+        "y": 111
       },
       "hiddenSeries": false,
       "id": 98,
@@ -2901,7 +2610,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 135
+        "y": 119
       },
       "id": 85,
       "panels": [],
@@ -2924,7 +2633,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 136
+        "y": 120
       },
       "hiddenSeries": false,
       "id": 80,
@@ -3019,7 +2728,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 136
+        "y": 120
       },
       "hiddenSeries": false,
       "id": 81,
@@ -3118,7 +2827,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 142
+        "y": 126
       },
       "hiddenSeries": false,
       "id": 77,
@@ -3217,7 +2926,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 142
+        "y": 126
       },
       "hiddenSeries": false,
       "id": 78,
@@ -3316,7 +3025,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 148
+        "y": 132
       },
       "hiddenSeries": false,
       "id": 82,
@@ -3417,7 +3126,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 154
+        "y": 138
       },
       "id": 61,
       "panels": [],
@@ -3442,7 +3151,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 155
+        "y": 139
       },
       "hiddenSeries": false,
       "id": 55,
@@ -3545,7 +3254,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 155
+        "y": 139
       },
       "hiddenSeries": false,
       "id": 76,
@@ -3645,7 +3354,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 163
+        "y": 147
       },
       "hiddenSeries": false,
       "id": 57,
@@ -3752,7 +3461,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 163
+        "y": 147
       },
       "hiddenSeries": false,
       "id": 59,
@@ -3853,7 +3562,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 170
+        "y": 154
       },
       "hiddenSeries": false,
       "id": 83,
@@ -3955,7 +3664,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 170
+        "y": 154
       },
       "hiddenSeries": false,
       "id": 86,
@@ -4053,7 +3762,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -4254,9 +3962,10 @@
       {
         "allValue": null,
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "0.99",
-          "value": "0.99"
+          "text": "None",
+          "value": ""
         },
         "datasource": null,
         "definition": "label_values(shoot:apiserver_latency_seconds:quantile, quantile)",

--- a/pkg/component/observability/plutono/dashboards/garden-shoot/apiserver-overview.json
+++ b/pkg/component/observability/plutono/dashboards/garden-shoot/apiserver-overview.json
@@ -15,6 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
+  "iteration": 1785002102603,
   "links": [
     {
       "icon": "external link",
@@ -37,6 +38,505 @@
         "x": 0,
         "y": 0
       },
+      "id": 102,
+      "panels": [],
+      "title": "API Server Vitals",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Number of instances api server is unreachable",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 104,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.50",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "max_over_time(count(up{role=\"apiserver\"} == 0) by (pod)[5m:])",
+          "interval": "",
+          "legendFormat": "{{pod}} - unreachable",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "API Server Unreachable",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:408",
+          "format": "short",
+          "label": "instances",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:409",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "kube-apiserver disruption events in the last 5 minutes.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 105,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.50",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{container=\"kube-apiserver\"}[5m])) by (pod)",
+          "interval": "",
+          "legendFormat": "{{pod}} - Restarted",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "API Server Restarted",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:408",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:409",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "OOM kill events on the kube-apiserver container.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 106,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.50",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(increase(container_oom_events_total{container=\"kube-apiserver\"}[5m])) by (pod)",
+          "interval": "",
+          "legendFormat": "{{pod}} - OOM",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "API Server OOM events",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:408",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:409",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Shows CPU usage in terms of percentage",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 107,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.50",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "(sum(rate(container_cpu_usage_seconds_total{container=\"kube-apiserver\"}[5m])) by(pod) / sum(kube_pod_container_resource_requests{container=\"kube-apiserver\", resource=\"cpu\", unit=\"core\"}) by(pod)) * 100",
+          "interval": "",
+          "legendFormat": "{{pod}} - CPU usage",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "API Server CPU usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:408",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:409",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Shows memory usage in terms of percentage",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "hiddenSeries": false,
+      "id": 108,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.50",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "(sum(container_memory_working_set_bytes{container=\"kube-apiserver\"}) by(pod) / sum(kube_pod_container_resource_requests{container=\"kube-apiserver\", resource=\"memory\", unit=\"byte\"}) by(pod)) * 100",
+          "interval": "",
+          "legendFormat": "{{pod}} - memory usage",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "API Server memory usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:408",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:409",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
       "id": 73,
       "panels": [],
       "title": "API Server Admission",
@@ -58,7 +558,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 1
+        "y": 26
       },
       "hiddenSeries": false,
       "id": 70,
@@ -89,7 +589,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -165,7 +665,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 1
+        "y": 26
       },
       "hiddenSeries": false,
       "id": 71,
@@ -196,7 +696,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -272,7 +772,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 7
+        "y": 32
       },
       "hiddenSeries": false,
       "id": 74,
@@ -296,7 +796,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -371,7 +871,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 7
+        "y": 32
       },
       "hiddenSeries": false,
       "id": 75,
@@ -395,7 +895,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -461,7 +961,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 38
       },
       "id": 91,
       "panels": [],
@@ -484,7 +984,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 39
       },
       "hiddenSeries": false,
       "id": 88,
@@ -504,7 +1004,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -579,7 +1079,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 14
+        "y": 39
       },
       "hiddenSeries": false,
       "id": 89,
@@ -599,7 +1099,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -665,7 +1165,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 44
       },
       "id": 97,
       "panels": [],
@@ -688,7 +1188,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 45
       },
       "hiddenSeries": false,
       "id": 93,
@@ -708,7 +1208,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -783,7 +1283,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 20
+        "y": 45
       },
       "hiddenSeries": false,
       "id": 95,
@@ -807,7 +1307,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -873,7 +1373,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 50
       },
       "id": 53,
       "panels": [],
@@ -906,7 +1406,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 51
       },
       "hiddenSeries": false,
       "id": 6,
@@ -932,7 +1432,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1016,7 +1516,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 51
       },
       "hiddenSeries": false,
       "id": 7,
@@ -1044,7 +1544,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1130,7 +1630,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 34
+        "y": 59
       },
       "hiddenSeries": false,
       "id": 49,
@@ -1158,7 +1658,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1239,7 +1739,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 34
+        "y": 59
       },
       "hiddenSeries": false,
       "id": 51,
@@ -1264,7 +1764,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1347,7 +1847,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 67
       },
       "hiddenSeries": false,
       "id": 47,
@@ -1375,7 +1875,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1460,7 +1960,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 75
       },
       "hiddenSeries": false,
       "id": 48,
@@ -1488,7 +1988,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1554,6 +2054,120 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "description": "Shows the request rate per code and resource for the API server.",
+      "editable": false,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "grid": {
+        "threshold1Color": "rgba(216, 200, 27, 0.27)",
+        "threshold2Color": "rgba(234, 112, 112, 0.22)"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 83
+      },
+      "hiddenSeries": false,
+      "id": 99,
+      "isNew": false,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.50",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_request_total{job=~\"$job\",pod=~\"$pod\"}[$__rate_interval])) by(code,resource,subresource)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{code}} /{{resource}} /{{subresource}}",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Request Rates Per Code and Resource",
+      "tooltip": {
+        "msResolution": false,
+        "shared": false,
+        "sort": 1,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:793",
+          "decimals": null,
+          "format": "short",
+          "label": "requests/s",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:794",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
       "description": "Shows the request rate per verb and resource for the API server.",
       "editable": false,
       "error": false,
@@ -1573,7 +2187,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 91
       },
       "hiddenSeries": false,
       "id": 45,
@@ -1601,7 +2215,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1667,6 +2281,120 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "description": "Shows the request rate per code, verb and resource for the API server.",
+      "editable": false,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "grid": {
+        "threshold1Color": "rgba(216, 200, 27, 0.27)",
+        "threshold2Color": "rgba(234, 112, 112, 0.22)"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 101
+      },
+      "hiddenSeries": false,
+      "id": 100,
+      "isNew": false,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.50",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_request_total{verb=~\"$verb\",pod=~\"$pod\"}[$__rate_interval])) by(code,resource,verb,subresource)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{code}} /{{verb}} /{{resource}} /{{subresource}}",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "API Server Request Rates Per Code, Verb And Resource",
+      "tooltip": {
+        "msResolution": false,
+        "shared": false,
+        "sort": 1,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:827",
+          "decimals": null,
+          "format": "short",
+          "label": "requests/s",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:828",
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1677,7 +2405,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 111
       },
       "hiddenSeries": false,
       "id": 67,
@@ -1701,7 +2429,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1776,7 +2504,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 111
       },
       "hiddenSeries": false,
       "id": 68,
@@ -1796,7 +2524,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1871,7 +2599,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 76
+        "y": 119
       },
       "hiddenSeries": false,
       "id": 63,
@@ -1904,7 +2632,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1979,7 +2707,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 76
+        "y": 119
       },
       "hiddenSeries": false,
       "id": 65,
@@ -2003,7 +2731,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2079,7 +2807,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 84
+        "y": 127
       },
       "hiddenSeries": false,
       "id": 98,
@@ -2106,7 +2834,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2173,7 +2901,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 92
+        "y": 135
       },
       "id": 85,
       "panels": [],
@@ -2196,7 +2924,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 93
+        "y": 136
       },
       "hiddenSeries": false,
       "id": 80,
@@ -2216,7 +2944,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2291,7 +3019,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 93
+        "y": 136
       },
       "hiddenSeries": false,
       "id": 81,
@@ -2315,7 +3043,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2390,7 +3118,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 99
+        "y": 142
       },
       "hiddenSeries": false,
       "id": 77,
@@ -2414,7 +3142,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2489,7 +3217,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 99
+        "y": 142
       },
       "hiddenSeries": false,
       "id": 78,
@@ -2513,7 +3241,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2588,7 +3316,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 105
+        "y": 148
       },
       "hiddenSeries": false,
       "id": 82,
@@ -2621,7 +3349,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2689,7 +3417,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 111
+        "y": 154
       },
       "id": 61,
       "panels": [],
@@ -2714,7 +3442,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 112
+        "y": 155
       },
       "hiddenSeries": false,
       "id": 55,
@@ -2738,7 +3466,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -2817,7 +3545,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 112
+        "y": 155
       },
       "hiddenSeries": false,
       "id": 76,
@@ -2841,7 +3569,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2917,7 +3645,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 120
+        "y": 163
       },
       "hiddenSeries": false,
       "id": 57,
@@ -2948,7 +3676,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3024,7 +3752,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 120
+        "y": 163
       },
       "hiddenSeries": false,
       "id": 59,
@@ -3048,7 +3776,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3125,7 +3853,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 127
+        "y": 170
       },
       "hiddenSeries": false,
       "id": 83,
@@ -3149,7 +3877,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -3227,7 +3955,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 127
+        "y": 170
       },
       "hiddenSeries": false,
       "id": 86,
@@ -3251,7 +3979,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.50",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -3312,6 +4040,7 @@
       }
     }
   ],
+  "refresh": false,
   "schemaVersion": 27,
   "style": "dark",
   "tags": [
@@ -3584,5 +4313,6 @@
   },
   "timezone": "utc",
   "title": "API Server",
-  "uid": "apiserver-overview"
+  "uid": "apiserver-overview",
+  "version": 1
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area monitoring
/area observability
/kind enhancement

**What this PR does / why we need it**:
Extends the `apiserver-overview` Plutono dashboard for shoot clusters with additional observability panels:

- **API Server Overview** – high-level health stat panel
- **API Server Restarted** – restart event tracking
- **API Server OOM events** – out-of-memory event visibility
- **Request Rates Per Code and Resource** – breakdown of request rates by HTTP status code and resource
- **API Server Request Rates Per Code, Verb And Resource** – detailed request rate breakdown by code, verb, and resource

These panels improve observability of the kube-apiserver for operators monitoring shoot control planes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Only the dashboard JSON was modified. No code or test changes are required as existing tests only validate the number of deployed dashboards, not panel content.

**Release note**:
```other operator
Extended the apiserver-overview Plutono dashboard with additional panels covering API server vitals, availability, restarts, OOM events and request rates per code, verb, and resource.
