### PR TITLE
Encrypt traffic between `Istio` and `OpenTelemetry collector` 

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -7,6 +7,7 @@ package collector
 import (
 	"context"
 	"fmt"
+	"path"
 	"strconv"
 	"time"
 
@@ -51,6 +52,9 @@ const (
 	openTelemetryCollectorName = "gardener-opentelemetry-collector"
 
 	kubeRBACProxyName = "rbac-proxy"
+
+	tlsMountPath       = "/tls"
+	tlsCertificateName = "tls-certificate"
 
 	metricsPort                    = 8888
 	timeoutWaitForManagedResources = 2 * time.Minute
@@ -130,6 +134,7 @@ func (o *otelCollector) newKubeRBACProxyShootAccessSecret() *gardenerutils.Acces
 func (o *otelCollector) Deploy(ctx context.Context) error {
 	var (
 		genericTokenKubeconfigSecretName string
+		ingressTLSSecret                 *corev1.Secret
 		loggingAgentShootAccessSecret    = o.newLoggingAgentShootAccessSecret()
 		kubeRBACProxyShootAccessSecret   = o.newKubeRBACProxyShootAccessSecret()
 		shootObjects                     = []client.Object{}
@@ -144,7 +149,8 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 
 			shootObjects = append(shootObjects, o.getKubeRBACProxyClusterRoleBinding(kubeRBACProxyShootAccessSecret.ServiceAccountName))
 		}
-		ingressTLSSecret, err := o.secretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
+		var err error
+		ingressTLSSecret, err = o.secretsManager.Generate(ctx, &secrets.CertificateSecretConfig{ // we want to update the outer secret
 			Name:                        "logging-tls",
 			CommonName:                  o.values.IngressHost,
 			Organization:                []string{"gardener.cloud:monitoring:ingress"},
@@ -157,13 +163,18 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 			return err
 		}
 
+		caBundle, found := o.secretsManager.Get(o.values.SecretNameServerCA)
+		if !found {
+			return fmt.Errorf("secret %q not found", o.values.SecretNameServerCA)
+		}
+
 		genericTokenKubeconfigSecret, found := o.secretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
 		if !found {
 			return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)
 		}
 		genericTokenKubeconfigSecretName = genericTokenKubeconfigSecret.Name
 
-		istioResources, err := o.getIstioResources(ingressTLSSecret)
+		istioResources, err := o.getIstioResources(ingressTLSSecret, caBundle)
 		if err != nil {
 			return fmt.Errorf("failed to get istio resources: %w", err)
 		}
@@ -201,7 +212,7 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		}
 	}
 
-	seedObjects = append(seedObjects, o.openTelemetryCollector(o.namespace, o.values.LokiEndpoint, genericTokenKubeconfigSecretName))
+	seedObjects = append(seedObjects, o.openTelemetryCollector(o.namespace, o.values.LokiEndpoint, genericTokenKubeconfigSecretName, ingressTLSSecret))
 	seedObjects = append(seedObjects, o.serviceMonitor())
 	seedObjects = append(seedObjects, o.serviceAccount())
 	seedObjects = append(seedObjects, o.vpa())
@@ -375,7 +386,7 @@ func (o *otelCollector) serviceMonitor() *monitoringv1.ServiceMonitor {
 	}
 }
 
-func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericTokenKubeconfigSecretName string) *otelv1beta1.OpenTelemetryCollector {
+func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericTokenKubeconfigSecretName string, ingressTLSSecret *corev1.Secret) *otelv1beta1.OpenTelemetryCollector {
 	obj := &otelv1beta1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      collectorconstants.OpenTelemetryCollectorResourceName,
@@ -608,10 +619,12 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 				Name:  kubeRBACProxyName + "-vali",
 				Image: o.values.KubeRBACProxyImage,
 				Args: []string{
-					fmt.Sprintf("--insecure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyValiPort),
+					fmt.Sprintf("--secure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyValiPort),
 					fmt.Sprintf("--upstream=http://logging:%d/", valiconstants.ValiPort),
 					"--kubeconfig=" + gardenerutils.VolumeMountPathGenericKubeconfig + "/kubeconfig",
 					"--logtostderr=true",
+					"--tls-cert-file=" + path.Join(tlsMountPath, secrets.DataKeyCertificate),
+					"--tls-private-key-file=" + path.Join(tlsMountPath, secrets.DataKeyPrivateKey),
 					"--v=6",
 				},
 				Resources: corev1.ResourceRequirements{
@@ -632,10 +645,12 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 				Name:  kubeRBACProxyName + "-otlp",
 				Image: o.values.KubeRBACProxyImage,
 				Args: []string{
-					fmt.Sprintf("--insecure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyOTLPReceiverPort),
+					fmt.Sprintf("--secure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyOTLPReceiverPort),
 					fmt.Sprintf("--upstream=http://127.0.0.1:%d/", collectorconstants.PushPort),
 					"--kubeconfig=" + gardenerutils.VolumeMountPathGenericKubeconfig + "/kubeconfig",
 					"--logtostderr=true",
+					"--tls-cert-file=" + path.Join(tlsMountPath, secrets.DataKeyCertificate),
+					"--tls-private-key-file=" + path.Join(tlsMountPath, secrets.DataKeyPrivateKey),
 					// The OTLP exporter uses gRPC, which operates over HTTP/2. To support HTTP/2 over cleartext (h2c),
 					// we must explicitly enable h2c in kube-rbac-proxy. By default, kube-rbac-proxy enforces HTTP/2 over TLS
 					// as per the HTTP/2 specification. However, since kube-rbac-proxy forwards to Vali over an unencrypted channel,
@@ -660,9 +675,20 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 		}
 
 		metav1.SetMetaDataLabel(&obj.ObjectMeta, gardenerutils.NetworkPolicyLabel(v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port), v1beta1constants.LabelNetworkPolicyAllowed)
-		obj.Spec.Volumes = []corev1.Volume{gardenerutils.GenerateGenericKubeconfigVolume(genericTokenKubeconfigSecretName, "shoot-access-"+kubeRBACProxyName, "kubeconfig")}
-		obj.Spec.AdditionalContainers[0].VolumeMounts = []corev1.VolumeMount{gardenerutils.GenerateGenericKubeconfigVolumeMount("kubeconfig", gardenerutils.VolumeMountPathGenericKubeconfig)}
-		obj.Spec.AdditionalContainers[1].VolumeMounts = []corev1.VolumeMount{gardenerutils.GenerateGenericKubeconfigVolumeMount("kubeconfig", gardenerutils.VolumeMountPathGenericKubeconfig)}
+		obj.Spec.Volumes = []corev1.Volume{
+			gardenerutils.GenerateGenericKubeconfigVolume(genericTokenKubeconfigSecretName, "shoot-access-"+kubeRBACProxyName, "kubeconfig"),
+			{
+				Name: tlsCertificateName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: ingressTLSSecret.Name,
+					},
+				},
+			},
+		}
+		tlsVolumeMount := corev1.VolumeMount{Name: tlsCertificateName, MountPath: tlsMountPath, ReadOnly: true}
+		obj.Spec.AdditionalContainers[0].VolumeMounts = []corev1.VolumeMount{gardenerutils.GenerateGenericKubeconfigVolumeMount("kubeconfig", gardenerutils.VolumeMountPathGenericKubeconfig), tlsVolumeMount}
+		obj.Spec.AdditionalContainers[1].VolumeMounts = []corev1.VolumeMount{gardenerutils.GenerateGenericKubeconfigVolumeMount("kubeconfig", gardenerutils.VolumeMountPathGenericKubeconfig), tlsVolumeMount}
 	}
 
 	// We want these annotations to be passed down to the service that will be created by the OpenTelemetry Operator.
@@ -692,10 +718,10 @@ func (o *otelCollector) newLoggingAgentShootAccessSecret() *gardenerutils.Access
 		WithTargetSecret(collectorconstants.OpenTelemetryCollectorSecretName, metav1.NamespaceSystem)
 }
 
-func (o *otelCollector) getIstioResources(tlsSecret *corev1.Secret) ([]client.Object, error) {
+func (o *otelCollector) getIstioResources(tlsSecret *corev1.Secret, caBundle *corev1.Secret) ([]client.Object, error) {
 	name := "logging"
 
-	// Istio expects the secret in the istio ingress gateway namespace => copy certificate to istio namespace
+	// Istio expects the server cert in the istio ingress gateway namespace to terminate inbound TLS from clients.
 	tlsSecretInIstioNamespace := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s-%s", o.namespace, name, tlsSecret.Name),
@@ -703,6 +729,18 @@ func (o *otelCollector) getIstioResources(tlsSecret *corev1.Secret) ([]client.Ob
 			Labels:    getLabels(),
 		},
 		Data: tlsSecret.Data,
+	}
+
+	// Istio expects the CA bundle in the istio ingress gateway namespace to verify the backend's server cert.
+	caBundleInIstioNamespace := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-%s", o.namespace, name, caBundle.Name),
+			Namespace: o.values.IstioIngressGatewayNamespace,
+			Labels:    getLabels(),
+		},
+		Data: map[string][]byte{
+			"cacert": caBundle.Data[secrets.DataKeyCertificateBundle],
+		},
 	}
 
 	gateway := &istionetworkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: o.namespace}}
