### PR TITLE
fix(otel-collector): remove duplicate `host.name` log attribute to prevent VictoriaLogs v1.52.0 panic on stream tag dedup

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -391,6 +391,17 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 							"limit_mib":       3000,
 							"spike_limit_mib": 600,
 						},
+						// VictoriaLogs merges resource attributes and log record attributes into stream tags.
+						// If host.name appears in both, it produces a duplicate stream tag which causes a panic.
+						// Delete it from log record attributes so it only exists at resource level.
+						"attributes/victorialogs": map[string]any{
+							"actions": []any{
+								map[string]any{
+									"key":    "host.name",
+									"action": "delete",
+								},
+							},
+						},
 						"resource/vali": map[string]any{
 							"attributes": []any{
 								map[string]any{
@@ -545,6 +556,8 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 				"otlp",
 			},
 			Processors: []string{
+				"memory_limiter",
+				"attributes/victorialogs",
 				"batch",
 			},
 		}

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -454,6 +454,14 @@ var _ = Describe("OpenTelemetry Collector", func() {
 									},
 								},
 							},
+							"attributes/victorialogs": map[string]any{
+								"actions": []any{
+									map[string]any{
+										"key":    "host.name",
+										"action": "delete",
+									},
+								},
+							},
 						},
 					},
 					Exporters: otelv1beta1.AnyConfig{
@@ -759,7 +767,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			openTelemetryCollector.Spec.Config.Service.Pipelines["logs/victorialogs"] = &otelv1beta1.Pipeline{
 				Exporters:  []string{"otlphttp/victorialogs"},
 				Receivers:  []string{"otlp"},
-				Processors: []string{"batch"},
+				Processors: []string{"memory_limiter", "attributes/victorialogs", "batch"},
 			}
 
 			Expect(customResourcesManagedResource).To(consistOf(


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
After upgrading VictoriaLogs from v1.37.2 to v1.52.0, the VictoriaLogs pod crashes with:
```
panic: FATAL: cannot unmarshal StreamTags: stream tags must be sorted in alphabetical order;
got "host.name" which is less or equal than "host.name"
```

VictoriaLogs `v1.52.0` changed its OTLP ingestion internals (`MustAdd` signature changed from `streamFields []Field` to `streamFieldsLen int`). When a `VL-Stream-Fields` header is set, the new code scans all log fields (resource attributes + log record attributes combined) for stream field names. This exposes a pre-existing duplicate:

- `host.name` is set in resource attributes by the OTel SDK host resource detector on the collector
- `host.name` is also set in log record attributes by the journald receiver from the `_HOSTNAME` field
- 
Previously, MustAdd only looked at the resource attributes slice (explicitly passed as streamFields), so the log-record-level host.name was never considered for stream tags. In v1.52.0 it scans everything, finds host.name twice, stores both in the stream tag binary, and then mustUnmarshalStreamTagsInplace enforces strict alphabetical ordering — panicking on the duplicate.

This PR add an `attributes/victorialogs` processor to the `logs/victorialogs` pipeline that deletes `host.name` from log record attributes before the data reaches VictoriaLogs. he resource-level `host.name` is preserved as a stream tag; the log-record-level copy (from `_HOSTNAME`) is redundant and its removal eliminates the panic.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rrhubenov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
