### PR TITLE
Copy required files in old version of gardener for upgrade test

### DIFF
--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -55,6 +55,14 @@ function copy_kubeconfig_files_to_old_gardener_version_folder() {
   cp "$KUBECONFIG_RUNTIME_CLUSTER"  "dev-setup/${KUBECONFIG_RUNTIME_CLUSTER#*/dev-setup/}"
   cp "$KUBECONFIG_SEED_CLUSTER"     "dev-setup/${KUBECONFIG_SEED_CLUSTER#*/dev-setup/}"
   cp "$KUBECONFIG_SEED_SECRET_PATH" "dev-setup/${KUBECONFIG_SEED_SECRET_PATH#*/dev-setup/}"
+
+  # Also copy the provider-local kubeconfigs that 'dev-setup/kind.sh up' writes. These are used by kustomize when
+  # building the gardenconfig overlays (secret-project-garden and secret-project-local secretGenerators).
+  for credential_path in \
+    "gardenconfig/components/credentials/secret-project-garden/kubeconfig/kubeconfig" \
+    "gardenconfig/components/credentials/secret-project-local/kubeconfig/kubeconfig"; do
+    cp "${KUBECONFIG_RUNTIME_CLUSTER%/kubeconfigs/*}/$credential_path" "dev-setup/$credential_path"
+  done
 }
 
 # copy_virtual_garden_kubeconfig_from_old_gardener_version_folder copies the virtual garden kubeconfig from the 'previous


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind bug

**What this PR does / why we need it**:

https://github.com/gardener/gardener/pull/14844 changed `dev-setup/kind.sh up` to write provider-local credentials to two new locations:
```
dev-setup/gardenconfig/components/credentials/secret-project-garden/kubeconfig/kubeconfig
dev-setup/gardenconfig/components/credentials/secret-project-local/kubeconfig/kubeconfig
```

These files are referenced by kustomize `secretGenerator` entries in the gardenconfig overlays. However, `copy_kubeconfig_files_to_old_gardener_version_folder` in `hack/ci-e2e-kind-upgrade.sh` was not updated to also copy these files into the old release folder before running `make gardener-up` there.

This PR copy both provider-local kubeconfigs from the next-version repo into the old release folder

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