@@ -761,14 +799,14 @@ func (o *otelCollector) getIstioResources(tlsSecret *corev1.Secret) ([]client.Ob
 	})
 
 	destinationRule := &istionetworkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: o.namespace}}
-	if err := istio.DestinationRuleWithLocalityPreference(destinationRule, getLabels(), []string{o.values.IstioIngressGatewayNamespace}, destinationHost)(); err != nil {
+	if err := istio.DestinationRuleWithTLSTermination(destinationRule, getLabels(), []string{o.values.IstioIngressGatewayNamespace}, destinationHost, o.values.IngressHost, caBundleInIstioNamespace.Name, istioapinetworkingv1beta1.ClientTLSSettings_SIMPLE)(); err != nil {
 		return nil, fmt.Errorf("failed to create destination rule resource: %w", err)
 	}
 	destinationRule.Spec.TrafficPolicy.ConnectionPool.Http = &istioapinetworkingv1beta1.ConnectionPoolSettings_HTTPSettings{
 		UseClientProtocol: true,
 	}
 
-	return []client.Object{tlsSecretInIstioNamespace, gateway, virtualService, destinationRule}, nil
+	return []client.Object{tlsSecretInIstioNamespace, caBundleInIstioNamespace, gateway, virtualService, destinationRule}, nil
 }
 
 func (o *otelCollector) getLoggingAgentClusterRole() *rbacv1.ClusterRole {

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -613,82 +613,61 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 				Port: collectorconstants.KubeRBACProxyOTLPReceiverPort,
 			},
 		})
-		obj.Spec.AdditionalContainers = []corev1.Container{
-			// TODO(rrhubenov): Remove the rbac-proxy-vali container when the `OpenTelemetryCollector` feature gate is promoted to GA.
-			{
-				Name:  kubeRBACProxyName + "-vali",
-				Image: o.values.KubeRBACProxyImage,
-				Args: []string{
-					fmt.Sprintf("--secure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyValiPort),
-					fmt.Sprintf("--upstream=http://logging:%d/", valiconstants.ValiPort),
-					"--kubeconfig=" + gardenerutils.VolumeMountPathGenericKubeconfig + "/kubeconfig",
-					"--logtostderr=true",
-					"--tls-cert-file=" + path.Join(tlsMountPath, secrets.DataKeyCertificate),
-					"--tls-private-key-file=" + path.Join(tlsMountPath, secrets.DataKeyPrivateKey),
-					"--v=6",
-				},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("5m"),
-						corev1.ResourceMemory: resource.MustParse("30Mi"),
-					},
-				},
-				SecurityContext: &corev1.SecurityContext{
-					AllowPrivilegeEscalation: new(false),
-					RunAsUser:                new(int64(65532)),
-					RunAsGroup:               new(int64(65534)),
-					RunAsNonRoot:             new(true),
-					ReadOnlyRootFilesystem:   new(true),
-				},
-			},
-			{
-				Name:  kubeRBACProxyName + "-otlp",
-				Image: o.values.KubeRBACProxyImage,
-				Args: []string{
-					fmt.Sprintf("--secure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyOTLPReceiverPort),
-					fmt.Sprintf("--upstream=http://127.0.0.1:%d/", collectorconstants.PushPort),
-					"--kubeconfig=" + gardenerutils.VolumeMountPathGenericKubeconfig + "/kubeconfig",
-					"--logtostderr=true",
-					"--tls-cert-file=" + path.Join(tlsMountPath, secrets.DataKeyCertificate),
-					"--tls-private-key-file=" + path.Join(tlsMountPath, secrets.DataKeyPrivateKey),
-					// The OTLP exporter uses gRPC, which operates over HTTP/2. To support HTTP/2 over cleartext (h2c),
-					// we must explicitly enable h2c in kube-rbac-proxy. By default, kube-rbac-proxy enforces HTTP/2 over TLS
-					// as per the HTTP/2 specification. However, since kube-rbac-proxy forwards to the otel-collector over an unencrypted channel,
-					// h2c support must be enforced when connecting to the upstream.
-					"--upstream-force-h2c",
-					"--v=6",
-				},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("5m"),
-						corev1.ResourceMemory: resource.MustParse("30Mi"),
-					},
-				},
-				SecurityContext: &corev1.SecurityContext{
-					AllowPrivilegeEscalation: new(false),
-					RunAsUser:                new(int64(65532)),
-					RunAsGroup:               new(int64(65534)),
-					RunAsNonRoot:             new(true),
-					ReadOnlyRootFilesystem:   new(true),
-				},
+
+		tlsEnabled := ingressTLSSecret != nil
+
+		listenScheme := func(port int32) string {
+			if tlsEnabled {
+				return fmt.Sprintf("--secure-listen-address=[::]:%d", port)
+			}
+			return fmt.Sprintf("--insecure-listen-address=[::]:%d", port)
+		}
+
+		tlsArgs := []string{}
+		if tlsEnabled {
+			tlsArgs = []string{
+				"--tls-cert-file=" + path.Join(tlsMountPath, secrets.DataKeyCertificate),
+				"--tls-private-key-file=" + path.Join(tlsMountPath, secrets.DataKeyPrivateKey),
+			}
+		}
+
+		resources := corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
 			},
 		}
 
