### PR TITLE
Ensure 14-day retention in logrotate

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Component", func() {
 Description=Rotate and Compress System Logs
 [Service]
 ExecStart=/usr/sbin/logrotate -s /var/lib/containerd-logrotate.status /etc/systemd/containerd.conf
+ExecStartPost=/bin/sh -c 'find /var/log/pods -name "*.log.*" -mtime +14 -delete 2>&1 || [ ! -d /var/log/pods ]'
 Restart=on-failure
 RestartSec=5
 StartLimitBurst=5

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -82,7 +82,6 @@ const logRotateData = `/var/log/pods/*/*/*.log {
     rotate 14
     copytruncate
     missingok
-    notifempty
     compress
     daily
     dateext

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -36,13 +36,13 @@ var _ = Describe("Component", func() {
 				Enable: new(true),
 				Content: new(`[Unit]
 Description=Rotate and Compress System Logs
+StartLimitBurst=5
+StartLimitIntervalSec=30
 [Service]
 ExecStart=/usr/sbin/logrotate -s /var/lib/containerd-logrotate.status /etc/systemd/containerd.conf
 ExecStartPost=/bin/sh -c 'find /var/log/pods -name "*.log.*" -mtime +14 -delete 2>&1 || [ ! -d /var/log/pods ]'
 Restart=on-failure
 RestartSec=5
-StartLimitBurst=5
-StartLimitIntervalSec=30
 [Install]
 WantedBy=multi-user.target`),
 				FilePaths: []string{"/etc/systemd/containerd.conf"},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -34,7 +34,6 @@ func Config(pathConfig, pathLogFiles, prefix string) ([]extensionsv1alpha1.Unit,
     rotate 14
     copytruncate
     missingok
-    notifempty
     compress
     daily
     dateext

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -9,16 +9,15 @@ import (
 )
 
 // Config returns the content for logrotate units and files.
-// Whenever logrotate is ran, this config will:
-//   - keep only 14 old (rotated) logs, and will discard older logs.
-//
-// Prefix carries the target container runtime (such as  containerd, docker).
-// When containerd is used the log rotation based on size is performed by kubelet.
+// Prefix carries the target container runtime (such as containerd, docker).
 //
 // A security requirement mandates that no log entry older than 14 days is present on the host.
-// kubelet only supports size-based log rotation, not time-based retention, so
-// logrotate is used to enforce daily rotation and a 14-day retention window on top of the
-// kubelet's own size-based rotation.
+// kubelet only supports size-based log rotation, not time-based retention, so two mechanisms
+// are combined to enforce the 14-day retention window:
+//   - logrotate handles daily rotation and pruning of active log files (*.log).
+//   - a find command deletes kubelet's size-rotated files (*.log.*) older than 14 days,
+//     since logrotate can only prune files it rotated itself.
+//
 // For the historical context, see https://github.com/gardener/gardener/issues/653.
 //
 // The timer is configured with jitter to avoid all nodes rotating logs at the same time
@@ -52,6 +51,7 @@ func Config(pathConfig, pathLogFiles, prefix string) ([]extensionsv1alpha1.Unit,
 Description=Rotate and Compress System Logs
 [Service]
 ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
+ExecStartPost=/bin/sh -c 'find /var/log/pods -name "*.log.*" -mtime +14 -delete 2>&1 || [ ! -d /var/log/pods ]'
 Restart=on-failure
 RestartSec=5
 StartLimitBurst=5

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -5,6 +5,8 @@
 package logrotate
 
 import (
+	"strings"
+
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
@@ -24,6 +26,10 @@ import (
 // which can cause spikes on the storage backend.
 // For more context, see https://github.com/gardener/gardener/issues/15149.
 func Config(pathConfig, pathLogFiles, prefix string) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File) {
+	// Derive the pod log directory by stripping the glob suffix from pathLogFiles.
+	// e.g. "/var/log/pods/*/*/*.log" -> "/var/log/pods"
+	podLogDir := strings.TrimRight(strings.SplitN(pathLogFiles, "*", 2)[0], "/")
+
 	serviceFile := extensionsv1alpha1.File{
 		Path:        pathConfig,
 		Permissions: new(uint32(0644)),
@@ -53,7 +59,7 @@ StartLimitBurst=5
 StartLimitIntervalSec=30
 [Service]
 ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
-ExecStartPost=/bin/sh -c 'find /var/log/pods -name "*.log.*" -mtime +14 -delete 2>&1 || [ ! -d /var/log/pods ]'
+ExecStartPost=/bin/sh -c 'find ` + podLogDir + ` -name "*.log.*" -mtime +14 -delete 2>&1 || [ ! -d ` + podLogDir + ` ]'
 Restart=on-failure
 RestartSec=5
 [Install]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -49,13 +49,13 @@ func Config(pathConfig, pathLogFiles, prefix string) ([]extensionsv1alpha1.Unit,
 		Enable: new(true),
 		Content: new(`[Unit]
 Description=Rotate and Compress System Logs
