### PR TITLE
Restart logrotate on failure

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -40,7 +40,8 @@ Description=Rotate and Compress System Logs
 ExecStart=/usr/sbin/logrotate -s /var/lib/containerd-logrotate.status /etc/systemd/containerd.conf
 Restart=on-failure
 RestartSec=5
-StartLimitBurst=0
+StartLimitBurst=5
+StartLimitIntervalSec=30
 [Install]
 WantedBy=multi-user.target`),
 				FilePaths: []string{"/etc/systemd/containerd.conf"},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -38,6 +38,9 @@ var _ = Describe("Component", func() {
 Description=Rotate and Compress System Logs
 [Service]
 ExecStart=/usr/sbin/logrotate -s /var/lib/containerd-logrotate.status /etc/systemd/containerd.conf
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=0
 [Install]
 WantedBy=multi-user.target`),
 				FilePaths: []string{"/etc/systemd/containerd.conf"},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -53,6 +53,9 @@ func Config(pathConfig, pathLogFiles, prefix string) ([]extensionsv1alpha1.Unit,
 Description=Rotate and Compress System Logs
 [Service]
 ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=0
 [Install]
 WantedBy=multi-user.target`),
 		FilePaths: []string{serviceFile.Path},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -55,7 +55,8 @@ Description=Rotate and Compress System Logs
 ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
 Restart=on-failure
 RestartSec=5
-StartLimitBurst=0
+StartLimitBurst=5
+StartLimitIntervalSec=30
 [Install]
 WantedBy=multi-user.target`),
 		FilePaths: []string{serviceFile.Path},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
@@ -40,7 +40,8 @@ Description=Rotate and Compress System Logs
 ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
 Restart=on-failure
 RestartSec=5
-StartLimitBurst=0
+StartLimitBurst=5
+StartLimitIntervalSec=30
 [Install]
 WantedBy=multi-user.target`),
 					FilePaths: []string{pathConfig},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
@@ -38,6 +38,9 @@ var _ = Describe("Logrotate", func() {
 Description=Rotate and Compress System Logs
 [Service]
 ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=0
 [Install]
 WantedBy=multi-user.target`),
 					FilePaths: []string{pathConfig},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area os
/kind bug

**What this PR does / why we need it**:

Configures the logrotate systemd service to restart automatically on failure, so a transient error doesn't leave the service in a permanently failed state.

**Which issue(s) this PR fixes**:

Fixes #15285

**Special notes for your reviewer**:

/cc @MichaelEischer @timebertt @breuerfelix 
/cc @oliver-goetz 

**Release note**:
```bugfix operator
The logrotate systemd service now restarts automatically on failure, preventing missed log rotations after transient errors.
```