+		valiContainer := o.newRBACProxyContainer(kubeRBACProxyName+"-vali", listenScheme(collectorconstants.KubeRBACProxyValiPort), fmt.Sprintf("http://logging:%d/", valiconstants.ValiPort), tlsArgs, resources)
+
+		// The OTLP exporter uses gRPC, which operates over HTTP/2. To support HTTP/2 over cleartext (h2c),
+		// we must explicitly enable h2c in kube-rbac-proxy. By default, kube-rbac-proxy enforces HTTP/2 over TLS
+		// as per the HTTP/2 specification. However, since kube-rbac-proxy forwards to the otel-collector over an unencrypted channel,
+		// h2c support must be enforced when connecting to the upstream.
+		otlpContainer := o.newRBACProxyContainer(kubeRBACProxyName+"-otlp", listenScheme(collectorconstants.KubeRBACProxyOTLPReceiverPort), fmt.Sprintf("http://127.0.0.1:%d/", collectorconstants.PushPort), append(tlsArgs, "--upstream-force-h2c"), resources)
+		obj.Spec.AdditionalContainers = []corev1.Container{valiContainer, otlpContainer}
+
 		metav1.SetMetaDataLabel(&obj.ObjectMeta, gardenerutils.NetworkPolicyLabel(v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port), v1beta1constants.LabelNetworkPolicyAllowed)
-		obj.Spec.Volumes = []corev1.Volume{
-			gardenerutils.GenerateGenericKubeconfigVolume(genericTokenKubeconfigSecretName, "shoot-access-"+kubeRBACProxyName, "kubeconfig"),
-			{
+
+		volumes := []corev1.Volume{gardenerutils.GenerateGenericKubeconfigVolume(genericTokenKubeconfigSecretName, "shoot-access-"+kubeRBACProxyName, "kubeconfig")}
+		mounts := []corev1.VolumeMount{gardenerutils.GenerateGenericKubeconfigVolumeMount("kubeconfig", gardenerutils.VolumeMountPathGenericKubeconfig)}
+
+		if tlsEnabled {
+			volumes = append(volumes, corev1.Volume{
 				Name: tlsCertificateName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						SecretName: ingressTLSSecret.Name,
 					},
 				},
-			},
+			})
+			mounts = append(mounts, corev1.VolumeMount{Name: tlsCertificateName, MountPath: tlsMountPath, ReadOnly: true})
 		}
-		tlsVolumeMount := corev1.VolumeMount{Name: tlsCertificateName, MountPath: tlsMountPath, ReadOnly: true}
-		obj.Spec.AdditionalContainers[0].VolumeMounts = []corev1.VolumeMount{gardenerutils.GenerateGenericKubeconfigVolumeMount("kubeconfig", gardenerutils.VolumeMountPathGenericKubeconfig), tlsVolumeMount}
-		obj.Spec.AdditionalContainers[1].VolumeMounts = []corev1.VolumeMount{gardenerutils.GenerateGenericKubeconfigVolumeMount("kubeconfig", gardenerutils.VolumeMountPathGenericKubeconfig), tlsVolumeMount}
+
+		obj.Spec.Volumes = volumes
+		for i := range obj.Spec.AdditionalContainers {
+			obj.Spec.AdditionalContainers[i].VolumeMounts = mounts
+		}
 	}
 
 	// We want these annotations to be passed down to the service that will be created by the OpenTelemetry Operator.
@@ -709,6 +688,30 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 	}
 
 	return obj
+}
+
+func (o *otelCollector) newRBACProxyContainer(name, listenAddr, upstream string, tlsArgs []string, resources corev1.ResourceRequirements) corev1.Container {
+	args := []string{
+		listenAddr,
+		"--upstream=" + upstream,
+		"--kubeconfig=" + gardenerutils.VolumeMountPathGenericKubeconfig + "/kubeconfig",
+		"--logtostderr=true",
+	}
+	args = append(args, tlsArgs...)
+	args = append(args, "--v=6")
+	return corev1.Container{
+		Name:      name,
+		Image:     o.values.KubeRBACProxyImage,
+		Args:      args,
+		Resources: resources,
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: new(false),
+			RunAsUser:                new(int64(65532)),
+			RunAsGroup:               new(int64(65534)),
+			RunAsNonRoot:             new(true),
+			ReadOnlyRootFilesystem:   new(true),
+		},
+	}
 }
 
 func (o *otelCollector) newLoggingAgentShootAccessSecret() *gardenerutils.AccessSecret {

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -54,7 +54,7 @@ const (
 	kubeRBACProxyName = "rbac-proxy"
 
 	tlsMountPath       = "/tls"
-	tlsCertificateName = "tls-certificate"
+	tlsCertificateName = "tlsCertificateVolumeName"
 
 	metricsPort                    = 8888
 	timeoutWaitForManagedResources = 2 * time.Minute
@@ -150,7 +150,7 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 			shootObjects = append(shootObjects, o.getKubeRBACProxyClusterRoleBinding(kubeRBACProxyShootAccessSecret.ServiceAccountName))
 		}
 		var err error
-		ingressTLSSecret, err = o.secretsManager.Generate(ctx, &secrets.CertificateSecretConfig{ // we want to update the outer secret
+		ingressTLSSecret, err = o.secretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
 			Name:                        "logging-tls",
 			CommonName:                  o.values.IngressHost,
 			Organization:                []string{"gardener.cloud:monitoring:ingress"},
@@ -721,7 +721,7 @@ func (o *otelCollector) newLoggingAgentShootAccessSecret() *gardenerutils.Access
 func (o *otelCollector) getIstioResources(tlsSecret *corev1.Secret, caBundle *corev1.Secret) ([]client.Object, error) {
 	name := "logging"
 
-	// Istio expects the server cert in the istio ingress gateway namespace to terminate inbound TLS from clients.
+	// Istio expects the secret in the istio ingress gateway namespace => copy certificate to istio namespace
 	tlsSecretInIstioNamespace := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s-%s", o.namespace, name, tlsSecret.Name),

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -653,8 +653,8 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 					"--tls-private-key-file=" + path.Join(tlsMountPath, secrets.DataKeyPrivateKey),
 					// The OTLP exporter uses gRPC, which operates over HTTP/2. To support HTTP/2 over cleartext (h2c),
 					// we must explicitly enable h2c in kube-rbac-proxy. By default, kube-rbac-proxy enforces HTTP/2 over TLS
-					// as per the HTTP/2 specification. However, since kube-rbac-proxy forwards to Vali over an unencrypted channel,
-					// h2c support must be enforced.
+					// as per the HTTP/2 specification. However, since kube-rbac-proxy forwards to the otel-collector over an unencrypted channel,
+					// h2c support must be enforced when connecting to the upstream.
 					"--upstream-force-h2c",
 					"--v=6",
 				},

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -614,60 +614,10 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 			},
 		})
 
