### PR TITLE
fix(logging): exclude additional logging-vl service from Prometheus ServiceMonitor

### DIFF
--- a/pkg/component/observability/logging/victorialogs/victorialogs.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs.go
@@ -293,12 +293,18 @@ func (v *victoriaLogs) getServiceMonitor() *monitoringv1.ServiceMonitor {
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: monitoringutils.ConfigObjectMeta("victoria-logs", v.namespace, v.getPrometheusLabel()),
 		Spec: monitoringv1.ServiceMonitorSpec{
-			Selector: metav1.LabelSelector{MatchLabels: map[string]string{
-				"app.kubernetes.io/name":      "vlsingle",
-				"app.kubernetes.io/instance":  constants.VLSingleResourceName,
-				"app.kubernetes.io/component": "monitoring",
-				"managed-by":                  "vm-operator",
-			}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name":      "vlsingle",
+					"app.kubernetes.io/instance":  constants.VLSingleResourceName,
+					"app.kubernetes.io/component": "monitoring",
+					"managed-by":                  "vm-operator",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "operator.victoriametrics.com/additional-service",
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				}},
+			},
 			Endpoints: []monitoringv1.Endpoint{{
 				Port: "http",
 				RelabelConfigs: []monitoringv1.RelabelConfig{

--- a/pkg/component/observability/logging/victorialogs/victorialogs_test.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs_test.go
@@ -167,12 +167,18 @@ var _ = Describe("VictoriaLogs", func() {
 		serviceMonitor = &monitoringv1.ServiceMonitor{
 			ObjectMeta: monitoringutils.ConfigObjectMeta("victoria-logs", namespace, shoot.Label),
 			Spec: monitoringv1.ServiceMonitorSpec{
-				Selector: metav1.LabelSelector{MatchLabels: map[string]string{
-					"app.kubernetes.io/name":      "vlsingle",
-					"app.kubernetes.io/instance":  victorialogsconstants.VLSingleResourceName,
-					"app.kubernetes.io/component": "monitoring",
-					"managed-by":                  "vm-operator",
-				}},
+				Selector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/name":      "vlsingle",
+						"app.kubernetes.io/instance":  victorialogsconstants.VLSingleResourceName,
+						"app.kubernetes.io/component": "monitoring",
+						"managed-by":                  "vm-operator",
+					},
+					MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key:      "operator.victoriametrics.com/additional-service",
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+					}},
+				},
 				Endpoints: []monitoringv1.Endpoint{{
 					Port: "http",
 					RelabelConfigs: []monitoringv1.RelabelConfig{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind bug

**What this PR does / why we need it**:

The ServiceMonitor for VictoriaLogs was selecting both services:

- `vlsingle-victoria-logs`: the default service managed by the operator and intended for Prometheus scraping
- `logging-vl`: the additional service, intended as a log ingestion endpoint for the OpenTelemetry Collector

Both services share the same `app.kubernetes.io/*` and `managed-by` labels causing Prometheus (via the ServiceMonitor)to scrape both and produce duplicate metrics.

The VM operator however marks any additional service with the label `operator.victoriametrics.com/additional-service=managed`. This label is present on `logging-vl` but missing on `vlsingle-victoria-logs`

The fix adds a matchExpressions DoesNotExist requirement on that label to the ServiceMonitor selector, ensuring only `vlsingle-victoria-logs` (aka default service) is scraped.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
VictoriaLogs ServiceMonitor excludes any additional services managed by the operator, avoiding duplicate metrics.
```
