### PR TITLE
Enhance in-place doc with how to handle failures

### DIFF
--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -182,10 +182,12 @@ If an in-place update fails and nodes are left in a problematic state, user inte
 
 When GNA marks a node update as failed (by setting the label `node.machine.sapcloud.io/update-result=failed`), it automatically retries the update on the next reconcile without any user intervention.
 
-The one exception is an OS update that rolls back to the previous version. In this case GNA returns a terminal error and stops reconciling that node. To unblock it, remove the OS update annotation and re-set the `InPlaceUpdate` node condition with reason `ReadyForUpdate` to trigger a new reconcile:
+The one exception is an OS update that rolls back to the previous version. In this case, GNA returns a terminal error and stops reconciling that node.
+This can be detected by checking the node's `InPlaceUpdate` condition (reason `UpdateFailed`) or the annotation `node.machine.sapcloud.io/update-failed-reason`.
+To unblock it, remove the OS update annotation and the failure label/annotation, then re-set the `InPlaceUpdate` node condition with reason `ReadyForUpdate` to trigger a new reconcile:
 
 ```bash
-kubectl annotate node <node-name> node-agent.gardener.cloud/updating-operating-system-version-
+kubectl annotate node <node-name> node-agent.gardener.cloud/updating-operating-system-version- && \
 kubectl patch node <node-name> --subresource=status --type=json \
   -p='[{"op":"add","path":"/status/conditions/-","value":{"type":"InPlaceUpdate","status":"True","reason":"ReadyForUpdate","message":"Retrying failed in-place update"}}]'
 ```

--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -154,7 +154,7 @@ The `inPlaceUpdates` field in the Shoot status provides details about in-place u
 ⚠️ For worker pools using the `AutoInPlaceUpdate` or `ManualInPlaceUpdate` strategy, the following actions are not allowed (they are allowed with `AutoRollingUpdate`):
 
 * Skipping a minor version when upgrading the worker pool Kubernetes version (`.spec.provider.workers[].kubernetes.version`).
-* Downgrading the machine image version of the worker pool (`.spec.provider.workers[].machine.image.version`).
+* Downgrading the machine image version of the worker pool (`.spec.provider.workers[].machine.image.version`). If a downgrade is required, the only option is to create a new worker pool with the desired lower machine image version.
 
 #### Customize In-Place Update Behaviour of Shoot Worker Nodes
 
@@ -176,7 +176,19 @@ An in-place update of the shoot worker nodes is triggered for rolling update tri
 > There are validations which restricts changing the above mentioned exception fields when an `in-place` update strategy is configured.
 
 When a worker pool is undergoing an in-place update, applying subsequent updates to the same worker pool is restricted.
-If an in-place update fails and nodes are left in a problematic state, user intervention is required to manually fix the nodes. In cases where a subsequent update is necessary to resolve the issue, users can update the worker pool after adding the force update annotation `gardener.cloud/operation=force-in-place-update` on the Shoot. Refer to [Force-update a worker pool with InPlace update strategy](shoot_operations.md#force-update-a-worker-pool-with-inplace-update-strategy) for more details.
+If an in-place update fails and nodes are left in a problematic state, user intervention is required to manually fix the nodes. If the issue can be resolved by retrying the same update, refer to [Retrying a Failed In-Place Update](#retrying-a-failed-in-place-update). In cases where a subsequent update is necessary to resolve the issue, users can update the worker pool after adding the force update annotation `gardener.cloud/operation=force-in-place-update` on the Shoot. Refer to [Force-update a worker pool with InPlace update strategy](shoot_operations.md#force-update-a-worker-pool-with-inplace-update-strategy) for more details.
+
+#### Retrying a Failed In-Place Update
+
+When GNA marks a node update as failed (by setting the label `node.machine.sapcloud.io/update-result=failed`), it automatically retries the update on the next reconcile without any user intervention.
+
+The one exception is an OS update that rolls back to the previous version. In this case GNA returns a terminal error and stops reconciling that node. To unblock it, remove the OS update annotation and re-set the `InPlaceUpdate` node condition with reason `ReadyForUpdate` to trigger a new reconcile:
+
+```bash
+kubectl annotate node <node-name> node-agent.gardener.cloud/updating-operating-system-version-
+kubectl patch node <node-name> --subresource=status --type=json \
+  -p='[{"op":"add","path":"/status/conditions/-","value":{"type":"InPlaceUpdate","status":"True","reason":"ReadyForUpdate","message":"Retrying failed in-place update"}}]'
+```
 
 > ⚠️ Changing the update strategy from `AutoRollingUpdate` to `AutoInPlaceUpdate`/`ManualInPlaceUpdate` (and vice versa) is not allowed. However, switching between `AutoInPlaceUpdate` and `ManualInPlaceUpdate` is permitted.
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR enhances in-place doc with what to do in case of failure.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shafeeqes @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