-		tlsEnabled := ingressTLSSecret != nil
-
-		listenScheme := func(port int32) string {
-			if tlsEnabled {
-				return fmt.Sprintf("--secure-listen-address=[::]:%d", port)
-			}
-			return fmt.Sprintf("--insecure-listen-address=[::]:%d", port)
-		}
-
-		tlsArgs := []string{}
-		if tlsEnabled {
-			tlsArgs = []string{
-				"--tls-cert-file=" + path.Join(tlsMountPath, secrets.DataKeyCertificate),
-				"--tls-private-key-file=" + path.Join(tlsMountPath, secrets.DataKeyPrivateKey),
-			}
-		}
-
-		resources := corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("5m"),
-				corev1.ResourceMemory: resource.MustParse("30Mi"),
-			},
-		}
-
-		// TODO(rrhubenov): Remove the rbac-proxy-vali container when the `OpenTelemetryCollector` feature gate is promoted to GA.
-		valiContainer := o.newRBACProxyContainer(kubeRBACProxyName+"-vali", listenScheme(collectorconstants.KubeRBACProxyValiPort), fmt.Sprintf("http://logging:%d/", valiconstants.ValiPort), tlsArgs, resources)
-
-		// The OTLP exporter uses gRPC, which operates over HTTP/2. To support HTTP/2 over cleartext (h2c),
-		// we must explicitly enable h2c in kube-rbac-proxy. By default, kube-rbac-proxy enforces HTTP/2 over TLS
-		// as per the HTTP/2 specification. However, since kube-rbac-proxy forwards to the otel-collector over an unencrypted channel,
-		// h2c support must be enforced when connecting to the upstream.
-		otlpContainer := o.newRBACProxyContainer(kubeRBACProxyName+"-otlp", listenScheme(collectorconstants.KubeRBACProxyOTLPReceiverPort), fmt.Sprintf("http://127.0.0.1:%d/", collectorconstants.PushPort), append(tlsArgs, "--upstream-force-h2c"), resources)
-		obj.Spec.AdditionalContainers = []corev1.Container{valiContainer, otlpContainer}
-
-		metav1.SetMetaDataLabel(&obj.ObjectMeta, gardenerutils.NetworkPolicyLabel(v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port), v1beta1constants.LabelNetworkPolicyAllowed)
-
-		volumes := []corev1.Volume{gardenerutils.GenerateGenericKubeconfigVolume(genericTokenKubeconfigSecretName, "shoot-access-"+kubeRBACProxyName, "kubeconfig")}
-		mounts := []corev1.VolumeMount{gardenerutils.GenerateGenericKubeconfigVolumeMount("kubeconfig", gardenerutils.VolumeMountPathGenericKubeconfig)}
-
-		if tlsEnabled {
-			volumes = append(volumes, corev1.Volume{
-				Name: tlsCertificateName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: ingressTLSSecret.Name,
-					},
-				},
-			})
-			mounts = append(mounts, corev1.VolumeMount{Name: tlsCertificateName, MountPath: tlsMountPath, ReadOnly: true})
-		}
-
-		obj.Spec.Volumes = volumes
-		for i := range obj.Spec.AdditionalContainers {
-			obj.Spec.AdditionalContainers[i].VolumeMounts = mounts
+		if ingressTLSSecret != nil {
+			o.injectSecureRBACProxy(obj, ingressTLSSecret, genericTokenKubeconfigSecretName)
+		} else {
+			o.injectInsecureRBACProxy(obj, genericTokenKubeconfigSecretName)
 		}
 	}
 
@@ -691,28 +641,129 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 	return obj
 }
 
