### PR TITLE
Increase test timeout for k8s and os update tests.

### DIFF
--- a/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_test.go
+++ b/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_test.go
@@ -44,7 +44,7 @@ var (
 	newWorkerPoolKubernetesVersion   = flag.String("k8s-version-worker-pools", "", "the version to use for .spec.provider.workers[].kubernetes.version (only when not equal to .spec.kubernetes.version)")
 )
 
-const UpdateKubernetesVersionTimeout = 45 * time.Minute
+const UpdateKubernetesVersionTimeout = 1 * time.Hour
 
 func init() {
 	framework.RegisterShootFrameworkFlags()

--- a/test/testmachinery/system/shoot_machine_image_update/machine_image_update_test.go
+++ b/test/testmachinery/system/shoot_machine_image_update/machine_image_update_test.go
@@ -40,7 +40,7 @@ import (
 
 var newWorkerPoolMachineImageVersion = flag.String("machine-image-version", "", "the version to use for .spec.provider.workers[].machine.image.version")
 
-const UpdateMachineImageVersionTimeout = 45 * time.Minute
+const UpdateMachineImageVersionTimeout = 1 * time.Hour
 
 func init() {
 	framework.RegisterShootFrameworkFlags()


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
Some cloud providers take extra time in the draining process; this can lead to tests taking little more time and context getting cancelled.

This PR increases the timeout to 1 hr for k8s and os update tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shafeeqes @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
