### PR TITLE
Remove deprecated prometheus environment variables from `victoria_operator`

### DIFF
--- a/pkg/component/observability/logging/victoria/operator/victoria_operator.go
+++ b/pkg/component/observability/logging/victoria/operator/victoria_operator.go
@@ -158,36 +158,12 @@ func (v *victoriaOperator) deployment() *appsv1.Deployment {
 								"--leader-elect",
 								fmt.Sprintf("--health-probe-bind-address=:%d", healthProbePort),
 								fmt.Sprintf("--metrics-bind-address=:%d", metricsPort),
-								"--controller.disableReconcileFor=VLAgent,VLCluster,VLogs,VMAgent,VMAlert,VMAlertmanager,VMAlertmanagerConfig,VMAnomaly,VMAuth,VMCluster,VMNodeScrape,VMPodScrape,VMProbe,VMRule,VMScrapeConfig,VMServiceScrape,VMSingle,VMStaticScrape,VMUser,VTSingle,VTCluster",
+								"--controller.disableReconcileFor=VLAgent,VLCluster,VLogs,VMAgent,VMAlert,VMAlertmanager,VMAlertmanagerConfig,VMAnomaly,VMAuth,VMCluster,VMNodeScrape,VMPodScrape,VMProbe,VMRule,VMScrapeConfig,VMServiceScrape,VMSingle,VMStaticScrape,VMUser,VTSingle,VTCluster,PodMonitor,ServiceMonitor,PrometheusRule,Probe,AlertmanagerConfig,ScrapeConfig",
 							},
 							Env: []corev1.EnvVar{
 								{
 									Name:  "WATCH_NAMESPACE",
 									Value: "",
-								},
-								{
-									Name:  "VM_ENABLEDPROMETHEUSCONVERTER_PODMONITOR",
-									Value: "false",
-								},
-								{
-									Name:  "VM_ENABLEDPROMETHEUSCONVERTER_SERVICESCRAPE",
-									Value: "false",
-								},
-								{
-									Name:  "VM_ENABLEDPROMETHEUSCONVERTER_PROMETHEUSRULE",
-									Value: "false",
-								},
-								{
-									Name:  "VM_ENABLEDPROMETHEUSCONVERTER_PROBE",
-									Value: "false",
-								},
-								{
-									Name:  "VM_ENABLEDPROMETHEUSCONVERTER_ALERTMANAGERCONFIG",
-									Value: "false",
-								},
-								{
-									Name:  "VM_ENABLEDPROMETHEUSCONVERTER_SCRAPECONFIG",
-									Value: "false",
 								},
 								{
 									Name:  "VM_DISABLESELFSERVICESCRAPECREATION",

--- a/pkg/component/observability/logging/victoria/operator/victoria_operator_test.go
+++ b/pkg/component/observability/logging/victoria/operator/victoria_operator_test.go
@@ -158,36 +158,12 @@ var _ = Describe("VictoriaOperator", func() {
 									"--leader-elect",
 									"--health-probe-bind-address=:8081",
 									"--metrics-bind-address=:8080",
-									"--controller.disableReconcileFor=VLAgent,VLCluster,VLogs,VMAgent,VMAlert,VMAlertmanager,VMAlertmanagerConfig,VMAnomaly,VMAuth,VMCluster,VMNodeScrape,VMPodScrape,VMProbe,VMRule,VMScrapeConfig,VMServiceScrape,VMSingle,VMStaticScrape,VMUser,VTSingle,VTCluster",
+									"--controller.disableReconcileFor=VLAgent,VLCluster,VLogs,VMAgent,VMAlert,VMAlertmanager,VMAlertmanagerConfig,VMAnomaly,VMAuth,VMCluster,VMNodeScrape,VMPodScrape,VMProbe,VMRule,VMScrapeConfig,VMServiceScrape,VMSingle,VMStaticScrape,VMUser,VTSingle,VTCluster,PodMonitor,ServiceMonitor,PrometheusRule,Probe,AlertmanagerConfig,ScrapeConfig",
 								},
 								Env: []corev1.EnvVar{
 									{
 										Name:  "WATCH_NAMESPACE",
 										Value: "",
-									},
-									{
-										Name:  "VM_ENABLEDPROMETHEUSCONVERTER_PODMONITOR",
-										Value: "false",
-									},
-									{
-										Name:  "VM_ENABLEDPROMETHEUSCONVERTER_SERVICESCRAPE",
-										Value: "false",
-									},
-									{
-										Name:  "VM_ENABLEDPROMETHEUSCONVERTER_PROMETHEUSRULE",
-										Value: "false",
-									},
-									{
-										Name:  "VM_ENABLEDPROMETHEUSCONVERTER_PROBE",
-										Value: "false",
-									},
-									{
-										Name:  "VM_ENABLEDPROMETHEUSCONVERTER_ALERTMANAGERCONFIG",
-										Value: "false",
-									},
-									{
-										Name:  "VM_ENABLEDPROMETHEUSCONVERTER_SCRAPECONFIG",
-										Value: "false",
 									},
 									{
 										Name:  "VM_DISABLESELFSERVICESCRAPECREATION",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind cleanup

**What this PR does / why we need it**:
In `VictoriMetrics` operator v0.69.0 the use for `VM_ENABLEDPROMETHEUSCONVERTER_*` environment variables was deprecated and replaced with CLI flag which keeps the same behavior - disabling `Prometheus CRD` reconciliation. Since gardener uses v.0.73.1 they should be replaced.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/observability/issues/85

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove deprecated `VM_ENABLEDPROMETHEUSCONVERTER_*` environment variables from the `victoria_operator` and migrate to the `--controller.disableReconcileFor` flag, as required by VictoriaMetrics operator v0.69+.
```