-func (o *otelCollector) newRBACProxyContainer(name, listenAddr, upstream string, tlsArgs []string, resources corev1.ResourceRequirements) corev1.Container {
-	args := []string{
-		listenAddr,
-		"--upstream=" + upstream,
-		"--kubeconfig=" + gardenerutils.VolumeMountPathGenericKubeconfig + "/kubeconfig",
-		"--logtostderr=true",
-	}
-	args = append(args, tlsArgs...)
-	args = append(args, "--v=6")
-	return corev1.Container{
-		Name:      name,
-		Image:     o.values.KubeRBACProxyImage,
-		Args:      args,
-		Resources: resources,
-		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: new(false),
-			RunAsUser:                new(int64(65532)),
-			RunAsGroup:               new(int64(65534)),
-			RunAsNonRoot:             new(true),
-			ReadOnlyRootFilesystem:   new(true),
+func (o *otelCollector) injectRBACProxyContainers(obj *otelv1beta1.OpenTelemetryCollector, valiRBACProxyArgs []string, OTLPRBACProxyArgs []string) {
+	obj.Spec.AdditionalContainers = []corev1.Container{
+		{
+			// TODO(rrhubenov): Remove the rbac-proxy-vali container when the `OpenTelemetryCollector` feature gate is promoted to GA.
+			Name:  kubeRBACProxyName + "-vali",
+			Image: o.values.KubeRBACProxyImage,
+			Args:  valiRBACProxyArgs,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("5m"),
+					corev1.ResourceMemory: resource.MustParse("30Mi"),
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: new(false),
+				RunAsUser:                new(int64(65532)),
+				RunAsGroup:               new(int64(65534)),
+				RunAsNonRoot:             new(true),
+				ReadOnlyRootFilesystem:   new(true),
+			},
+		},
+		{
+			Name:  kubeRBACProxyName + "-otlp",
+			Image: o.values.KubeRBACProxyImage,
+			Args:  OTLPRBACProxyArgs,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("5m"),
+					corev1.ResourceMemory: resource.MustParse("30Mi"),
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: new(false),
+				RunAsUser:                new(int64(65532)),
+				RunAsGroup:               new(int64(65534)),
+				RunAsNonRoot:             new(true),
+				ReadOnlyRootFilesystem:   new(true),
+			},
 		},
 	}
+
+	metav1.SetMetaDataLabel(&obj.ObjectMeta, gardenerutils.NetworkPolicyLabel(v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port), v1beta1constants.LabelNetworkPolicyAllowed)
+}
+
+func (o *otelCollector) injectInsecureRBACProxy(obj *otelv1beta1.OpenTelemetryCollector, genericTokenKubeconfigSecretName string) {
+	o.injectRBACProxyContainers(obj, o.insecureValiRBACProxyArgs(), o.insecureOTLPRBACProxyArgs())
+
+	kubeconfigVolumeMount := gardenerutils.GenerateGenericKubeconfigVolumeMount("kubeconfig", gardenerutils.VolumeMountPathGenericKubeconfig)
+	obj.Spec.Volumes = []corev1.Volume{
+		gardenerutils.GenerateGenericKubeconfigVolume(genericTokenKubeconfigSecretName, "shoot-access-"+kubeRBACProxyName, "kubeconfig"),
+	}
+	obj.Spec.AdditionalContainers[0].VolumeMounts = []corev1.VolumeMount{kubeconfigVolumeMount}
+	obj.Spec.AdditionalContainers[1].VolumeMounts = []corev1.VolumeMount{kubeconfigVolumeMount}
+}
+
+func (o *otelCollector) injectSecureRBACProxy(obj *otelv1beta1.OpenTelemetryCollector, ingressTLSSecret *corev1.Secret, genericTokenKubeconfigSecretName string) {
+	o.injectRBACProxyContainers(obj, o.secureValiRBACProxyArgs(), o.secureOTLPRBACProxyArgs())
+
+	kubeconfigVolumeMount := gardenerutils.GenerateGenericKubeconfigVolumeMount("kubeconfig", gardenerutils.VolumeMountPathGenericKubeconfig)
+	tlsVolumeMount := corev1.VolumeMount{Name: tlsCertificateName, MountPath: tlsMountPath, ReadOnly: true}
+	obj.Spec.Volumes = []corev1.Volume{
+		gardenerutils.GenerateGenericKubeconfigVolume(genericTokenKubeconfigSecretName, "shoot-access-"+kubeRBACProxyName, "kubeconfig"),
+		{
+			Name: tlsCertificateName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: ingressTLSSecret.Name,
+				},
+			},
+		},
+	}
+	obj.Spec.AdditionalContainers[0].VolumeMounts = []corev1.VolumeMount{kubeconfigVolumeMount, tlsVolumeMount}
+	obj.Spec.AdditionalContainers[1].VolumeMounts = []corev1.VolumeMount{kubeconfigVolumeMount, tlsVolumeMount}
+}
+
+func (o *otelCollector) rbacProxyCommonArgs() []string {
+	return []string{
+		"--kubeconfig=" + gardenerutils.VolumeMountPathGenericKubeconfig + "/kubeconfig",
+		"--logtostderr=true",
+		"--v=6",
+	}
+}
+
+func (o *otelCollector) insecureValiRBACProxyArgs() []string {
+	return append(o.rbacProxyCommonArgs(),
+		fmt.Sprintf("--insecure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyValiPort),
+		fmt.Sprintf("--upstream=http://logging:%d/", valiconstants.ValiPort),
+	)
+}
+
+func (o *otelCollector) insecureOTLPRBACProxyArgs() []string {
+	return append(o.rbacProxyCommonArgs(),
+		fmt.Sprintf("--insecure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyOTLPReceiverPort),
+		fmt.Sprintf("--upstream=http://127.0.0.1:%d/", collectorconstants.PushPort),
+		// The OTLP exporter uses gRPC, which operates over HTTP/2. To support HTTP/2 over cleartext (h2c),
+		// we must explicitly enable h2c in kube-rbac-proxy. By default, kube-rbac-proxy enforces HTTP/2 over TLS
+		// as per the HTTP/2 specification. However, since kube-rbac-proxy forwards to the otel-collector over an unencrypted channel,
+		// h2c support must be enforced when connecting to the upstream.
+		"--upstream-force-h2c",
+	)
+}
+
+func (o *otelCollector) secureValiRBACProxyArgs() []string {
+	return append(o.rbacProxyCommonArgs(),
+		fmt.Sprintf("--secure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyValiPort),
+		fmt.Sprintf("--upstream=http://logging:%d/", valiconstants.ValiPort),
+		"--tls-cert-file="+path.Join(tlsMountPath, secrets.DataKeyCertificate),
+		"--tls-private-key-file="+path.Join(tlsMountPath, secrets.DataKeyPrivateKey),
+	)
+}
+
+func (o *otelCollector) secureOTLPRBACProxyArgs() []string {
+	return append(o.rbacProxyCommonArgs(),
+		fmt.Sprintf("--secure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyOTLPReceiverPort),
+		fmt.Sprintf("--upstream=http://127.0.0.1:%d/", collectorconstants.PushPort),
+		// The OTLP exporter uses gRPC, which operates over HTTP/2. To support HTTP/2 over cleartext (h2c),
+		// we must explicitly enable h2c in kube-rbac-proxy. By default, kube-rbac-proxy enforces HTTP/2 over TLS
+		// as per the HTTP/2 specification. However, since kube-rbac-proxy forwards to the otel-collector over an unencrypted channel,
+		// h2c support must be enforced when connecting to the upstream.
+		"--upstream-force-h2c",
+		"--tls-cert-file="+path.Join(tlsMountPath, secrets.DataKeyCertificate),
+		"--tls-private-key-file="+path.Join(tlsMountPath, secrets.DataKeyPrivateKey),
+	)
 }
 
 func (o *otelCollector) newLoggingAgentShootAccessSecret() *gardenerutils.AccessSecret {

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -53,8 +53,8 @@ const (
 
 	kubeRBACProxyName = "rbac-proxy"
 
-	tlsMountPath       = "/tls"
-	tlsCertificateName = "tlsCertificateVolumeName"
+	tlsMountPath             = "/tls"
+	tlsCertificateVolumeName = "tls-certificate"
 
 	metricsPort                    = 8888
 	timeoutWaitForManagedResources = 2 * time.Minute
@@ -617,6 +617,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 		if ingressTLSSecret != nil {
 			o.injectSecureRBACProxy(obj, ingressTLSSecret, genericTokenKubeconfigSecretName)
 		} else {
+			// no tls => no istio => assume another type of network policies were configured
 			o.injectInsecureRBACProxy(obj, genericTokenKubeconfigSecretName)
 		}
 	}
@@ -700,11 +701,11 @@ func (o *otelCollector) injectSecureRBACProxy(obj *otelv1beta1.OpenTelemetryColl
 	o.injectRBACProxyContainers(obj, o.secureValiRBACProxyArgs(), o.secureOTLPRBACProxyArgs())
 
 	kubeconfigVolumeMount := gardenerutils.GenerateGenericKubeconfigVolumeMount("kubeconfig", gardenerutils.VolumeMountPathGenericKubeconfig)
-	tlsVolumeMount := corev1.VolumeMount{Name: tlsCertificateName, MountPath: tlsMountPath, ReadOnly: true}
+	tlsVolumeMount := corev1.VolumeMount{Name: tlsCertificateVolumeName, MountPath: tlsMountPath, ReadOnly: true}
 	obj.Spec.Volumes = []corev1.Volume{
 		gardenerutils.GenerateGenericKubeconfigVolume(genericTokenKubeconfigSecretName, "shoot-access-"+kubeRBACProxyName, "kubeconfig"),
 		{
-			Name: tlsCertificateName,
+			Name: tlsCertificateVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: ingressTLSSecret.Name,

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -802,9 +802,6 @@ func (o *otelCollector) getIstioResources(tlsSecret *corev1.Secret, caBundle *co
 	if err := istio.DestinationRuleWithTLSTermination(destinationRule, getLabels(), []string{o.values.IstioIngressGatewayNamespace}, destinationHost, o.values.IngressHost, caBundleInIstioNamespace.Name, istioapinetworkingv1beta1.ClientTLSSettings_SIMPLE)(); err != nil {
 		return nil, fmt.Errorf("failed to create destination rule resource: %w", err)
 	}
-	destinationRule.Spec.TrafficPolicy.ConnectionPool.Http = &istioapinetworkingv1beta1.ConnectionPoolSettings_HTTPSettings{
-		UseClientProtocol: true,
-	}
 
 	return []client.Object{tlsSecretInIstioNamespace, caBundleInIstioNamespace, gateway, virtualService, destinationRule}, nil
 }

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -641,7 +641,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 	return obj
 }
 
-func (o *otelCollector) injectRBACProxyContainers(obj *otelv1beta1.OpenTelemetryCollector, valiRBACProxyArgs []string, OTLPRBACProxyArgs []string) {
+func (o *otelCollector) injectRBACProxyContainers(obj *otelv1beta1.OpenTelemetryCollector, valiRBACProxyArgs []string, otlpRBACProxyArgs []string) {
 	obj.Spec.AdditionalContainers = []corev1.Container{
 		{
 			// TODO(rrhubenov): Remove the rbac-proxy-vali container when the `OpenTelemetryCollector` feature gate is promoted to GA.
@@ -665,7 +665,7 @@ func (o *otelCollector) injectRBACProxyContainers(obj *otelv1beta1.OpenTelemetry
 		{
 			Name:  kubeRBACProxyName + "-otlp",
 			Image: o.values.KubeRBACProxyImage,
-			Args:  OTLPRBACProxyArgs,
+			Args:  otlpRBACProxyArgs,
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("5m"),

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -638,6 +638,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 			},
 		}
 
+		// TODO(rrhubenov): Remove the rbac-proxy-vali container when the `OpenTelemetryCollector` feature gate is promoted to GA.
 		valiContainer := o.newRBACProxyContainer(kubeRBACProxyName+"-vali", listenScheme(collectorconstants.KubeRBACProxyValiPort), fmt.Sprintf("http://logging:%d/", valiconstants.ValiPort), tlsArgs, resources)
 
 		// The OTLP exporter uses gRPC, which operates over HTTP/2. To support HTTP/2 over cleartext (h2c),

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -218,7 +218,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				volumeMount,
-				{Name: "tls-certificate", MountPath: "/tls", ReadOnly: true},
+				{Name: "tlsCertificateVolumeName", MountPath: "/tls", ReadOnly: true},
 			},
 		}
 
@@ -250,7 +250,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				volumeMount,
-				{Name: "tls-certificate", MountPath: "/tls", ReadOnly: true},
+				{Name: "tlsCertificateVolumeName", MountPath: "/tls", ReadOnly: true},
 			},
 		}
 
@@ -569,7 +569,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 
 		openTelemetryCollector.Spec.AdditionalContainers = []corev1.Container{kubeRBACProxyValiContainer, kubeRBACProxyOTLPContainer}
 		openTelemetryCollector.Spec.Volumes = []corev1.Volume{volume, {
-			Name: "tls-certificate",
+			Name: "tlsCertificateVolumeName",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: "logging-tls",

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -14,7 +14,6 @@ import (
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -113,6 +112,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 
 		By("Create secrets managed outside of this package for which secretsmanager.Get() will be called")
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "generic-token-kubeconfig", Namespace: namespace}})).To(Succeed())
+		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca", Namespace: namespace}, Data: map[string][]byte{"bundle.crt": []byte("ca-bundle")}})).To(Succeed())
 	})
 
 	JustBeforeEach(func() {
@@ -195,10 +195,12 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Name:  "rbac-proxy-vali",
 			Image: kubeRBACProxyImage,
 			Args: []string{
-				"--insecure-listen-address=[::]:8081",
+				"--secure-listen-address=[::]:8081",
 				"--upstream=http://logging:3100/",
 				"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
 				"--logtostderr=true",
+				"--tls-cert-file=/tls/tls.crt",
+				"--tls-private-key-file=/tls/tls.key",
 				"--v=6",
 			},
 			Resources: corev1.ResourceRequirements{
@@ -216,6 +218,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				volumeMount,
+				{Name: "tls-certificate", MountPath: "/tls", ReadOnly: true},
 			},
 		}
 
@@ -223,10 +226,12 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Name:  "rbac-proxy-otlp",
 			Image: kubeRBACProxyImage,
 			Args: []string{
-				"--insecure-listen-address=[::]:8080",
+				"--secure-listen-address=[::]:8080",
 				"--upstream=http://127.0.0.1:4317/",
 				"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
 				"--logtostderr=true",
+				"--tls-cert-file=/tls/tls.crt",
+				"--tls-private-key-file=/tls/tls.key",
 				"--upstream-force-h2c",
 				"--v=6",
 			},
@@ -245,6 +250,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				volumeMount,
+				{Name: "tls-certificate", MountPath: "/tls", ReadOnly: true},
 			},
 		}
 
@@ -562,7 +568,14 @@ var _ = Describe("OpenTelemetry Collector", func() {
 		}
 
 		openTelemetryCollector.Spec.AdditionalContainers = []corev1.Container{kubeRBACProxyValiContainer, kubeRBACProxyOTLPContainer}
-		openTelemetryCollector.Spec.Volumes = []corev1.Volume{volume}
+		openTelemetryCollector.Spec.Volumes = []corev1.Volume{volume, {
+			Name: "tls-certificate",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "logging-tls",
+				},
+			},
+		}}
 		openTelemetryCollector.Spec.Ports = append(openTelemetryCollector.Spec.Ports, otelv1beta1.PortsSpec{
 			ServicePort: kubeRBACValiServicePort,
 		})
@@ -623,12 +636,12 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				getVirtualService(),
 				getDestinationRule(),
 				getTLSSecret(tlsSecret),
+				getCaBundleSecret(),
 				vpa,
 				serviceMonitor,
 				serviceAccount,
 			))
 
