### PR TITLE
Fix `MaintenanceTimeWindow` timezone pattern to accept all valid UTC offsets

### DIFF
--- a/charts/gardener/operator/files/crd-gardens.yaml
+++ b/charts/gardener/operator/files/crd-gardens.yaml
@@ -2027,13 +2027,13 @@ spec:
                             description: |-
                               Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
                               If not present, a random value will be computed.
-                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]\+[0-1][0-4]00
+                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00
                             type: string
                           end:
                             description: |-
                               End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
                               If not present, the value will be computed based on the "Begin" value.
-                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]\+[0-1][0-4]00
+                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00
                             type: string
                         required:
                         - begin

--- a/charts/gardener/operator/files/crd-gardens.yaml
+++ b/charts/gardener/operator/files/crd-gardens.yaml
@@ -2025,15 +2025,15 @@ spec:
                         properties:
                           begin:
                             description: |-
-                              Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+                              Begin is the beginning of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".
                               If not present, a random value will be computed.
-                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00
+                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]([+](0[0-9]|1[0-4])|[-](0[0-9]|1[0-2]))00
                             type: string
                           end:
                             description: |-
-                              End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+                              End is the end of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".
                               If not present, the value will be computed based on the "Begin" value.
-                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00
+                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]([+](0[0-9]|1[0-4])|[-](0[0-9]|1[0-2]))00
                             type: string
                         required:
                         - begin

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -8169,7 +8169,7 @@ string
 </em>
 </td>
 <td>
-<p>Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".<br />If not present, a random value will be computed.</p>
+<p>Begin is the beginning of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".<br />If not present, a random value will be computed.</p>
 </td>
 </tr>
 <tr>
@@ -8180,7 +8180,7 @@ string
 </em>
 </td>
 <td>
-<p>End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".<br />If not present, the value will be computed based on the "Begin" value.</p>
+<p>End is the end of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".<br />If not present, the value will be computed based on the "Begin" value.</p>
 </td>
 </tr>
 

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -2027,13 +2027,13 @@ spec:
                             description: |-
                               Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
                               If not present, a random value will be computed.
-                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]\+[0-1][0-4]00
+                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00
                             type: string
                           end:
                             description: |-
                               End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
                               If not present, the value will be computed based on the "Begin" value.
-                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]\+[0-1][0-4]00
+                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00
                             type: string
                         required:
                         - begin

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -2025,15 +2025,15 @@ spec:
                         properties:
                           begin:
                             description: |-
-                              Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+                              Begin is the beginning of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".
                               If not present, a random value will be computed.
-                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00
+                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]([+](0[0-9]|1[0-4])|[-](0[0-9]|1[0-2]))00
                             type: string
                           end:
                             description: |-
-                              End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+                              End is the end of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".
                               If not present, the value will be computed based on the "Begin" value.