+StartLimitBurst=5
+StartLimitIntervalSec=30
 [Service]
 ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
 ExecStartPost=/bin/sh -c 'find /var/log/pods -name "*.log.*" -mtime +14 -delete 2>&1 || [ ! -d /var/log/pods ]'
 Restart=on-failure
 RestartSec=5
-StartLimitBurst=5
-StartLimitIntervalSec=30
 [Install]
 WantedBy=multi-user.target`),
 		FilePaths: []string{serviceFile.Path},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
@@ -71,7 +71,6 @@ WantedBy=multi-user.target`),
     rotate 14
     copytruncate
     missingok
-    notifempty
     compress
     daily
     dateext

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
@@ -29,6 +29,8 @@ var _ = Describe("Logrotate", func() {
 				pathLogFiles.WriteString(containerd.ContainerRuntime)
 				pathLogFiles.WriteString("/*.log")
 
+				podLogDir := "/var/log/" + containerd.ContainerRuntime
+
 				units, files := logrotate.Config(pathConfig, pathLogFiles.String(), prefix)
 
 				serviceUnit := extensionsv1alpha1.Unit{
@@ -40,7 +42,7 @@ StartLimitBurst=5
 StartLimitIntervalSec=30
 [Service]
 ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
-ExecStartPost=/bin/sh -c 'find /var/log/pods -name "*.log.*" -mtime +14 -delete 2>&1 || [ ! -d /var/log/pods ]'
+ExecStartPost=/bin/sh -c 'find ` + podLogDir + ` -name "*.log.*" -mtime +14 -delete 2>&1 || [ ! -d ` + podLogDir + ` ]'
 Restart=on-failure
 RestartSec=5
 [Install]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Logrotate", func() {
 Description=Rotate and Compress System Logs
 [Service]
 ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
+ExecStartPost=/bin/sh -c 'find /var/log/pods -name "*.log.*" -mtime +14 -delete 2>&1 || [ ! -d /var/log/pods ]'
 Restart=on-failure
 RestartSec=5
 StartLimitBurst=5

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
@@ -36,13 +36,13 @@ var _ = Describe("Logrotate", func() {
 					Enable: new(true),
 					Content: new(`[Unit]
 Description=Rotate and Compress System Logs
+StartLimitBurst=5
+StartLimitIntervalSec=30
 [Service]
 ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
 ExecStartPost=/bin/sh -c 'find /var/log/pods -name "*.log.*" -mtime +14 -delete 2>&1 || [ ! -d /var/log/pods ]'
 Restart=on-failure
 RestartSec=5
-StartLimitBurst=5
-StartLimitIntervalSec=30
 [Install]
 WantedBy=multi-user.target`),
 					FilePaths: []string{pathConfig},


### PR DESCRIPTION
**How to categorize this PR?**
/area os
/kind bug

**What this PR does / why we need it**:

Two pre-existing issues with the logrotate setup:

1. `notifempty` caused logrotate to skip rotation entirely when the active log was empty, leaving old `.gz` files around indefinitely since pruning only runs as part of a rotation pass.
2. kubelet's size-based rotation produces files like `0.log.20260706-182012[.gz]` which logrotate cannot prune via `rotate`/`maxage` — it only prunes files it rotated itself.

Fix (1) by removing `notifempty`. Fix (2) by adding a `find` command as `ExecStartPost` in the service unit to delete `*.log.*` files older than 14 days.

Both fixes were verified with local logrotate runs.

**Which issue(s) this PR fixes**:

Follow-up to: https://github.com/gardener/gardener/pull/15161#discussion_r3553879533

**Special notes for your reviewer**:

`StartLimitBurst`/`StartLimitIntervalSec` are placed in `[Unit]` rather than `[Service]` — SUSE's systemd 249 (SLES SP4+) silently ignores these directives in `[Service]`. Verified with `systemd-analyze verify` on openSUSE Leap 15.4/15.6 and Garden Linux 2150.8.0.

The pod log directory in `ExecStartPost` is derived from the `pathLogFiles` argument rather than hardcoded.

/cc @oliver-goetz @ialidzhikov 

**Release note**:
```bugfix operator
The logrotate service now correctly enforces 14-day log retention: `notifempty` has been removed so pruning always runs, and a `find` command cleans up kubelet size-rotated log files (`*.log.*`) that logrotate cannot prune itself.
```