-			// Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBACProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResourceSecret), customResourcesManagedResourceSecret)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "logging-tls", Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 			Expect(customResourcesManagedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
@@ -681,6 +694,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				getVirtualService(),
 				getDestinationRule(),
 				getTLSSecret(tlsSecret),
+				getCaBundleSecret(),
 				vpa,
 				serviceMonitor,
 				serviceAccount,
@@ -728,6 +742,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 		It("should use custom CA secret name for certificate signing", func() {
 			values.SecretNameServerCA = "custom-ca-secret"
 			values.ShootNodeLoggingEnabled = false // Disable node logging for simpler test
+			Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "custom-ca-secret", Namespace: namespace}, Data: map[string][]byte{"bundle.crt": []byte("custom-ca-bundle")}})).To(Succeed())
 
 			component = New(c, namespace, values, fakeSecretManager)
 
@@ -741,6 +756,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 		It("should use seed CA secret when SecretNameServerCA is set to SecretNameCASeed", func() {
 			values.SecretNameServerCA = v1beta1constants.SecretNameCASeed
 			values.ShootNodeLoggingEnabled = false // Disable node logging for simpler test
+			Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.SecretNameCASeed, Namespace: namespace}, Data: map[string][]byte{"bundle.crt": []byte("seed-ca-bundle")}})).To(Succeed())
 
 			component = New(c, namespace, values, fakeSecretManager)
 
@@ -771,6 +787,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				getVirtualService(),
 				getDestinationRule(),
 				getTLSSecret(tlsSecret),
+				getCaBundleSecret(),
 				vpa,
 				serviceMonitor,
 				serviceAccount,
@@ -807,6 +824,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				getVirtualService(),
 				getDestinationRule(),
 				getTLSSecret(tlsSecret),
+				getCaBundleSecret(),
 				vpa,
 				serviceMonitor,
 				serviceAccount,
