### PR TITLE
[GEP-38] Reduce initial sizes for Seed and Shoot control plane `VictoriaLogs` PVCs

### DIFF
--- a/pkg/apis/config/gardenlet/v1alpha1/types.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/types.go
@@ -525,6 +525,7 @@ type VictoriaLogs struct {
 type GardenVictoriaLogs struct {
 	// Storage is the disk storage capacity of VictoriaLogs.
 	// Defaults to 100Gi.
+	// If pvc-autoscaler is enabled, this value is ignored and the initial size is set to 5Gi.
 	// +optional
 	Storage *resource.Quantity `json:"storage,omitempty" yaml:"storage,omitempty"`
 }

--- a/pkg/component/observability/logging/victorialogs/victorialogs.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs.go
@@ -185,10 +185,10 @@ func (v *victoriaLogs) vlSingle() *victoriametricsv1.VLSingle {
 					},
 				},
 			},
-			// This annotation tells the VictoriaMetrics operator not to attempt PVC resizing itself
+			// This annotation tells the VictoriaMetrics operator not to attempt resizing the PVC itself,
 			// if the CR's storage field is mutated. PVC resizing is instead owned by the dedicated
-			// pvc-autoscaler component. If pvc-autoscaler gets disabled and you want to resize the PVC
-			// via the operator again, you'd have to remove this annotation and modify the storage field.
+			// pvc-autoscaler component. If pvc-autoscaler gets disabled, the PVC will not be resized
+			// to the storage size specified in the VLSingle CR as long as this annotation is still present.
 			StorageMetadata: victoriametricsv1beta1.EmbeddedObjectMetadata{
 				Annotations: map[string]string{
 					"operator.victoriametrics.com/pvc-allow-volume-expansion": "false",
@@ -282,7 +282,7 @@ func (v *victoriaLogs) getPVCA(pvcAutoscaling PVCAutoscalingConfig) *pvcautoscal
 					ScaleUp: &pvcautoscalerv1alpha1.ScalingRules{
 						UtilizationThresholdPercent: new(70),
 						StepPercent:                 new(10),
-						MinStepAbsolute:             new(resource.MustParse("1Gi")),
+						MinStepAbsolute:             new(resource.MustParse("2Gi")),
 					},
 				},
 			},

--- a/pkg/component/observability/logging/victorialogs/victorialogs.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs.go
@@ -185,6 +185,10 @@ func (v *victoriaLogs) vlSingle() *victoriametricsv1.VLSingle {
 					},
 				},
 			},
+			// This annotation tells the VictoriaMetrics operator not to attempt PVC resizing itself
+			// if the CR's storage field is mutated. PVC resizing is instead owned by the dedicated
+			// pvc-autoscaler component. If pvc-autoscaler gets disabled and you want to resize the PVC
+			// via the operator again, you'd have to remove this annotation and modify the storage field.
 			StorageMetadata: victoriametricsv1beta1.EmbeddedObjectMetadata{
 				Annotations: map[string]string{
 					"operator.victoriametrics.com/pvc-allow-volume-expansion": "false",

--- a/pkg/component/observability/logging/victorialogs/victorialogs.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs.go
@@ -185,6 +185,11 @@ func (v *victoriaLogs) vlSingle() *victoriametricsv1.VLSingle {
 					},
 				},
 			},
+			StorageMetadata: victoriametricsv1beta1.EmbeddedObjectMetadata{
+				Annotations: map[string]string{
+					"operator.victoriametrics.com/pvc-allow-volume-expansion": "false",
+				},
+			},
 			ServiceSpec: &victoriametricsv1beta1.AdditionalServiceSpec{
 				EmbeddedObjectMetadata: victoriametricsv1beta1.EmbeddedObjectMetadata{
 					Name: constants.ServiceName,

--- a/pkg/component/observability/logging/victorialogs/victorialogs_test.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs_test.go
@@ -561,7 +561,7 @@ func getPVCA(maxCapacity resource.Quantity) *pvcautoscalerv1alpha1.PersistentVol
 					ScaleUp: &pvcautoscalerv1alpha1.ScalingRules{
 						UtilizationThresholdPercent: new(70),
 						StepPercent:                 new(10),
-						MinStepAbsolute:             new(resource.MustParse("1Gi")),
+						MinStepAbsolute:             new(resource.MustParse("2Gi")),
 					},
 				},
 			},