-                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00
+                            pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]([+](0[0-9]|1[0-4])|[-](0[0-9]|1[0-2]))00
                             type: string
                         required:
                         - begin

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -1277,10 +1277,10 @@ type MaintenanceRotationConfig struct {
 
 // MaintenanceTimeWindow contains information about the time window for maintenance operations.
 type MaintenanceTimeWindow struct {
-	// Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+	// Begin is the beginning of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".
 	// If not present, a random value will be computed.
 	Begin string
-	// End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+	// End is the end of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".
 	// If not present, the value will be computed based on the "Begin" value.
 	End string
 }

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2280,13 +2280,13 @@ message MaintenanceTimeWindow {
   // Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
   // If not present, a random value will be computed.
   // +kubebuilder:validation:Required
-  // +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]\+[0-1][0-4]00`
+  // +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00`
   optional string begin = 1;
 
   // End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
   // If not present, the value will be computed based on the "Begin" value.
   // +kubebuilder:validation:Required
-  // +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]\+[0-1][0-4]00`
+  // +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00`
   optional string end = 2;
 }
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2277,16 +2277,16 @@ message MaintenanceRotationConfig {
 
 // MaintenanceTimeWindow contains information about the time window for maintenance operations.
 message MaintenanceTimeWindow {
-  // Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+  // Begin is the beginning of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".
   // If not present, a random value will be computed.
   // +kubebuilder:validation:Required
-  // +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00`
+  // +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]([+](0[0-9]|1[0-4])|[-](0[0-9]|1[0-2]))00`
   optional string begin = 1;
 
-  // End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+  // End is the end of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".
   // If not present, the value will be computed based on the "Begin" value.
   // +kubebuilder:validation:Required
-  // +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00`
+  // +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]([+](0[0-9]|1[0-4])|[-](0[0-9]|1[0-2]))00`
   optional string end = 2;
 }
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1675,12 +1675,12 @@ type MaintenanceTimeWindow struct {
 	// Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
 	// If not present, a random value will be computed.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00`
+	// +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]([+](0[0-9]|1[0-4])|[-](0[0-9]|1[0-2]))00`
 	Begin string `json:"begin" protobuf:"bytes,1,opt,name=begin"`
 	// End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
 	// If not present, the value will be computed based on the "Begin" value.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00`
+	// +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]([+](0[0-9]|1[0-4])|[-](0[0-9]|1[0-2]))00`
 	End string `json:"end" protobuf:"bytes,2,opt,name=end"`
 }
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1675,12 +1675,12 @@ type MaintenanceTimeWindow struct {
 	// Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
 	// If not present, a random value will be computed.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]\+[0-1][0-4]00`
+	// +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00`
 	Begin string `json:"begin" protobuf:"bytes,1,opt,name=begin"`
 	// End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
 	// If not present, the value will be computed based on the "Begin" value.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]\+[0-1][0-4]00`
+	// +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9][+-](0[0-9]|1[0-4])00`
 	End string `json:"end" protobuf:"bytes,2,opt,name=end"`
 }
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1672,12 +1672,12 @@ type MaintenanceRotationConfig struct {
 
 // MaintenanceTimeWindow contains information about the time window for maintenance operations.
 type MaintenanceTimeWindow struct {
-	// Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+	// Begin is the beginning of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".
 	// If not present, a random value will be computed.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]([+](0[0-9]|1[0-4])|[-](0[0-9]|1[0-2]))00`
 	Begin string `json:"begin" protobuf:"bytes,1,opt,name=begin"`
-	// End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+	// End is the end of the time window in the format HHMMSS±ZONE, e.g. "220000+0100" or "220000-0500".
 	// If not present, the value will be computed based on the "Begin" value.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]([+](0[0-9]|1[0-4])|[-](0[0-9]|1[0-2]))00`

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -6653,7 +6653,7 @@ func schema_pkg_apis_core_v1beta1_MaintenanceTimeWindow(ref common.ReferenceCall
 				Properties: map[string]spec.Schema{
 					"begin": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. \"220000+0100\". If not present, a random value will be computed.",
+							Description: "Begin is the beginning of the time window in the format HHMMSS±ZONE, e.g. \"220000+0100\" or \"220000-0500\". If not present, a random value will be computed.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -6661,7 +6661,7 @@ func schema_pkg_apis_core_v1beta1_MaintenanceTimeWindow(ref common.ReferenceCall
 					},
 					"end": {
 						SchemaProps: spec.SchemaProps{
-							Description: "End is the end of the time window in the format HHMMSS+ZONE, e.g. \"220000+0100\". If not present, the value will be computed based on the \"Begin\" value.",
+							Description: "End is the end of the time window in the format HHMMSS±ZONE, e.g. \"220000+0100\" or \"220000-0500\". If not present, the value will be computed based on the \"Begin\" value.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area usability
/kind bug

**What this PR does / why we need it**:

The `MaintenanceTimeWindow` `Begin`/`End` kubebuilder validation pattern had two issues:

1. `\+` — rejected all negative offsets (e.g. `-0700` for US/Pacific)
2. `[0-1][0-4]` — rejected offsets `+0500`–`+0900` (e.g. `+0800` Beijing, `+0900` Tokyo)

Fixed by replacing the timezone part with `([+](0[0-9]|1[0-4])|[-](0[0-9]|1[0-2]))00`, which correctly models the real UTC offset range of -12:00 to +14:00.

> [!NOTE]
> The pattern is not enforced for `Shoot` resources but **is** enforced in CRD contexts — e.g. the `Garden` operator resource and downstream projects embedding `ShootTemplate` as a CRD.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

fyi @Diaphteiros

**Release note**:
```bugfix operator
Fixed `MaintenanceTimeWindow` validation pattern to correctly allow negative UTC offsets (e.g. `-0700`) and all positive offsets up to `+1400`. The pattern now accurately reflects the valid UTC offset range (-12:00 to +14:00). Affects CRD-based consumers such as the `Garden` operator resource and downstream projects embedding `ShootTemplate`.
```