@@ -1002,11 +1020,8 @@ func getDestinationRule() *istionetworkingv1beta1.DestinationRule {
 			Host:     "opentelemetry-collector-collector.some-namespace.svc.cluster.local",
 			TrafficPolicy: &istioapinetworkingv1beta1.TrafficPolicy{
 				LoadBalancer: &istioapinetworkingv1beta1.LoadBalancerSettings{
-					LocalityLbSetting: &istioapinetworkingv1beta1.LocalityLoadBalancerSetting{
-						FailoverPriority: []string{"topology.kubernetes.io/zone"},
-						Enabled: &wrapperspb.BoolValue{
-							Value: true,
-						},
+					LbPolicy: &istioapinetworkingv1beta1.LoadBalancerSettings_Simple{
+						Simple: istioapinetworkingv1beta1.LoadBalancerSettings_LEAST_REQUEST,
 					},
 				},
 				ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
@@ -1021,8 +1036,11 @@ func getDestinationRule() *istionetworkingv1beta1.DestinationRule {
 						UseClientProtocol: true,
 					},
 				},
-				OutlierDetection: &istioapinetworkingv1beta1.OutlierDetection{},
-				Tls:              &istioapinetworkingv1beta1.ClientTLSSettings{},
+				Tls: &istioapinetworkingv1beta1.ClientTLSSettings{
+					Mode:           istioapinetworkingv1beta1.ClientTLSSettings_SIMPLE,
+					CredentialName: "some-namespace-logging-" + v1beta1constants.SecretNameCACluster,
+					Sni:            ingressHost,
+				},
 			},
 		},
 	}
@@ -1036,6 +1054,19 @@ func getTLSSecret(tlsSecret *corev1.Secret) *corev1.Secret {
 			Labels:    getLabels(),
 		},
 		Data: tlsSecret.Data,
+	}
+}
+
+func getCaBundleSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-namespace-logging-" + v1beta1constants.SecretNameCACluster,
+			Namespace: "istio-ingress",
+			Labels:    getLabels(),
+		},
+		Data: map[string][]byte{
+			"cacert": []byte("ca-bundle"),
+		},
 	}
 }
 

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -51,6 +51,7 @@ const (
 	ingressHost                     = "otel.foo.bar"
 	managedResourceNameTarget       = "logging-target"
 	managedResourceSecretNameTarget = "managedresource-logging-target"
+	kubeRBACProxyImage              = "kube-rbac-proxy:latest"
 )
 
 var _ = Describe("OpenTelemetry Collector", func() {
@@ -60,7 +61,6 @@ var _ = Describe("OpenTelemetry Collector", func() {
 		image                                       = "some-image:some-tag"
 		lokiEndpoint                                = "logging"
 		genericTokenKubeconfigSecretName            = "generic-token-kubeconfig"
-		kubeRBACProxyImage                          = "kube-rbac-proxy:latest"
 		kubeRBACProxyShootAccessSecretName          = "shoot-access-rbac-proxy"
 		opentelemetryCollectorShootAccessSecretName = "shoot-access-opentelemetry-collector"
 		values                                      Values
@@ -191,68 +191,8 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			AutomountServiceAccountToken: new(false),
 		}
 
-		kubeRBACProxyValiContainer = corev1.Container{
-			Name:  "rbac-proxy-vali",
-			Image: kubeRBACProxyImage,
-			Args: []string{
-				"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
-				"--logtostderr=true",
-				"--v=6",
-				"--secure-listen-address=[::]:8081",
-				"--upstream=http://logging:3100/",
-				"--tls-cert-file=/tls/tls.crt",
-				"--tls-private-key-file=/tls/tls.key",
-			},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("5m"),
-					corev1.ResourceMemory: resource.MustParse("30Mi"),
-				},
-			},
-			SecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: new(false),
-				RunAsUser:                new(int64(65532)),
-				RunAsGroup:               new(int64(65534)),
-				RunAsNonRoot:             new(true),
-				ReadOnlyRootFilesystem:   new(true),
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				volumeMount,
-				{Name: "tlsCertificateVolumeName", MountPath: "/tls", ReadOnly: true},
-			},
-		}
-
-		kubeRBACProxyOTLPContainer = corev1.Container{
-			Name:  "rbac-proxy-otlp",
-			Image: kubeRBACProxyImage,
-			Args: []string{
-				"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
-				"--logtostderr=true",
-				"--v=6",
-				"--secure-listen-address=[::]:8080",
-				"--upstream=http://127.0.0.1:4317/",
-				"--upstream-force-h2c",
-				"--tls-cert-file=/tls/tls.crt",
-				"--tls-private-key-file=/tls/tls.key",
-			},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("5m"),
-					corev1.ResourceMemory: resource.MustParse("30Mi"),
-				},
-			},
-			SecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: new(false),
-				RunAsUser:                new(int64(65532)),
-				RunAsGroup:               new(int64(65534)),
-				RunAsNonRoot:             new(true),
-				ReadOnlyRootFilesystem:   new(true),
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				volumeMount,
-				{Name: "tlsCertificateVolumeName", MountPath: "/tls", ReadOnly: true},
-			},
-		}
+		kubeRBACProxyValiContainer = getSecureValiKubeRBACContainer(volumeMount)
+		kubeRBACProxyOTLPContainer = getSecureOtlpKubeRBACContainer(volumeMount)
 
 		allowedMetrics := []string{
 			"otelcol_exporter_enqueue_failed_log_records",
@@ -569,7 +509,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 
 		openTelemetryCollector.Spec.AdditionalContainers = []corev1.Container{kubeRBACProxyValiContainer, kubeRBACProxyOTLPContainer}
 		openTelemetryCollector.Spec.Volumes = []corev1.Volume{volume, {
-			Name: "tlsCertificateVolumeName",
+			Name: "tls-certificate",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: "logging-tls",
@@ -828,6 +768,67 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				vpa,
 				serviceMonitor,
 				serviceAccount,
+			))
+		})
+
+		It("should create kubeRBACProxy with insecure listen and no tls volumes when TLS secret is not installed", func() {
+			values.ClusterType = "seed"
+			values.ShootNodeLoggingEnabled = false
+			component = New(c, namespace, values, fakeSecretManager)
+
+			Expect(component.Deploy(ctx)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
+
+			// Extract the OpenTelemetryCollector from the managed resource and verify insecure proxy args and no TLS volume
+			seedVolumeMount := corev1.VolumeMount{
+				Name:      "kubeconfig",
+				MountPath: "/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig",
+				ReadOnly:  true,
+			}
+
+			seedCollector := openTelemetryCollector.DeepCopy()
+			seedCollector.Spec.AdditionalContainers = []corev1.Container{getInsecureValiKubeRBACContainer(seedVolumeMount), getInsecureOtlpKubeRBACContainer(seedVolumeMount)}
+			// Only the kubeconfig volume — no TLS volume
+			seedCollector.Spec.Volumes = []corev1.Volume{{
+				Name: "kubeconfig",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						DefaultMode: new(int32(420)),
+						Sources: []corev1.VolumeProjection{
+							{
+								Secret: &corev1.SecretProjection{
+									LocalObjectReference: corev1.LocalObjectReference{Name: ""},
+									Items:                []corev1.KeyToPath{{Key: secrets.DataKeyKubeconfig, Path: secrets.DataKeyKubeconfig}},
+									Optional:             new(false),
+								},
+							},
+							{
+								Secret: &corev1.SecretProjection{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-rbac-proxy"},
+									Items:                []corev1.KeyToPath{{Key: resourcesv1alpha1.DataKeyToken, Path: resourcesv1alpha1.DataKeyToken}},
+									Optional:             new(false),
+								},
+							},
+						},
+					},
+				},
+			}}
+			seedCollector.Annotations = map[string]string{
+				resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationPrefix +
+					v1beta1constants.LabelNetworkPolicySeedScrapeTargets +
+					resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationSuffix: `[{"protocol":"TCP","port":8888}]`,
+			}
+			metav1.SetMetaDataLabel(&seedCollector.ObjectMeta, "networking.resources.gardener.cloud/to-kube-apiserver-tcp-443", "allowed")
+
+			seedServiceMonitor := serviceMonitor.DeepCopy()
+			seedServiceMonitor.Name = "seed-opentelemetry-collector"
+			seedServiceMonitor.Labels = map[string]string{"prometheus": "seed"}
+
+			Expect(customResourcesManagedResource).To(consistOf(
+				seedCollector,
+				seedServiceMonitor,
+				serviceAccount,
+				vpa,
 			))
 		})
 	})