--- a/pkg/component/observability/logging/victorialogs/victorialogs_test.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs_test.go
@@ -132,6 +132,11 @@ var _ = Describe("VictoriaLogs", func() {
 						},
 					},
 				},
+				StorageMetadata: victoriametricsv1beta1.EmbeddedObjectMetadata{
+					Annotations: map[string]string{
+						"operator.victoriametrics.com/pvc-allow-volume-expansion": "false",
+					},
+				},
 				ServiceSpec: &victoriametricsv1beta1.AdditionalServiceSpec{
 					EmbeddedObjectMetadata: victoriametricsv1beta1.EmbeddedObjectMetadata{
 						Name: "logging-vl",

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -307,7 +307,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.victoriaLogs, err = r.newVictoriaLogs(seed.GetInfo().Spec.Settings)
+	c.victoriaLogs, err = r.newVictoriaLogs(seed)
 	if err != nil {
 		return
 	}
@@ -625,10 +625,15 @@ func (r *Reconciler) newVali(seed *seedpkg.Seed, istioIngressGatewayLabels map[s
 	return deployer, err
 }
 
-func (r *Reconciler) newVictoriaLogs(seedSettings *gardencorev1beta1.SeedSettings) (component.DeployWaiter, error) {
+func (r *Reconciler) newVictoriaLogs(seed *seedpkg.Seed) (component.DeployWaiter, error) {
 	var storage *resource.Quantity
 	if r.Config.Logging != nil && r.Config.Logging.VictoriaLogs != nil && r.Config.Logging.VictoriaLogs.Garden != nil {
 		storage = r.Config.Logging.VictoriaLogs.Garden.Storage
+	}
+
+	pvcAutoscalerEnabled := v1beta1helper.SeedSettingPersistentVolumeClaimAutoscalerEnabled(seed.GetInfo().Spec.Settings)
+	if pvcAutoscalerEnabled {
+		storage = new(resource.MustParse(seed.GetValidVolumeSize("5Gi")))
 	}
 
 	deployer, err := sharedcomponent.NewVictoriaLogs(
@@ -640,7 +645,7 @@ func (r *Reconciler) newVictoriaLogs(seedSettings *gardencorev1beta1.SeedSetting
 		storage,
 		false,
 		victorialogs.PVCAutoscalingConfig{
-			Enabled:     v1beta1helper.SeedSettingPersistentVolumeClaimAutoscalerEnabled(seedSettings),
+			Enabled:     pvcAutoscalerEnabled,
 			MaxCapacity: resource.MustParse("200Gi"),
 		},
 	)

--- a/pkg/gardenlet/operation/botanist/logging.go
+++ b/pkg/gardenlet/operation/botanist/logging.go
@@ -240,16 +240,23 @@ func (b *Botanist) DefaultOtelCollector() (collector.Interface, error) {
 
 // DefaultVictoriaLogs returns a deployer for VictoriaLogs.
 func (b *Botanist) DefaultVictoriaLogs() (component.DeployWaiter, error) {
+	var storage *resource.Quantity
+
+	pvcAutoscalerEnabled := v1beta1helper.SeedSettingPersistentVolumeClaimAutoscalerEnabled(b.Seed.GetInfo().Spec.Settings)
+	if pvcAutoscalerEnabled {
+		storage = new(resource.MustParse(b.GetValidVolumeSize("5Gi")))
+	}
+
 	deployer, err := shared.NewVictoriaLogs(
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		component.ClusterTypeShoot,
 		b.Shoot.GetReplicas(1),
 		v1beta1constants.PriorityClassNameShootControlPlane100,
-		nil,
+		storage,
 		false,
 		victorialogs.PVCAutoscalingConfig{
-			Enabled:     v1beta1helper.SeedSettingPersistentVolumeClaimAutoscalerEnabled(b.Seed.GetInfo().Spec.Settings),
+			Enabled:     pvcAutoscalerEnabled,
 			MaxCapacity: resource.MustParse("40Gi"),
 		},
 	)

--- a/pkg/gardenlet/operation/botanist/logging_test.go
+++ b/pkg/gardenlet/operation/botanist/logging_test.go
@@ -8,11 +8,14 @@ import (
 	"context"
 	"fmt"
 
+	victoriametricsv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,6 +30,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	mockcomponent "github.com/gardener/gardener/pkg/component/mock"
 	mockvali "github.com/gardener/gardener/pkg/component/observability/logging/vali/mock"
+	victorialogsconstants "github.com/gardener/gardener/pkg/component/observability/logging/victorialogs/constants"
 	mockcollector "github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector/mock"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
@@ -34,6 +38,7 @@ import (
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -376,4 +381,48 @@ var _ = Describe("Logging", func() {
 			})
 		})
 	})
+
+	DescribeTable("#DefaultVictoriaLogs PVC storage",
+		func(pvcAutoscalerEnabled bool, minimumVolumeSize *resource.Quantity, expectedStorage resource.Quantity) {
+			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.VictoriaLogsBackend, true))
+			gardenletfeatures.RegisterFeatureGates()
+
+			var volume *gardencorev1beta1.SeedVolume
+			if minimumVolumeSize != nil {
+				volume = &gardencorev1beta1.SeedVolume{MinimumSize: minimumVolumeSize}
+			}
+
+			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{
+				Spec: gardencorev1beta1.SeedSpec{
+					Volume: volume,
+					Settings: &gardencorev1beta1.SeedSettings{
+						PersistentVolumeClaimAutoscaler: &gardencorev1beta1.SeedSettingPersistentVolumeClaimAutoscaler{
+							Enabled: pvcAutoscalerEnabled,
+						},
+					},
+				},
+			})
+
+			deployer, err := botanist.DefaultVictoriaLogs()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployer.Deploy(ctx)).To(Succeed())
+
+			objects, err := managedresources.GetObjects(ctx, fakeClient, controlPlaneNamespace, victorialogsconstants.ManagedResourceNameRuntime)
+			Expect(err).NotTo(HaveOccurred())
+
+			var vlSingle *victoriametricsv1.VLSingle
+			for _, obj := range objects {
+				if vl, ok := obj.(*victoriametricsv1.VLSingle); ok {
+					vlSingle = vl
+					break
+				}
+			}
+			Expect(vlSingle).NotTo(BeNil(), "expected a VLSingle resource in the VictoriaLogs managed resource")
+			Expect(vlSingle.Spec.Storage.Resources.Requests[corev1.ResourceStorage]).To(Equal(expectedStorage))
+		},
+		Entry("small volume when the PVC autoscaler is enabled", true, nil, resource.MustParse("5Gi")),
+		Entry("default volume when the PVC autoscaler is disabled", false, nil, resource.MustParse("30Gi")),
+		Entry("clamped to the seed minimum volume size when the PVC autoscaler is enabled", true, new(resource.MustParse("20Gi")), resource.MustParse("20Gi")),
+		Entry("initial size when it exceeds the seed minimum volume size", true, new(resource.MustParse("2Gi")), resource.MustParse("5Gi")),
+	)
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
When the `PVC autoscaler` is enabled, `VictoriaLogs` no longer provisions its default volume size up front. Instead it starts with a small initial size (`5Gi`) and lets the autoscaler grow the volume on demand up to the configured `MaxCapacity`. This avoids over-provisioning storage that the autoscaler would otherwise manage, reducing wasted capacity for both the Seed and Shoot control plane instances.

The initial size is clamped to the Seed's minimum volume size (via `GetValidVolumeSize`), so cloud-providers with minimum values still get a valid disk storage request.

**Which issue(s) this PR fixes**:
Part of #14383

**Special notes for your reviewer**:
This PR only reduces sizes for Seed and Shoot control plane `VictoriaLogs` instances, the corresponding `Garden` PR will be open after #15321 is merged. Also, VictoriaLogs does not have the PVC protection that Vali has, so redeploying with a smaller storage value won't be a problem for existing instances and it won't try to mutate them - it only logs when with a level of `info` that there's differences in the sizes.
/cc @plkokanov @Kostov6 @rrhubenov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The initial PVC size for `VictoriaLogs` is now reduced to `5Gi` for Seed and Shoot control plane instances when the PVC autoscaler is enabled.
```
