### PR TITLE
Add instructions on configuring feature gates in the local Gardener setup

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -6,7 +6,7 @@ This page contains an overview of the various feature gates an administrator can
 
 Feature gates are a set of key=value pairs that describe Gardener features. You can turn these features on or off using the component configuration file for a specific component.
 
-Each Gardener component lets you enable or disable a set of feature gates that are relevant to that component. For example, this is the configuration of the [gardenlet](../../example/20-componentconfig-gardenlet.yaml) component.
+Each Gardener component lets you enable or disable a set of feature gates that are relevant to that component. For example, this is the configuration of the [gardenlet](../../example/20-componentconfig-gardenlet.yaml) component. [Configure feature gates](./getting_started_locally.md#configure-feature-gates-optional) provides instructions on configuring feature gates for different Gardener components using the local Gardener setup as an example.
 
 The following tables are a summary of the feature gates that you can set on different Gardener components.
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -85,6 +85,18 @@ After executing `make kind-up IPFAMILY=ipv6`, execute the following command to s
 ip6tables -t nat -A POSTROUTING -o $(ip route | grep '^default') -s fd00:10::/64 -j MASQUERADE
 ```
 
+## Configure feature gates (optional)
+
+You can optionally configure [feature gates](./feature_gates.md) on different components of your local Gardener deployment. The feature gates can be set by editing respective resource manifests before [setting up Gardener](#setting-up-gardener). They can also be configured dynamically on the running deployment by editing respective resources on the appropriate clusters. The files and the resources to edit for configuring feature gates on respective Gardener components are detailed in the table below.
+
+| Gardener components | Resource manifests | Respective resources for dynamic configuration |
+| --- | --- | --- |
+| `gardener-operator` | [`charts/gardener/operator/values.yaml`](../../charts/gardener/operator/values.yaml) | N/A |
+| `gardenlet` | [`dev-setup/gardenlet/base/gardenlet.yaml`](../../dev-setup/gardenlet/base/gardenlet.yaml) |  `gardenlet` resource on the virtual garden cluster |
+| `gardener-apiserver` and `gardener-controller-manager` | [`dev-setup/garden/base/garden.yaml`](../../dev-setup/garden/base/garden.yaml) | `garden` resource on the runtime cluster |
+
+> To configure `gardener-operator` feature gates in the running local setup, run `make gardener-up` or `make gardener-dev` after updating the `featureGates` configuration in [`charts/gardener/operator/values.yaml`](../../charts/gardener/operator/values.yaml). This will restart the `gardener-operator` with the updated configuration.
+
 ## Setting Up Gardener
 
 ```bash

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -85,13 +85,13 @@ After executing `make kind-up IPFAMILY=ipv6`, execute the following command to s
 ip6tables -t nat -A POSTROUTING -o $(ip route | grep '^default') -s fd00:10::/64 -j MASQUERADE
 ```
 
-## Configure feature gates (optional)
+## Configure Feature Gates (Optional)
 
 You can optionally configure [feature gates](./feature_gates.md) on different components of your local Gardener deployment. The feature gates can be set by editing respective resource manifests before [setting up Gardener](#setting-up-gardener). They can also be configured dynamically on the running deployment by editing respective resources on the appropriate clusters. The files and the resources to edit for configuring feature gates on respective Gardener components are detailed in the table below.
 
 | Gardener components | Resource manifests | Respective resources for dynamic configuration |
 | --- | --- | --- |
-| `gardener-operator` | [`charts/gardener/operator/values.yaml`](../../charts/gardener/operator/values.yaml) | N/A |
+| `gardener-operator` | [`charts/gardener/operator/values.yaml`](../../charts/gardener/operator/values.yaml) (`config.featureGates`) | N/A |
 | `gardenlet` | [`dev-setup/gardenlet/base/gardenlet.yaml`](../../dev-setup/gardenlet/base/gardenlet.yaml) |  `gardenlet` resource on the virtual garden cluster |
 | `gardener-apiserver` and `gardener-controller-manager` | [`dev-setup/garden/base/garden.yaml`](../../dev-setup/garden/base/garden.yaml) | `garden` resource on the runtime cluster |
 


### PR DESCRIPTION
/area documentation
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
The current [Feature Gates documentation](https://gardener.cloud/docs/gardener/deployment/feature_gates/) lacks detailed instructions on how to configure feature gates on different Gardener components using some explicit examples, kind of like a counterpart to the [Configure Feature Gates](https://kubernetes.io/docs/tasks/administer-cluster/configure-feature-gates/) section in Kubernetes' documentation. We could cover this gap by using the local Gardener deployment and its components as a concrete example for configuring the feature gates. 

Extending the local setup docs with instructions on (optionally) configuring feature gates for different components may also be useful for new contributors to know how they can tweak their local setups while working on select features. This will also fill the gap in our knowledge sources that currently do no provide detailed instructions on configuring feature gates specific to local deployment. See the Gardener Docs AI responses below:

Response output 1/2: 
<img width="750" height="600" alt="image" src="https://github.com/user-attachments/assets/77c1af8a-9003-4426-aa0c-67b9602606b5" />

Response output 2/2: 
<img width="750" height="600" alt="image" src="https://github.com/user-attachments/assets/cf56faf0-85ea-4166-b6c1-d59681e5f804" />


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
