### PR TITLE
Report interrupted e2e specs as skipped in JUnit report

### DIFF
--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -24,13 +24,13 @@ source $(dirname "${0}")/ci-common.sh
 
 ginkgo_flags=
 
-# If running in prow, we want to generate a machine-readable output file under the location specified via $ARTIFACTS.
-# This will add a JUnit view above the build log that shows an overview over successful and failed test cases.
+# If running in prow, we want to generate a machine-readable JUnit report under the location specified via $ARTIFACTS.
+# The report is written by the custom JUnit reporter registered in the test suite, which adds a JUnit view above the
+# build log that shows an overview over successful and failed test cases.
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
   mkdir -p "$ARTIFACTS"
-  ginkgo_flags="--output-dir=$ARTIFACTS --junit-report=junit.xml"
   if [ "${JOB_TYPE:-}" != "periodic" ]; then
-    ginkgo_flags+=" --fail-fast"
+    ginkgo_flags="--fail-fast"
   fi
 fi
 

--- a/test/e2e/gardenadm/e2e_suite_test.go
+++ b/test/e2e/gardenadm/e2e_suite_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/test/e2e"
 	_ "github.com/gardener/gardener/test/e2e/gardenadm/managedinfra"
 	_ "github.com/gardener/gardener/test/e2e/gardenadm/unmanagedinfra"
 )
@@ -25,3 +26,5 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 })
+
+var _ = e2e.CustomJUnitReport()

--- a/test/e2e/gardener/e2e_suite_test.go
+++ b/test/e2e/gardener/e2e_suite_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/test/e2e"
 	_ "github.com/gardener/gardener/test/e2e/gardener/managedseed"
 	_ "github.com/gardener/gardener/test/e2e/gardener/project"
 	_ "github.com/gardener/gardener/test/e2e/gardener/seed"
@@ -33,3 +34,5 @@ func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Test E2E Gardener Suite")
 }
+
+var _ = e2e.CustomJUnitReport()

--- a/test/e2e/ginkgo.go
+++ b/test/e2e/ginkgo.go
@@ -5,7 +5,14 @@
 package e2e
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/reporters"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
 )
 
 // BeforeTestSetup looks like a ginkgo setup node but runs the given function right away, i.e., during ginkgo's tree
@@ -31,4 +38,28 @@ func BeforeTestSetup(f func()) {
 	// Recover from panics that might happen by calling Fail() during the test setup.
 	defer GinkgoRecover()
 	f()
+}
+
+// CustomJUnitReport registers a ReportAfterSuite node that writes a JUnit XML report to $ARTIFACTS/junit.xml.
+// Specs that were interrupted by another parallel Ginkgo process due to --fail-fast are reported as skipped instead of
+// errored, so that only the actual failure (in the other process) is visible in the report.
+// Call this function via a top-level var in your suite file:
+//
+//	var _ = e2e.CustomJUnitReport()
+func CustomJUnitReport() bool {
+	return ReportAfterSuite("Custom JUnit report", func(report Report) {
+		artifactsDir := os.Getenv("ARTIFACTS")
+		if artifactsDir == "" {
+			return
+		}
+
+		for i, sr := range report.SpecReports {
+			if sr.State == types.SpecStateInterrupted &&
+				strings.Contains(sr.Failure.Message, "Interrupted by Other Ginkgo Process") {
+				report.SpecReports[i].State = types.SpecStateSkipped
+			}
+		}
+
+		Expect(reporters.GenerateJUnitReport(report, filepath.Join(artifactsDir, "junit.xml"))).To(Succeed())
+	})
 }

--- a/test/e2e/operator/e2e_suite_test.go
+++ b/test/e2e/operator/e2e_suite_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/gardener/gardener/test/e2e"
 	_ "github.com/gardener/gardener/test/e2e/operator/garden"
 )
 
@@ -17,3 +18,5 @@ func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Test E2E Operator Suite")
 }
+
+var _ = e2e.CustomJUnitReport()


### PR DESCRIPTION
/area testing
/kind enhancement

**What this PR does / why we need it**:

When running e2e tests with `--fail-fast` in PR jobs, a failure in one parallel Ginkgo process interrupts all others with `"Interrupted by Other Ginkgo Process"`. The built-in Ginkgo JUnit reporter emits these as `<error>` entries, cluttering the report with false failures and obscuring the actual root cause.

This PR adds a `CustomJUnitReport` function in `test/e2e/ginkgo.go` that registers a `ReportAfterSuite` node. It rewrites specs matching `SpecStateInterrupted` + `"Interrupted by Other Ginkgo Process"` to `SpecStateSkipped` before generating the JUnit XML, so they appear as `<skipped>` instead of `<error>`. The original interrupt message is preserved in the `<skipped message="...">` attribute.

The `--junit-report` Ginkgo CLI flag is removed from `hack/test-e2e-local.sh` since the JUnit file is now produced exclusively by the `ReportAfterSuite` hook, avoiding duplicate reports.

The hook is registered only in the gardener e2e suite (`test/e2e/gardener`), which is the only suite running with parallel execution in PR jobs. The `CustomJUnitReport` function is placed in `test/e2e/ginkgo.go` so it can easily be reused by other suites in the future.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:

**Release note**:
```other developer
NONE
```