@@ -1148,5 +1149,129 @@ func getLabels() map[string]string {
 		gardenerutils.NetworkPolicyLabel("logging-vl", 9428): "allowed",
 		v1beta1constants.LabelNetworkPolicyToDNS:             "allowed",
 		v1beta1constants.LabelObservabilityApplication:       "opentelemetry-collector",
+	}
+}
+
+func getInsecureValiKubeRBACContainer(volumeMount corev1.VolumeMount) corev1.Container {
+	return corev1.Container{
+		Name:  "rbac-proxy-vali",
+		Image: kubeRBACProxyImage,
+		Args: []string{
+			"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+			"--logtostderr=true",
+			"--v=6",
+			"--insecure-listen-address=[::]:8081",
+			"--upstream=http://logging:3100/",
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: new(false),
+			RunAsUser:                new(int64(65532)),
+			RunAsGroup:               new(int64(65534)),
+			RunAsNonRoot:             new(true),
+			ReadOnlyRootFilesystem:   new(true),
+		},
+		VolumeMounts: []corev1.VolumeMount{volumeMount},
+	}
+}
+
+func getInsecureOtlpKubeRBACContainer(volumeMount corev1.VolumeMount) corev1.Container {
+	return corev1.Container{
+		Name:  "rbac-proxy-otlp",
+		Image: kubeRBACProxyImage,
+		Args: []string{
+			"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+			"--logtostderr=true",
+			"--v=6",
+			"--insecure-listen-address=[::]:8080",
+			"--upstream=http://127.0.0.1:4317/",
+			"--upstream-force-h2c",
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: new(false),
+			RunAsUser:                new(int64(65532)),
+			RunAsGroup:               new(int64(65534)),
+			RunAsNonRoot:             new(true),
+			ReadOnlyRootFilesystem:   new(true),
+		},
+		VolumeMounts: []corev1.VolumeMount{volumeMount},
+	}
+}
+
+func getSecureValiKubeRBACContainer(volumeMount corev1.VolumeMount) corev1.Container {
+	return corev1.Container{
+		Name:  "rbac-proxy-vali",
+		Image: kubeRBACProxyImage,
+		Args: []string{
+			"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+			"--logtostderr=true",
+			"--v=6",
+			"--secure-listen-address=[::]:8081",
+			"--upstream=http://logging:3100/",
+			"--tls-cert-file=/tls/tls.crt",
+			"--tls-private-key-file=/tls/tls.key",
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: new(false),
+			RunAsUser:                new(int64(65532)),
+			RunAsGroup:               new(int64(65534)),
+			RunAsNonRoot:             new(true),
+			ReadOnlyRootFilesystem:   new(true),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			volumeMount,
+			{Name: "tls-certificate", MountPath: "/tls", ReadOnly: true},
+		},
+	}
+}
+
+func getSecureOtlpKubeRBACContainer(volumeMount corev1.VolumeMount) corev1.Container {
+	return corev1.Container{
+		Name:  "rbac-proxy-otlp",
+		Image: kubeRBACProxyImage,
+		Args: []string{
+			"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+			"--logtostderr=true",
+			"--v=6",
+			"--secure-listen-address=[::]:8080",
+			"--upstream=http://127.0.0.1:4317/",
+			"--upstream-force-h2c",
+			"--tls-cert-file=/tls/tls.crt",
+			"--tls-private-key-file=/tls/tls.key",
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: new(false),
+			RunAsUser:                new(int64(65532)),
+			RunAsGroup:               new(int64(65534)),
+			RunAsNonRoot:             new(true),
+			ReadOnlyRootFilesystem:   new(true),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			volumeMount,
+			{Name: "tls-certificate", MountPath: "/tls", ReadOnly: true},
+		},
 	}
 }

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -195,13 +195,13 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Name:  "rbac-proxy-vali",
 			Image: kubeRBACProxyImage,
 			Args: []string{
-				"--secure-listen-address=[::]:8081",
-				"--upstream=http://logging:3100/",
 				"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
 				"--logtostderr=true",
+				"--v=6",
+				"--secure-listen-address=[::]:8081",
+				"--upstream=http://logging:3100/",
 				"--tls-cert-file=/tls/tls.crt",
 				"--tls-private-key-file=/tls/tls.key",
-				"--v=6",
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -226,14 +226,14 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Name:  "rbac-proxy-otlp",
 			Image: kubeRBACProxyImage,
 			Args: []string{
-				"--secure-listen-address=[::]:8080",
-				"--upstream=http://127.0.0.1:4317/",
 				"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
 				"--logtostderr=true",
+				"--v=6",
+				"--secure-listen-address=[::]:8080",
+				"--upstream=http://127.0.0.1:4317/",
+				"--upstream-force-h2c",
 				"--tls-cert-file=/tls/tls.crt",
 				"--tls-private-key-file=/tls/tls.key",
-				"--upstream-force-h2c",
-				"--v=6",
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind enhancement
/label crypto

**What this PR does / why we need it**:
Traffic between `Istio` and the `OpenTelemetry collector` was previously unencrypted. This PR enables TLS encryption on that internal path by:
  - Switching both `kube-rbac-proxy sidecars` from `--insecure-listen-address` to `--secure-listen-address`, providing them with the existing logging-tls certificate and key via a mounted volume.
  - Copying the CA bundle into the `Istio ingress gateway` namespace so `Istio` can verify the collector's server certificate.
  - Replacing the `DestinationRule` from locality-preference routing to TLS termination mode, so `Istio` initiates TLS when forwarding traffic to the collector backend. 
This ensures that traffic from the `Istio`  to the `OpenTelemetry collector` is encrypted in transit. The traffic from the `kube-rbac-proxies` to the `OpenTelemetry collector` was not encrypted as they are in the same pod.

cc @oliver-goetz  @ScheererJ because of the discussion which popped up during work on: https://github.com/gardener/gardener/pull/14730

**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardener/observability/issues/81

**Special notes for your reviewer**:
NONE

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Encrypt traffic between the `Istio ingress gateway` and the `OpenTelemetry collector` by enabling TLS on the `kube-rbac-proxy` sidecars (both the `Vali` and `OTLP` receiver endpoints) and configuring Istio's `DestinationRule` to use TLS termination with CA verification.
```
