### PR TITLE
Downgrade `victoria-logs` down to `v1.50.0`

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -193,7 +193,7 @@ images:
   - name: victoria-logs
     sourceRepository: github.com/VictoriaMetrics/VictoriaLogs
     repository: europe-docker.pkg.dev/gardener-project/releases/3rd/victoriametrics/victoria-logs
-    tag: "v1.52.0"
+    tag: "v1.50.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind bug
Due to a bug in `VictoriaLogs` 
**What this PR does / why we need it**:
Due to a [bug](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1628) in VL `v1.52.0`, it is suggested to revert back to `v1.50.0` for the time being. NOTE: Switching to `v1.50.0` and not `v1.51.0` since that version has been mirrored to the gardener artifact registry.

Original PR that bumped to 1.52: https://github.com/gardener/gardener/pull/15359
**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following dependencies have been updated:
- `europe-docker.pkg.dev/gardener-project/releases/3rd/victoriametrics/victoria-logs` from `v1.37.2` to `v1.50.0`. 
```
