### PR TITLE
fix: reduce vpn watchdog threshold to 8 (from 10)

### DIFF
--- a/pkg/component/networking/vpn/shoot/shoot.go
+++ b/pkg/component/networking/vpn/shoot/shoot.go
@@ -672,7 +672,7 @@ func (v *vpnShoot) tunnelControllerContainer() *corev1.Container {
 			},
 			{
 				Name:  "WATCHDOG_THRESHOLD",
-				Value: "10",
+				Value: "8",
 			},
 			{
 				Name:  "WATCHDOG_COOLDOWN",

--- a/pkg/component/networking/vpn/shoot/shoot_test.go
+++ b/pkg/component/networking/vpn/shoot/shoot_test.go
@@ -719,7 +719,7 @@ var _ = Describe("VPNShoot", func() {
 							},
 							{
 								Name:  "WATCHDOG_THRESHOLD",
-								Value: "10",
+								Value: "8",
 							},
 							{
 								Name:  "WATCHDOG_COOLDOWN",


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
- Address stakeholder feedback on live clusters that the threshold of 10 was too conservative
- Reducing the threshold to 8 which is in-line with previous measurements of 40% bad measurements in the window (8/20 = 0.4) being a good trade-off between availability and disruption.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
VPN watchdog threshold has been reduced to 8 (from 10) to improve reaction time under bad network conditions.
```
