### PR TITLE
[release-v1.146] Update dependency gardener/dashboard to v1.84.5

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -54,7 +54,7 @@ images:
   - name: gardener-dashboard
     sourceRepository: github.com/gardener/dashboard
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard
-    tag: "1.84.3"
+    tag: "1.84.5"
   - name: terminal-controller-manager
     sourceRepository: github.com/gardener/terminal-controller-manager
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/terminal-controller-manager


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area dependency
/kind task

**What this PR does / why we need it**:
Bumps `gardener/dashboard` from `1.84.3` to `1.84.5` on this release branch. See gardener/gardener#15375 for the same bump on master.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other dependency
The following dependencies have been updated:
- `gardener/dashboard` from `1.84.3` to `1.84.5`. [Release Notes](https://redirect.github.com/gardener/dashboard/releases/tag/1.84.5)
```