### PR TITLE
[GEP-28] Harmonize `Operation` initialization for `gardenlet` and `gardenadm`

### DIFF
--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -34,9 +34,6 @@ import (
 	"github.com/gardener/gardener/pkg/gardenadm"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
-	gardenpkg "github.com/gardener/gardener/pkg/gardenlet/operation/garden"
-	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
-	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	"github.com/gardener/gardener/pkg/nodeagent"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -175,8 +172,19 @@ func NewGardenadmBotanistWithoutResources(log logr.Logger) (*GardenadmBotanist, 
 		return nil, fmt.Errorf("failed fetching hostname: %w", err)
 	}
 
+	gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{}
+	gardenletconfigv1alpha1.SetObjectDefaults_GardenletConfiguration(gardenletConfig)
+
+	// Stub `Operation`; used only for hostname/client-set creation (e.g., `gardenadm join`).
 	b := &GardenadmBotanist{
-		Botanist: &botanistpkg.Botanist{Operation: newOperation(log, newFakeGardenClient(), newFakeSeedClientSet(""))},
+		Botanist: &botanistpkg.Botanist{Operation: &operation.Operation{
+			Logger:         log,
+			Clock:          clock.RealClock{},
+			Config:         gardenletConfig,
+			GardenClient:   newFakeGardenClient(),
+			SeedClientSet:  newFakeSeedClientSet(""),
+			ShootClientSet: newFakeSeedClientSet(""),
+		}},
 
 		HostName: hostName,
 		DBus:     dbus.New(log),
@@ -188,20 +196,6 @@ func NewGardenadmBotanistWithoutResources(log logr.Logger) (*GardenadmBotanist, 
 	}
 
 	return b, nil
-}
-
-func newOperation(log logr.Logger, gardenClient client.Client, clientSet kubernetes.Interface) *operation.Operation {
-	gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{}
-	gardenletconfigv1alpha1.SetObjectDefaults_GardenletConfiguration(gardenletConfig)
-
-	return &operation.Operation{
-		Logger:         log,
-		Clock:          clock.RealClock{},
-		Config:         gardenletConfig,
-		GardenClient:   gardenClient,
-		SeedClientSet:  clientSet,
-		ShootClientSet: clientSet,
-	}
 }
 
 func newBotanist(
@@ -223,26 +217,39 @@ func newBotanist(
 		log.Info("Initializing gardenadm botanist with control plane client set", keysAndValues...) //nolint:logcheck
 	}
 
-	var (
-		o   = newOperation(log, gardenClient, clientSet)
-		err error
-	)
-
-	o.Garden, err = newGardenObject(ctx, resources.Project)
-	if err != nil {
-		return nil, fmt.Errorf("failed creating garden object: %w", err)
+	var seed *gardencorev1beta1.Seed
+	if !runsControlPlane {
+		seed = resources.Seed
 	}
 
-	o.Shoot, err = newShootObject(ctx, clientSet, gardenClient, resources, runsControlPlane)
+	gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{}
+	gardenletconfigv1alpha1.SetObjectDefaults_GardenletConfiguration(gardenletConfig)
+
+	o, err := operation.Initialize(
+		ctx,
+		log,
+		gardenClient,
+		clientSet,
+		nil, // gardenadm has no ShootClientMap
+		gardenletConfig,
+		&gardencorev1beta1.Gardener{Name: "gardenadm", Version: version.Get().GitVersion},
+		resources.Shoot.Name, // matches `Seed.Status.ClusterIdentity` written by `initializeSeedResource`
+		resources.Shoot,
+		resources.Project,
+		resources.CloudProfile,
+		seed,
+		nil, // no `ExposureClass` in gardenadm
+	)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating shoot object: %w", err)
+		return nil, fmt.Errorf("failed initializing operation: %w", err)
 	}
 
 	if !runsControlPlane {
-		o.Seed, err = seedpkg.NewBuilder().WithSeedObject(resources.Seed).Build(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed creating seed object: %w", err)
-		}
+		// In self-hosted shoot clusters, kube-system is used as the control plane namespace.
+		// However, when bootstrapping a self-hosted shoot cluster with `gardenadm bootstrap` using a temporary local cluster,
+		// we want to avoid conflicts with kube-system components of the bootstrap cluster by placing all shoot-related
+		// components in another namespace. In this case, we use the technical ID as the control plane namespace, as usual.
+		o.Shoot.ControlPlaneNamespace = resources.Shoot.Status.TechnicalID
 	}
 
 	if caBundle := imagevector.ContainersCABundle(); caBundle != nil && caBundle.Inline != nil {
@@ -296,45 +303,6 @@ func initializeFakeGardenResources(
 	}
 
 	return nil
-}
-
-func newGardenObject(ctx context.Context, project *gardencorev1beta1.Project) (*gardenpkg.Garden, error) {
-	return gardenpkg.
-		NewBuilder().
-		WithProject(project).
-		Build(ctx)
-}
-
-func newShootObject(
-	ctx context.Context,
-	clientSet kubernetes.Interface,
-	gardenClient client.Client,
-	resources gardenadm.Resources,
-	runsControlPlane bool,
-) (
-	*shootpkg.Shoot,
-	error,
-) {
-	obj, err := shootpkg.
-		NewBuilder().
-		WithProjectName(resources.Project.Name).
-		WithCloudProfileObject(resources.CloudProfile).
-		WithShootObject(resources.Shoot).
-		WithShootCredentialsFrom(gardenClient).
-		Build(ctx, clientSet, gardenClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed building shoot object: %w", err)
-	}
-
-	// In self-hosted shoot clusters, kube-system is used as the control plane namespace.
-	// However, when bootstrapping a self-hosted shoot cluster with `gardenadm bootstrap` using a temporary local cluster,
-	// we want to avoid conflicts with kube-system components of the bootstrap cluster by placing all shoot-related
-	// components in another namespace. In this case, we use the technical ID as the control plane namespace, as usual.
-	if !runsControlPlane {
-		obj.ControlPlaneNamespace = resources.Shoot.Status.TechnicalID
-	}
-
-	return obj, nil
 }
 
 func newFakeGardenClient() client.Client {

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/afero"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
@@ -28,7 +27,6 @@ import (
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/gardenadm"
@@ -138,8 +136,6 @@ func NewGardenadmBotanist(
 		return nil, fmt.Errorf("failed initializing shoot resource: %w", err)
 	}
 
-	initializeSeedResource(resources, runsControlPlane)
-
 	gardenClient := newFakeGardenClient()
 	if err := initializeFakeGardenResources(ctx, gardenClient, resources, extensions); err != nil {
 		return nil, fmt.Errorf("failed initializing resources in fake garden client: %w", err)
@@ -217,11 +213,6 @@ func newBotanist(
 		log.Info("Initializing gardenadm botanist with control plane client set", keysAndValues...) //nolint:logcheck
 	}
 
-	var seed *gardencorev1beta1.Seed
-	if !runsControlPlane {
-		seed = resources.Seed
-	}
-
 	gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{}
 	gardenletconfigv1alpha1.SetObjectDefaults_GardenletConfiguration(gardenletConfig)
 
@@ -233,11 +224,11 @@ func newBotanist(
 		nil, // gardenadm has no ShootClientMap
 		gardenletConfig,
 		&gardencorev1beta1.Gardener{Name: "gardenadm", Version: version.Get().GitVersion},
-		resources.Shoot.Name, // matches `Seed.Status.ClusterIdentity` written by `initializeSeedResource`
+		resources.Shoot.Name,
 		resources.Shoot,
 		resources.Project,
 		resources.CloudProfile,
-		seed,
+		nil, // no `Seed` in gardenadm
 		nil, // no `ExposureClass` in gardenadm
 	)
 	if err != nil {
@@ -252,10 +243,6 @@ func newBotanist(
 		o.Shoot.ControlPlaneNamespace = resources.Shoot.Status.TechnicalID
 	}
 
-	if caBundle := imagevector.ContainersCABundle(); caBundle != nil && caBundle.Inline != nil {
-		o.RegistryCABundle = caBundle.Inline
-	}
-
 	return botanistpkg.New(ctx, o)
 }
 
@@ -265,7 +252,7 @@ func initializeFakeGardenResources(
 	resources gardenadm.Resources,
 	extensions []Extension,
 ) error {
-	objects := []client.Object{resources.Seed.DeepCopy(), resources.Shoot.DeepCopy()}
+	objects := []client.Object{resources.Shoot.DeepCopy()}
 
 	for _, extension := range extensions {
 		objects = append(
@@ -373,22 +360,6 @@ func initializeShootResource(resources gardenadm.Resources, fs afero.Afero, runs
 	}
 
 	return nil
-}
-
-func initializeSeedResource(resources gardenadm.Resources, runsControlPlane bool) {
-	seed := resources.Seed
-	seed.Name = resources.Shoot.Name
-	seed.Status = gardencorev1beta1.SeedStatus{ClusterIdentity: new(resources.Shoot.Name)}
-
-	if runsControlPlane {
-		// When running the control plane (`gardenadm init`), mark the seed as a self-hosted shoot cluster.
-		// Otherwise (`gardenadm bootstrap`), the bootstrap cluster should behave like a standard seed cluster.
-		// If the seed is marked as a self-hosted shoot cluster, extensions are configured differently, e.g., they merge the
-		// shoot webhooks into the seed webhooks.
-		metav1.SetMetaDataLabel(&seed.ObjectMeta, v1beta1constants.LabelSelfHostedShootCluster, "true")
-	}
-
-	kubernetes.GardenScheme.Default(seed)
 }
 
 func shootUID(fs afero.Afero) (types.UID, error) {

--- a/pkg/gardenadm/botanist/botanist_test.go
+++ b/pkg/gardenadm/botanist/botanist_test.go
@@ -182,7 +182,7 @@ metadata:
 					HaveField("ControllerRegistration.Name", "provider-stackit"),
 					HaveField("ControllerRegistration.Name", "dns-local"),
 				))
-				Expect(b.Seed.GetInfo()).To(HaveField("ObjectMeta.Labels", Not(HaveKeyWithValue("seed.gardener.cloud/self-hosted-shoot-cluster", "true"))))
+				Expect(b.Seed).To(BeNil())
 			})
 
 			It("should use the technical ID as the control plane namespace", func() {

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -65,7 +65,7 @@ func ComputeExtensions(resources gardenadm.Resources, runsControlPlane, managedI
 				Spec: gardencorev1beta1.ControllerInstallationSpec{
 					RegistrationRef: corev1.ObjectReference{Name: controllerRegistration.Name},
 					DeploymentRef:   &corev1.ObjectReference{Name: controllerDeployment.Name},
-					SeedRef:         &corev1.ObjectReference{Name: resources.Shoot.Name},
+					ShootRef:        &corev1.ObjectReference{Name: resources.Shoot.Name, Namespace: resources.Shoot.Namespace},
 				},
 			}
 		)

--- a/pkg/gardenadm/botanist/extensions_test.go
+++ b/pkg/gardenadm/botanist/extensions_test.go
@@ -259,7 +259,8 @@ var _ = Describe("Extensions", func() {
 					HaveField("ObjectMeta.Name", controllerRegistrationControlPlane.Name),
 					HaveField("Spec.RegistrationRef.Name", controllerRegistrationControlPlane.Name),
 					HaveField("Spec.DeploymentRef.Name", controllerDeploymentControlPlane.Name),
-					HaveField("Spec.SeedRef.Name", shoot.Name),
+					HaveField("Spec.ShootRef.Name", shoot.Name),
+					HaveField("Spec.ShootRef.Namespace", shoot.Namespace),
 				)),
 			))
 		})

--- a/pkg/gardenadm/resources.go
+++ b/pkg/gardenadm/resources.go
@@ -50,7 +50,6 @@ func init() {
 type Resources struct {
 	CloudProfile            *gardencorev1beta1.CloudProfile
 	Project                 *gardencorev1beta1.Project
-	Seed                    *gardencorev1beta1.Seed
 	Shoot                   *gardencorev1beta1.Shoot
 	ShootState              *gardencorev1beta1.ShootState
 	ControllerRegistrations []*gardencorev1beta1.ControllerRegistration
@@ -66,7 +65,7 @@ type Resources struct {
 // It returns among others a CloudProfile, Project, and Shoot resource if found, or an error if any issues occur during
 // reading or decoding. It ignores hidden files and directories (starting with a dot).
 func ReadManifests(log logr.Logger, fsys fs.FS) (Resources, error) {
-	resources := Resources{Seed: &gardencorev1beta1.Seed{}}
+	resources := Resources{}
 
 	if err := VisitManifestFiles(fsys, func(path string, file fs.File) error {
 		reader := yaml.NewYAMLReader(bufio.NewReader(file))

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -27,7 +27,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/gardener/gardener/imagevector"
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -388,10 +387,6 @@ func (r *Reconciler) initializeOperation(
 	)
 	if err != nil {
 		return nil, err
-	}
-
-	if containersCABundle := imagevector.ContainersCABundle(); containersCABundle != nil && containersCABundle.Inline != nil {
-		op.RegistryCABundle = containersCABundle.Inline
 	}
 
 	// Only set UID once the operation was initialized successfully.

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -44,9 +44,6 @@ import (
 	gardenletmetrics "github.com/gardener/gardener/pkg/gardenlet/metrics"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
-	"github.com/gardener/gardener/pkg/gardenlet/operation/garden"
-	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
-	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils"
 	errorsutils "github.com/gardener/gardener/pkg/utils/errors"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -374,97 +371,21 @@ func (r *Reconciler) initializeOperation(
 	*operation.Operation,
 	error,
 ) {
-	var (
-		gardenSecrets  map[string]*corev1.Secret
-		internalDomain *gardenerutils.Domain
-		defaultDomains []*gardenerutils.Domain
-		err            error
+	op, err := operation.Initialize(
+		ctx,
+		log,
+		r.GardenClient,
+		r.SeedClientSet,
+		r.ShootClientMap,
+		&r.Config,
+		r.Identity,
+		r.GardenClusterIdentity,
+		shoot,
+		project,
+		cloudProfile,
+		seed,
+		exposureClass,
 	)
-
-	if !v1beta1helper.IsShootSelfHosted(shoot.Spec.Provider.Workers) {
-		// TODO(rfranzke): Enable shoot gardenlet to read the gardener.cloud/role=shoot-service-account-issuer secret from
-		//  garden namespace (adapt authorizer) --> requires virtual garden to be at least 1.34 (this promotes the selector
-		//  feature gate to GA, hence, we can enforce the needed label selectors)
-		gardenSecrets, err = gardenerutils.ReadGardenSecrets(
-			ctx,
-			log,
-			r.GardenClient,
-			gardenerutils.ComputeGardenNamespace(seed.Name),
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		internalDomain, err = gardenerutils.ReadGardenInternalDomain(
-			ctx,
-			r.GardenClient,
-			gardenerutils.ComputeGardenNamespace(seed.Name),
-			true,
-			seed.Spec.DNS.Internal,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		defaultDomains, err = gardenerutils.ReadGardenDefaultDomains(
-			ctx,
-			r.GardenClient,
-			gardenerutils.ComputeGardenNamespace(seed.Name),
-			seed.Spec.DNS.Defaults,
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	gardenObj, err := garden.
-		NewBuilder().
-		WithProject(project).
-		WithInternalDomain(internalDomain).
-		WithDefaultDomains(defaultDomains).
-		Build(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	shootBuilder := shootpkg.
-		NewBuilder().
-		WithProjectName(project.Name).
-		WithCloudProfileObject(cloudProfile).
-		WithShootObject(shoot).
-		WithShootCredentialsFrom(r.GardenClient).
-		WithExposureClassObject(exposureClass).
-		WithInternalDomain(gardenObj.InternalDomain).
-		WithDefaultDomains(gardenObj.DefaultDomains).
-		WithServiceAccountIssuerHostname(gardenSecrets[v1beta1constants.GardenRoleShootServiceAccountIssuer])
-
-	opBuilder := operation.
-		NewBuilder().
-		WithLogger(log).
-		WithConfig(&r.Config).
-		WithGardenerInfo(r.Identity).
-		WithGardenClusterIdentity(r.GardenClusterIdentity).
-		WithSecrets(gardenSecrets).
-		WithInternalDomain(gardenObj.InternalDomain).
-		WithDefaultDomains(gardenObj.DefaultDomains).
-		WithGarden(gardenObj)
-
-	if seed != nil {
-		seedObj, err := seedpkg.NewBuilder().WithSeedObject(seed).Build(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		shootBuilder = shootBuilder.WithSeedObject(seed)
-		opBuilder = opBuilder.WithSeed(seedObj)
-	}
-
-	shootObj, err := shootBuilder.Build(ctx, r.SeedClientSet, r.GardenClient)
-	if err != nil {
-		return nil, err
-	}
-
-	op, err := opBuilder.WithShoot(shootObj).Build(ctx, r.GardenClient, r.SeedClientSet, r.ShootClientMap, shoot)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gardenlet/operation/botanist/backupentry.go
+++ b/pkg/gardenlet/operation/botanist/backupentry.go
@@ -30,7 +30,7 @@ func (b *Botanist) DefaultCoreBackupEntry() corebackupentry.Interface {
 		BucketName:     string(b.Shoot.GetInfo().Status.UID),
 	}
 
-	if !b.Shoot.RunsControlPlane() {
+	if !b.Shoot.IsSelfHosted() {
 		values.BucketName = string(b.Seed.GetInfo().UID)
 	}
 

--- a/pkg/gardenlet/operation/botanist/etcddruid.go
+++ b/pkg/gardenlet/operation/botanist/etcddruid.go
@@ -29,11 +29,6 @@ func (b *Botanist) DefaultEtcdDruid() (component.DeployWaiter, error) {
 		}
 	}
 
-	// See https://github.com/gardener/gardener/pull/14352
-	// TODO(rfranzke): Remove this from here once `gardenadm` and the shoot gardenlet construct the Operation object in
-	//  the same way.
-	b.Config.ETCDConfig.FeatureGates = map[string]bool{"UpgradeEtcdVersion": true}
-
 	return sharedcomponent.NewEtcdDruid(
 		b.SeedClientSet.Client(),
 		v1beta1constants.GardenNamespace,

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -40,7 +40,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 		}
 	)
 
-	if !b.Shoot.IsWorkerless && !b.Shoot.RunsControlPlane() {
+	if !b.Shoot.IsWorkerless && !b.Shoot.IsSelfHosted() {
 		vpnConfig.Enabled = true
 		vpnConfig.HighAvailabilityEnabled = b.Shoot.VPNHighAvailabilityEnabled
 		vpnConfig.HighAvailabilityNumberOfSeedServers = b.Shoot.VPNHighAvailabilityNumberOfSeedServers

--- a/pkg/gardenlet/operation/botanist/namespaces.go
+++ b/pkg/gardenlet/operation/botanist/namespaces.go
@@ -96,12 +96,13 @@ func (b *Botanist) DeployControlPlaneNamespace(ctx context.Context) error {
 
 		if b.Shoot.IsSelfHosted() && b.Shoot.RunsControlPlane() {
 			zones = v1beta1helper.ControlPlaneWorkerPoolForShoot(b.Shoot.GetInfo().Spec.Provider.Workers).Zones
-		} else if seedZones := b.Seed.GetInfo().Spec.Provider.Zones; len(seedZones) > 0 &&
-			!b.Shoot.IsSelfHosted() &&
-			(!failureToleranceTypeExisting || existingFailureToleranceType != newFailureToleranceType) {
-			zones, err = calculateShootZones(ctx, b.SeedClientSet.Client(), b.Logger, namespace, shootFailureToleranceType, seedZones, allShootZones(b.Shoot.GetInfo().Spec.Provider.Workers), v1beta1helper.SeedSettingZoneSelectionMode(b.Seed.GetInfo().Spec.Settings))
-			if err != nil {
-				return err
+		} else if !b.Shoot.IsSelfHosted() {
+			if seedZones := b.Seed.GetInfo().Spec.Provider.Zones; len(seedZones) > 0 &&
+				(!failureToleranceTypeExisting || existingFailureToleranceType != newFailureToleranceType) {
+				zones, err = calculateShootZones(ctx, b.SeedClientSet.Client(), b.Logger, namespace, shootFailureToleranceType, seedZones, allShootZones(b.Shoot.GetInfo().Spec.Provider.Workers), v1beta1helper.SeedSettingZoneSelectionMode(b.Seed.GetInfo().Spec.Settings))
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/pkg/gardenlet/operation/initialize.go
+++ b/pkg/gardenlet/operation/initialize.go
@@ -85,6 +85,12 @@ func Initialize(
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		// See https://github.com/gardener/gardener/pull/14352
+		if config.ETCDConfig.FeatureGates == nil {
+			config.ETCDConfig.FeatureGates = make(map[string]bool)
+		}
+		config.ETCDConfig.FeatureGates["UpgradeEtcdVersion"] = true
 	}
 
 	gardenObj, err := garden.

--- a/pkg/gardenlet/operation/initialize.go
+++ b/pkg/gardenlet/operation/initialize.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package operation
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
+	"github.com/gardener/gardener/pkg/gardenlet/operation/garden"
+	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
+	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+// Initialize creates a new Operation from the given inputs.
+// It is called by the gardenlet `Shoot` reconciler and by `gardenadm` so that both share the same `Operation`
+// construction logic.
+func Initialize(
+	ctx context.Context,
+	log logr.Logger,
+	gardenClient client.Client,
+	seedClientSet kubernetes.Interface,
+	shootClientMap clientmap.ClientMap,
+	config *gardenletconfigv1alpha1.GardenletConfiguration,
+	gardenerInfo *gardencorev1beta1.Gardener,
+	gardenClusterIdentity string,
+	shoot *gardencorev1beta1.Shoot,
+	project *gardencorev1beta1.Project,
+	cloudProfile *gardencorev1beta1.CloudProfile,
+	seed *gardencorev1beta1.Seed,
+	exposureClass *gardencorev1beta1.ExposureClass,
+) (
+	*Operation,
+	error,
+) {
+	var (
+		gardenSecrets  map[string]*corev1.Secret
+		internalDomain *gardenerutils.Domain
+		defaultDomains []*gardenerutils.Domain
+		err            error
+	)
+
+	if !v1beta1helper.IsShootSelfHosted(shoot.Spec.Provider.Workers) {
+		// TODO(rfranzke): Enable shoot gardenlet to read the gardener.cloud/role=shoot-service-account-issuer secret from
+		//  garden namespace (adapt authorizer) --> requires virtual garden to be at least 1.34 (this promotes the selector
+		//  feature gate to GA, hence, we can enforce the needed label selectors)
+		gardenSecrets, err = gardenerutils.ReadGardenSecrets(
+			ctx,
+			log,
+			gardenClient,
+			gardenerutils.ComputeGardenNamespace(seed.Name),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		internalDomain, err = gardenerutils.ReadGardenInternalDomain(
+			ctx,
+			gardenClient,
+			gardenerutils.ComputeGardenNamespace(seed.Name),
+			true,
+			seed.Spec.DNS.Internal,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		defaultDomains, err = gardenerutils.ReadGardenDefaultDomains(
+			ctx,
+			gardenClient,
+			gardenerutils.ComputeGardenNamespace(seed.Name),
+			seed.Spec.DNS.Defaults,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	gardenObj, err := garden.
+		NewBuilder().
+		WithProject(project).
+		WithInternalDomain(internalDomain).
+		WithDefaultDomains(defaultDomains).
+		Build(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	shootBuilder := shootpkg.
+		NewBuilder().
+		WithProjectName(project.Name).
+		WithCloudProfileObject(cloudProfile).
+		WithShootObject(shoot).
+		WithShootCredentialsFrom(gardenClient).
+		WithExposureClassObject(exposureClass).
+		WithInternalDomain(gardenObj.InternalDomain).
+		WithDefaultDomains(gardenObj.DefaultDomains).
+		WithServiceAccountIssuerHostname(gardenSecrets[v1beta1constants.GardenRoleShootServiceAccountIssuer])
+
+	opBuilder := NewBuilder().
+		WithLogger(log).
+		WithConfig(config).
+		WithGardenerInfo(gardenerInfo).
+		WithGardenClusterIdentity(gardenClusterIdentity).
+		WithSecrets(gardenSecrets).
+		WithInternalDomain(gardenObj.InternalDomain).
+		WithDefaultDomains(gardenObj.DefaultDomains).
+		WithGarden(gardenObj)
+
+	if seed != nil {
+		seedObj, err := seedpkg.NewBuilder().WithSeedObject(seed).Build(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		shootBuilder = shootBuilder.WithSeedObject(seed)
+		opBuilder = opBuilder.WithSeed(seedObj)
+	}
+
+	shootObj, err := shootBuilder.Build(ctx, seedClientSet, gardenClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return opBuilder.WithShoot(shootObj).Build(ctx, gardenClient, seedClientSet, shootClientMap, shoot)
+}

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -263,6 +263,8 @@ func (b *Builder) Build(
 			}
 			operation.Seed = seed
 		}
+	} else {
+		operation.ShootClientSet = seedClientSet
 	}
 
 	garden, err := b.gardenFunc(ctx, internalDomain, defaultDomains)
@@ -277,10 +279,12 @@ func (b *Builder) Build(
 	}
 	operation.Shoot = shoot
 
-	// Get the ManagedSeed object for this shoot, if it exists.
-	operation.ManagedSeed, err = kubernetesutils.GetManagedSeedWithReader(ctx, gardenClient, shoot.GetInfo().Namespace, shoot.GetInfo().Name)
-	if err != nil {
-		return nil, fmt.Errorf("could not get managed seed for shoot %s/%s: %w", shoot.GetInfo().Namespace, shoot.GetInfo().Name, err)
+	if !isSelfHostedShoot {
+		// Get the ManagedSeed object for this shoot, if it exists. A self-hosted shoot is never a managed seed.
+		operation.ManagedSeed, err = kubernetesutils.GetManagedSeedWithReader(ctx, gardenClient, shoot.GetInfo().Namespace, shoot.GetInfo().Name)
+		if err != nil {
+			return nil, fmt.Errorf("could not get managed seed for shoot %s/%s: %w", shoot.GetInfo().Namespace, shoot.GetInfo().Name, err)
+		}
 	}
 
 	gardenerInfo, err := b.gardenerInfoFunc()

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/imagevector"
 	"github.com/gardener/gardener/pkg/api/config/gardenlet/v1alpha1/helper"
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
@@ -304,6 +305,10 @@ func (b *Builder) Build(
 		return nil, err
 	}
 	operation.Logger = logger
+
+	if caBundle := imagevector.ContainersCABundle(); caBundle != nil && caBundle.Inline != nil {
+		operation.RegistryCABundle = caBundle.Inline
+	}
 
 	return operation, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind cleanup

**What this PR does / why we need it**:
Extracts `Reconciler.initializeOperation` from the `gardenlet` `Shoot` controller into a shared `operation.Initialize` function and routes `gardenadm {init,bootstrap,connect}` through it. Removes the parallel `Operation` construction in `pkg/gardenadm/botanist`, so both entry points build `Operation` from a single canonical path. Also drops the synthesized `Seed` from `gardenadm.Resources`: a self-hosted shoot has no seed, and the previous stub carried no real data (its `UID` was never assigned).

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
- `gardenlet.Reconciler.initializeOperation` collapses to a thin wrapper that calls `operation.Initialize` and then performs the UID-patching side effect.
- Two `gardenlet` sites needed follow-ups now that `b.Seed` can be nil on self-hosted flows: `DefaultKubeAPIServer`'s VPN block is now gated on `!b.Shoot.IsSelfHosted()`, and `DefaultCoreBackupEntry`'s bucket-name override moves from `!b.Shoot.RunsControlPlane()` to `!b.Shoot.IsSelfHosted()`. The old `!RunsControlPlane` branch in `backupentry.go` was dead for `gardenadm bootstrap` (Seed UID never set) and unreachable for `gardenadm init`.

**Release note**:
```other operator
NONE
```