### PR TITLE
[GEP-28] Integrate existing task groups into flow for hosted `Shoot`s

### DIFF
--- a/dev-setup/skaffold-cloud-provider-local.yaml
+++ b/dev-setup/skaffold-cloud-provider-local.yaml
@@ -61,8 +61,7 @@ build:
           envTemplate:
             template: '{{.GARDENER_VERSION}}'
         - name: sha
-          gitCommit:
-            variant: AbbrevCommitSha
+          inputDigest: {}
 deploy:
   helm:
     releases:

--- a/dev-setup/skaffold-operator.yaml
+++ b/dev-setup/skaffold-operator.yaml
@@ -917,8 +917,7 @@ build:
           envTemplate:
             template: '{{.GARDENER_VERSION}}'
         - name: sha
-          gitCommit:
-            variant: AbbrevCommitSha
+          inputDigest: {}
 deploy:
   helm:
     releases:
@@ -1399,8 +1398,7 @@ build:
           envTemplate:
             template: '{{.GARDENER_VERSION}}'
         - name: sha
-          gitCommit:
-            variant: AbbrevCommitSha
+          inputDigest: {}
 manifests:
   kustomize:
     paths:

--- a/dev-setup/skaffold-seed.yaml
+++ b/dev-setup/skaffold-seed.yaml
@@ -608,8 +608,7 @@ build:
           envTemplate:
             template: '{{.GARDENER_VERSION}}'
         - name: sha
-          gitCommit:
-            variant: AbbrevCommitSha
+          inputDigest: {}
 profiles:
   - name: dev
     activation:

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -145,6 +145,7 @@ func DeployGardenerResourceManager(
 	namespace string,
 	determineReplicas func(ctx context.Context) (int32, error),
 	getAPIServerAddress func() string,
+	skipClientCertBootstrap bool,
 ) error {
 	var secrets resourcemanager.Secrets
 
@@ -156,7 +157,7 @@ func DeployGardenerResourceManager(
 		gardenerResourceManager.SetReplicas(&replicaCount)
 	}
 
-	mustBootstrap, err := mustBootstrapGardenerResourceManager(ctx, c, clock, gardenerResourceManager, namespace)
+	mustBootstrap, err := mustBootstrapGardenerResourceManager(ctx, c, clock, gardenerResourceManager, namespace, skipClientCertBootstrap)
 	if err != nil {
 		return err
 	}
@@ -193,7 +194,10 @@ func DeployGardenerResourceManager(
 	return gardenerResourceManager.Deploy(ctx)
 }
 
-func mustBootstrapGardenerResourceManager(ctx context.Context, c client.Client, clock clockutils.Clock, gardenerResourceManager resourcemanager.Interface, namespace string) (bool, error) {
+func mustBootstrapGardenerResourceManager(ctx context.Context, c client.Client, clock clockutils.Clock, gardenerResourceManager resourcemanager.Interface, namespace string, skipClientCertBootstrap bool) (bool, error) {
+	if skipClientCertBootstrap {
+		return false, nil
+	}
 	if ptr.Deref(gardenerResourceManager.GetReplicas(), 0) == 0 {
 		return false, nil // GRM should not be scaled up, hence no need to bootstrap.
 	}

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -235,7 +235,7 @@ var _ = Describe("ResourceManager", func() {
 				})
 
 				It("should set the secrets and deploy", func() {
-					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false)).To(Succeed())
 
 					Expect(resourceManager.Replicas).To(PointTo(Equal(int32(2))))
 					Expect(resourceManager.Secrets.BootstrapKubeconfig).To(BeNil())
@@ -244,7 +244,7 @@ var _ = Describe("ResourceManager", func() {
 
 				It("should fail when the deploy function fails", func() {
 					resourceManager.DeployError = fakeErr
-					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(MatchError(fakeErr))
+					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false)).To(MatchError(fakeErr))
 				})
 			})
 		})
@@ -265,13 +265,13 @@ var _ = Describe("ResourceManager", func() {
 
 				Context("deploy with 2 replicas", func() {
 					It("bootstraps because the shoot access secret was not found", func() {
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false)).To(Succeed())
 					})
 
 					It("bootstraps because the shoot access secret was never reconciled", func() {
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false)).To(Succeed())
 					})
 
 					It("bootstraps because the shoot access secret was not renewed", func() {
@@ -279,7 +279,7 @@ var _ = Describe("ResourceManager", func() {
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false)).To(Succeed())
 					})
 
 					It("bootstraps because the shoot token expired while the shoot was hibernated", func() {
@@ -290,13 +290,13 @@ var _ = Describe("ResourceManager", func() {
 						// Simulate time passing while the shoot was hibernated: clock advances past the renew timestamp.
 						fakeClock.Step(2 * time.Hour)
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false)).To(Succeed())
 					})
 
 					It("bootstraps because the managed resource was not found", func() {
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false)).To(Succeed())
 					})
 
 					It("bootstraps because the managed resource indicates that the shoot access token lost access", func() {
@@ -309,7 +309,7 @@ var _ = Describe("ResourceManager", func() {
 						}
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false)).To(Succeed())
 					})
 
 					It("bootstraps because the managed resource indicates that the shoot access token was invalidated", func() {
@@ -322,7 +322,7 @@ var _ = Describe("ResourceManager", func() {
 						}
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false)).To(Succeed())
 					})
 				})
 			})
@@ -342,7 +342,7 @@ var _ = Describe("ResourceManager", func() {
 					k8sSeedClient = fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build()
 					sm = fakesecretsmanager.New(fakeClient, namespace)
 
-					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(MatchError(fakeErr))
+					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false)).To(MatchError(fakeErr))
 				})
 
 				Context("waiting for bootstrapping process", func() {
@@ -357,14 +357,14 @@ var _ = Describe("ResourceManager", func() {
 						shootAccessSecret.Annotations = nil
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(MatchError(ContainSubstring("token not yet generated")))
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false)).To(MatchError(ContainSubstring("token not yet generated")))
 					})
 
 					It("fails because the shoot access token renew timestamp cannot be parsed", func() {
 						shootAccessSecret.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": "foo"}
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress).Error()).To(ContainSubstring("could not parse renew timestamp"))
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false).Error()).To(ContainSubstring("could not parse renew timestamp"))
 					})
 
 					It("fails because the shoot access token was not renewed", func() {
@@ -372,7 +372,7 @@ var _ = Describe("ResourceManager", func() {
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress).Error()).To(ContainSubstring("token not yet renewed"))
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false).Error()).To(ContainSubstring("token not yet renewed"))
 					})
 
 					It("fails because the managed resource is not getting healthy", func() {
@@ -383,7 +383,7 @@ var _ = Describe("ResourceManager", func() {
 						}
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress).Error()).To(ContainSubstring(fmt.Sprintf("managed resource %s/%s is not healthy", namespace, managedResource.Name)))
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress, false).Error()).To(ContainSubstring(fmt.Sprintf("managed resource %s/%s is not healthy", namespace, managedResource.Name)))
 					})
 				})
 			})

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -126,7 +126,7 @@ func run(ctx context.Context, opts *Options) error {
 				SkipIf(hasMigratedExtensionKind[extensionsv1alpha1.InfrastructureResource]),
 		)
 		_ = g.AddGroup(
-			b.ReconcileOperatingSystemConfigTaskGroup().
+			b.ReconcileOperatingSystemConfigTaskGroup(false).
 				WithDependencies(syncPointBootstrapped),
 		)
 		_ = g.AddGroup(

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -121,7 +121,7 @@ func run(ctx context.Context, opts *Options) error {
 			reconcileExtensionControllers,
 		)
 		reconcileInfrastructure = g.AddGroup(
-			b.ReconcileInfrastructureTaskGroup().
+			b.ReconcileInfrastructureTaskGroup(false).
 				WithDependencies(syncPointBootstrapped).
 				SkipIf(hasMigratedExtensionKind[extensionsv1alpha1.InfrastructureResource]),
 		)

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -134,7 +134,7 @@ func run(ctx context.Context, opts *Options) error {
 				WithDependencies(syncPointBootstrapped),
 		)
 		reconcileWorker = g.AddGroup(
-			b.ReconcileWorkerTaskGroup().
+			b.ReconcileWorkerTaskGroup(false).
 				WithDependencies(syncPointBootstrapped, botanist.TaskGroupReconcileOperatingSystemConfig).
 				SkipIf(hasMigratedExtensionKind[extensionsv1alpha1.WorkerResource]),
 		)

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -110,7 +110,7 @@ func run(ctx context.Context, opts *Options) error {
 			Dependencies: flow.NewTaskIDs(deployNamespaces, initializeSecretsManagement),
 		})
 		_ = g.AddGroup(
-			b.ReconcileGardenerResourceManagerTaskGroup(true, false).
+			b.ReconcileGardenerResourceManagerTaskGroup(true, true, false).
 				WithDependencies(deployPriorityClassCritical),
 		)
 		_                             = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -112,7 +112,7 @@ func run(ctx context.Context, opts *Options) error {
 		reconcileExtensionControllers = g.AddGroup(b.ReconcileExtensionControllersTaskGroup(podNetworkAvailable))
 		reconcileNetworkPolicies      = g.AddGroup(b.ReconcileNetworkPoliciesTaskGroup())
 		_                             = g.AddGroup(
-			b.ReconcileInfrastructureTaskGroup().
+			b.ReconcileInfrastructureTaskGroup(false).
 				WithDependencies(gardenadmbotanist.TaskGroupReconcileExtensionControllers),
 		)
 		_                         = g.AddGroup(b.ReconcileShootNamespacesTaskGroup())

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -86,8 +86,9 @@ func run(ctx context.Context, opts *Options) error {
 	}
 
 	var (
-		g           = flow.NewGraph("init")
-		allowBackup = v1beta1helper.GetBackupConfigForShoot(b.Shoot.GetInfo(), nil) != nil
+		g                = flow.NewGraph("init")
+		allowBackup      = v1beta1helper.GetBackupConfigForShoot(b.Shoot.GetInfo(), nil) != nil
+		kubeProxyEnabled = v1beta1helper.KubeProxyEnabled(b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy)
 
 		_                           = g.AddGroup(b.DeployNamespacesTaskGroup())
 		_                           = g.AddGroup(b.DeployCloudProviderSecretTaskGroup())
@@ -117,7 +118,7 @@ func run(ctx context.Context, opts *Options) error {
 		)
 		_                         = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(false))
 		reconcileSystemComponents = g.AddGroup(
-			b.ReconcileSystemComponentsTaskGroup().
+			b.ReconcileSystemComponentsTaskGroup(kubeProxyEnabled, false).
 				WithDependencies(gardenadmbotanist.TaskGroupReconcileNetworkPolicies),
 		)
 

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -134,7 +134,7 @@ func run(ctx context.Context, opts *Options) error {
 				SkipIf(podNetworkAvailable || opts.UseHostNetwork),
 		)
 		_ = g.AddGroup(
-			b.ReconcileControlPlaneTaskGroup().
+			b.ReconcileControlPlaneTaskGroup(false).
 				WithDependencies(gardenadmbotanist.TaskGroupReconcileExtensionControllers),
 		)
 		syncPointBootstrapped = flow.NewTaskIDs(

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -106,7 +106,7 @@ func run(ctx context.Context, opts *Options) error {
 			Dependencies: flow.NewTaskIDs(activateGardenerNodeAgent),
 		})
 		reconcileGardenerResourceManager = g.AddGroup(
-			b.ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, shootIsGarden).
+			b.ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, shootIsGarden, false).
 				WithDependencies(approveGardenerNodeAgentCSR),
 		)
 		_                             = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())
@@ -123,7 +123,7 @@ func run(ctx context.Context, opts *Options) error {
 		)
 
 		reconcileGardenerResourceManagerInPodNetwork = g.AddGroup(
-			b.ReconcileGardenerResourceManagerTaskGroup(true, shootIsGarden).
+			b.ReconcileGardenerResourceManagerTaskGroup(true, shootIsGarden, false).
 				WithID(botanist.TaskGroupReconcileGardenerResourceManager + "InPodNetwork").
 				WithDependencies(reconcileSystemComponents).
 				SkipIf(podNetworkAvailable || opts.UseHostNetwork),

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -115,7 +115,7 @@ func run(ctx context.Context, opts *Options) error {
 			b.ReconcileInfrastructureTaskGroup(false).
 				WithDependencies(gardenadmbotanist.TaskGroupReconcileExtensionControllers),
 		)
-		_                         = g.AddGroup(b.ReconcileShootNamespacesTaskGroup())
+		_                         = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(false))
 		reconcileSystemComponents = g.AddGroup(
 			b.ReconcileSystemComponentsTaskGroup().
 				WithDependencies(gardenadmbotanist.TaskGroupReconcileNetworkPolicies),

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -221,7 +221,7 @@ func run(ctx context.Context, opts *Options) error {
 				WithDependencies(waitUntilWebhookComponentsReady),
 		)
 		reconcileWorker = g.AddGroup(
-			b.ReconcileWorkerTaskGroup().
+			b.ReconcileWorkerTaskGroup(false).
 				WithDependencies(syncPointBootstrapped),
 		)
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -417,17 +417,10 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			SkipIf:       !flowCtx.isRestoringHAControlPlane || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(scaleEtcdAfterRestore),
 		})
-		deployGardenerResourceManager = g.Add(flow.Task{
-			Name:         "Deploying gardener-resource-manager",
-			Fn:           flow.TaskFn(b.DeployGardenerResourceManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
-		})
-		waitUntilGardenerResourceManagerReady = g.Add(flow.Task{
-			Name:         "Waiting until gardener-resource-manager reports readiness",
-			Fn:           b.Shoot.Components.ControlPlane.ResourceManager.Wait,
-			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
-		})
+		waitUntilGardenerResourceManagerReady = g.AddGroup(
+			b.ReconcileGardenerResourceManagerTaskGroup(true, true, flowCtx.skipReadiness).
+				WithDependencies(waitUntilKubeAPIServerIsReady),
+		)
 		_ = g.Add(flow.Task{
 			Name: "Renewing shoot access secrets after creation of new ServiceAccount signing key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
@@ -633,7 +626,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 				return b.DeployClusterIdentity(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.HibernationEnabled,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Populating static manifests from seed to shoot",
@@ -654,7 +647,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn:     flow.TaskFn(b.DeployVPNShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				waitUntilGardenerResourceManagerReady, deployGardenerResourceManager, deployKubeScheduler, deployVPNSeedServer, waitUntilShootNamespacesReady),
+				waitUntilGardenerResourceManagerReady, waitUntilGardenerResourceManagerReady, deployKubeScheduler, deployVPNSeedServer, waitUntilShootNamespacesReady),
 		})
 		waitUntilVPNShootReady = g.Add(flow.Task{
 			Name: "Waiting until vpn-shoot system component is ready",
@@ -671,7 +664,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				deployGardenerResourceManager, waitUntilOperatingSystemConfigReady, waitUntilShootNamespacesReady),
+				waitUntilGardenerResourceManagerReady, waitUntilOperatingSystemConfigReady, waitUntilShootNamespacesReady),
 		})
 		reconcileSystemComponents = g.AddGroup(b.ReconcileSystemComponentsTaskGroup(flowCtx.kubeProxyEnabled, flowCtx.skipReadiness).WithDependencies(
 			waitUntilControlPlaneReady,
@@ -721,7 +714,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Name:         "Deploying managed resources for the gardener-node-agent",
 			Fn:           flow.TaskFn(b.DeployManagedResourceForGardenerNodeAgent).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
 
 		syncPointAllSystemComponentsDeployed = flow.NewTaskIDs(
@@ -965,7 +958,7 @@ func (r *Reconciler) setupReconcileSelfHostedShootFlow(ctx context.Context, b *b
 		_                                = g.AddGroup(b.ReconcileCustomResourceDefinitionsTaskGroup())
 		_                                = g.AddGroup(b.ReconcileClusterResourceTaskGroup())
 		_                                = g.AddGroup(b.InitializeSecretsManagementTaskGroup())
-		reconcileGardenerResourceManager = g.AddGroup(b.ReconcileGardenerResourceManagerTaskGroup(true, shootIsGarden))
+		reconcileGardenerResourceManager = g.AddGroup(b.ReconcileGardenerResourceManagerTaskGroup(true, shootIsGarden, flowCtx.skipReadiness))
 		_                                = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())
 		_                                = g.AddGroup(b.ReconcileInfrastructureTaskGroup(flowCtx.skipReadiness))
 		_                                = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -693,13 +693,13 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			SkipIf:       b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
-		deployShootSystemResources = g.Add(flow.Task{
-			Name:   "Deploying shoot system resources",
-			Fn:     flow.TaskFn(b.DeployShootSystem).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.HibernationEnabled,
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				waitUntilGardenerResourceManagerReady, initializeShootClients, waitUntilOperatingSystemConfigReady, waitUntilShootNamespacesReady),
-		})
+		deployShootSystemResources = g.AddGroup(b.ReconcileSystemResourcesTaskGroup().WithDependencies(
+			waitUntilControlPlaneReady,
+			waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
+			waitUntilGardenerResourceManagerReady,
+			initializeShootClients,
+			waitUntilOperatingSystemConfigReady,
+		))
 		_ = g.Add(flow.Task{
 			Name:         "Populating static manifests from seed to shoot",
 			Fn:           flow.TaskFn(b.PopulateStaticManifestsFromSeedToShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -241,6 +241,8 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn:           flow.TaskFn(b.ReconcileIstioInternalLoadBalancingConfigMap).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
+		_                           = g.AddGroup(b.ReconcileCustomResourceDefinitionsTaskGroup())
+		_                           = g.AddGroup(b.ReconcileClusterResourceTaskGroup())
 		initializeSecretsManagement = g.AddGroup(
 			b.InitializeSecretsManagementTaskGroup().
 				WithDependencies(reconcileIstioInternalLoadbalancingConfigMap),

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -230,10 +230,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 	}
 
 	var (
-		deployNamespace = g.Add(flow.Task{
-			Name: "Deploying Shoot namespace in Seed",
-			Fn:   flow.TaskFn(b.DeployControlPlaneNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
-		})
+		deployNamespace            = g.AddGroup(b.DeployNamespacesTaskGroup())
 		ensureShootClusterIdentity = g.Add(flow.Task{
 			Name:         "Ensuring Shoot cluster identity",
 			Fn:           flow.TaskFn(b.EnsureShootClusterIdentity).RetryUntilTimeout(defaultInterval, defaultTimeout),

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -257,25 +257,10 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn:           flow.TaskFn(b.DeployReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
-		deployInfrastructure = g.Add(flow.Task{
-			Name:         "Deploying Shoot infrastructure",
-			Fn:           flow.TaskFn(b.DeployInfrastructure).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, deployReferencedResources),
-		})
-		waitUntilInfrastructureReady = g.Add(flow.Task{
-			Name: "Waiting until shoot infrastructure has been reconciled",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if !flowCtx.skipReadiness {
-					if err := b.WaitForInfrastructure(ctx); err != nil {
-						return err
-					}
-				}
-				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployInfrastructure)
-			}),
-			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(deployInfrastructure),
-		})
+		waitUntilInfrastructureReady = g.AddGroup(
+			b.ReconcileInfrastructureTaskGroup(flowCtx.skipReadiness).
+				WithDependencies(deployReferencedResources),
+		)
 		deployKubeAPIServerService = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes API server service in the Seed cluster",
 			Fn:           flow.TaskFn(b.Shoot.Components.ControlPlane.KubeAPIServerService.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -298,7 +283,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 				if err := b.DeployOrDestroyInternalDNSRecord(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployDNSRecordInternal)
+				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskDeployDNSRecordInternal)
 			}),
 			SkipIf:       b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
@@ -309,7 +294,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 				if err := b.DeployOrDestroyExternalDNSRecord(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployDNSRecordExternal)
+				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskDeployDNSRecordExternal)
 			}),
 			SkipIf:       b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
@@ -727,7 +712,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 					return err
 				}
 				if controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartCoreAddons) {
-					return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskRestartCoreAddons)
+					return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskRestartCoreAddons)
 				}
 				return nil
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -978,7 +963,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 				if err := b.DeployOrDestroyIngressDNSRecord(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskDeployDNSRecordIngress)
+				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskDeployDNSRecordIngress)
 			}),
 			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(nginxLBReady),
@@ -1130,7 +1115,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 				if err := b.RestartControlPlanePods(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, b, v1beta1constants.ShootTaskRestartControlPlanePods)
+				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskRestartControlPlanePods)
 			}),
 			SkipIf:       !flowCtx.requestControlPlanePodsRestart,
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager, deployControlPlane),
@@ -1156,7 +1141,7 @@ func (r *Reconciler) setupReconcileSelfHostedShootFlow(ctx context.Context, b *b
 		_                                = g.AddGroup(b.InitializeSecretsManagementTaskGroup())
 		reconcileGardenerResourceManager = g.AddGroup(b.ReconcileGardenerResourceManagerTaskGroup(true, shootIsGarden))
 		_                                = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())
-		_                                = g.AddGroup(b.ReconcileInfrastructureTaskGroup())
+		_                                = g.AddGroup(b.ReconcileInfrastructureTaskGroup(flowCtx.skipReadiness))
 		_                                = g.AddGroup(b.ReconcileControlPlaneTaskGroup())
 		_                                = g.AddGroup(b.ReconcileShootNamespacesTaskGroup())
 		reconcileSystemComponents        = g.AddGroup(b.ReconcileSystemComponentsTaskGroup())
@@ -1199,24 +1184,6 @@ func (r *Reconciler) setupReconcileSelfHostedShootFlow(ctx context.Context, b *b
 	)
 
 	return nil
-}
-
-func removeTaskAnnotation(ctx context.Context, b *botanistpkg.Botanist, tasksToRemove ...string) error {
-	// Check if shoot generation was changed mid-air, i.e., whether we need to wait for the next reconciliation until we
-	// can safely remove the task annotations to ensure all required tasks are executed.
-	shoot := &gardencorev1beta1.Shoot{}
-	if err := b.GardenClient.Get(ctx, client.ObjectKeyFromObject(b.Shoot.GetInfo()), shoot); err != nil {
-		return err
-	}
-
-	if shoot.Generation != b.Shoot.GetInfo().Generation {
-		return nil
-	}
-
-	return b.Shoot.UpdateInfo(ctx, b.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
-		controllerutils.RemoveTasks(shoot.Annotations, tasksToRemove...)
-		return nil
-	})
 }
 
 func shootHasPendingInPlaceUpdateWorkers(shoot *gardencorev1beta1.Shoot) bool {

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -242,11 +242,10 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn:           flow.TaskFn(b.ReconcileIstioInternalLoadBalancingConfigMap).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
-		initializeSecretsManagement = g.Add(flow.Task{
-			Name:         "Initializing secrets management",
-			Fn:           flow.TaskFn(b.InitializeSecretsManagement).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deployNamespace, reconcileIstioInternalLoadbalancingConfigMap),
-		})
+		initializeSecretsManagement = g.AddGroup(
+			b.InitializeSecretsManagementTaskGroup().
+				WithDependencies(reconcileIstioInternalLoadbalancingConfigMap),
+		)
 		initialValiDeployment = g.Add(flow.Task{
 			Name:         "Deploying initial shoot logging stack in Seed",
 			Fn:           flow.TaskFn(b.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
 	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 	"github.com/gardener/gardener/pkg/utils/gardener/tokenrequest"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 )
 
@@ -805,7 +804,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			SkipIf:       b.Shoot.IsWorkerless || !b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployManagedResourceForGardenerNodeAgent),
 		})
-		deployMachineControllerManager = g.AddGroup(b.ReconcileMachineControllerManagerTaskGroup().WithDependencies(
+		_ = g.AddGroup(b.ReconcileMachineControllerManagerTaskGroup().WithDependencies(
 			waitUntilInfrastructureReady,
 			initializeShootClients,
 			waitUntilOperatingSystemConfigReady,
@@ -813,84 +812,15 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			createNewServiceAccountSecrets,
 			scaleClusterAutoscalerToZero,
 		))
-		deployWorker = g.Add(flow.Task{
-			Name:         "Configuring shoot worker pools",
-			Fn:           flow.TaskFn(b.DeployWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(deployMachineControllerManager, deployShootSystemResources, waitUntilKubeRootCAConfigMapsUpdated),
-		})
-		waitUntilWorkerStatusUpdate = g.Add(flow.Task{
-			Name: "Waiting until worker resource status is updated with latest machine deployments",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.Extensions.Worker.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)
-			}),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
-			Dependencies: flow.NewTaskIDs(deployWorker),
-		})
-		deployExtensionResourcesAfterWorker = g.Add(flow.Task{
-			Name:         "Deploying extension resources after workers",
-			Fn:           flow.TaskFn(b.DeployExtensionsAfterWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
-		})
-		deployClusterAutoscaler = g.Add(flow.Task{
-			Name:         "Deploying cluster autoscaler",
-			Fn:           flow.TaskFn(b.DeployClusterAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
-			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate, deployManagedResourceForGardenerNodeAgent),
-		})
-		waitUntilWorkerReady = g.Add(flow.Task{
-			Name: "Waiting until shoot worker nodes have been reconciled",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if err := b.Shoot.Components.Extensions.Worker.Wait(ctx); err != nil {
-					return err
-				}
-
-				// If the worker is ready, all the AutoInPlaceUpdate worker pools should be updated already, so we can remove them from the status.
-				if shootHasPendingInPlaceUpdateWorkers(b.Shoot.GetInfo()) {
-					// gardenlet's shoot status reconciler might concurrently update the status, so we need to use optimistic locking.
-					if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, false, true, func(shoot *gardencorev1beta1.Shoot) error {
-						shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate = nil
-
-						if len(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate) == 0 {
-							shoot.Status.InPlaceUpdates.PendingWorkerUpdates = nil
-						}
-
-						if shoot.Status.InPlaceUpdates.PendingWorkerUpdates == nil {
-							shoot.Status.InPlaceUpdates = nil
-						}
-
-						return nil
-					}); err != nil {
-						return fmt.Errorf("failed to remove pending AutoInPlaceUpdate worker pools from status: %w", err)
-					}
-				}
-
-				// If there are no pending workers rollouts for in-place updates, we can remove the force in-place update annotation.
-				if (b.Shoot.GetInfo().Status.InPlaceUpdates == nil || b.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates == nil) &&
-					kubernetesutils.HasMetaDataAnnotation(b.Shoot.GetInfo(), v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationForceInPlaceUpdate) {
-					return b.Shoot.UpdateInfo(ctx, b.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
-						delete(shoot.Annotations, v1beta1constants.GardenerOperation)
-						return nil
-					})
-				}
-
-				return nil
-			}),
-			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness,
-			Dependencies: flow.NewTaskIDs(deployWorker, waitUntilWorkerStatusUpdate, deployManagedResourceForGardenerNodeAgent),
-		})
+		waitUntilWorkerReady = g.AddGroup(b.ReconcileWorkerTaskGroup(flowCtx.skipReadiness).WithDependencies(
+			deployManagedResourceForGardenerNodeAgent,
+			waitUntilKubeRootCAConfigMapsUpdated,
+		))
 		_ = g.Add(flow.Task{
 			Name:         "Checking if we have dual-stack pod CIDRs in nodes",
 			Fn:           b.CheckPodCIDRsInNodes,
 			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Waiting until extension resources handled after workers are ready",
-			Fn:           b.Shoot.Components.Extensions.Extension.WaitAfterWorker,
-			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness,
-			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterWorker),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Scaling down machine-controller-manager",
@@ -991,7 +921,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Name:         "Hibernating control plane",
 			Fn:           flow.TaskFn(b.HibernateControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			SkipIf:       !b.Shoot.HibernationEnabled,
-			Dependencies: flow.NewTaskIDs(initializeShootClients, deployPrometheus, deployAlertmanager, deploySeedLogging, deployClusterAutoscaler, waitUntilWorkerReady, waitUntilExtensionResourcesAfterKAPIReady, waitUntilEtcdScaledAfterRestore),
+			Dependencies: flow.NewTaskIDs(initializeShootClients, deployPrometheus, deployAlertmanager, deploySeedLogging, waitUntilWorkerReady, waitUntilExtensionResourcesAfterKAPIReady, waitUntilEtcdScaledAfterRestore),
 		})
 
 		// logic is inverted here
@@ -1138,13 +1068,8 @@ func (r *Reconciler) setupReconcileSelfHostedShootFlow(ctx context.Context, b *b
 			b.ReconcileMachineControllerManagerTaskGroup().
 				WithDependencies(reconcileStaticControlPlanePods),
 		)
-		_ = g.AddGroup(b.ReconcileWorkerTaskGroup())
+		_ = g.AddGroup(b.ReconcileWorkerTaskGroup(flowCtx.skipReadiness))
 	)
 
 	return nil
-}
-
-func shootHasPendingInPlaceUpdateWorkers(shoot *gardencorev1beta1.Shoot) bool {
-	return shoot.Status.InPlaceUpdates != nil && shoot.Status.InPlaceUpdates.PendingWorkerUpdates != nil &&
-		(len(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate) > 0 || len(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate) > 0)
 }

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -618,28 +618,15 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			deleteBastions,
 			waitUntilExtensionResourcesAfterKAPIReady,
 		))
-		deployNetwork = g.Add(flow.Task{
-			Name:         "Deploying shoot network plugin",
-			Fn:           flow.TaskFn(b.DeployNetwork).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilGardenerResourceManagerReady, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
-		})
-		waitUntilNetworkIsReady = g.Add(flow.Task{
-			Name: "Waiting until shoot network plugin has been reconciled",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.Extensions.Network.Wait(ctx)
-			}),
-			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness,
-			Dependencies: flow.NewTaskIDs(deployNetwork),
-		})
-		_ = g.Add(flow.Task{
-			Name: "Check coreDNS migration",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.CheckDNSServiceMigration(ctx)
-			}),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
-			Dependencies: flow.NewTaskIDs(waitUntilNetworkIsReady),
-		})
+		deployShootSystemResources = g.AddGroup(b.ReconcileSystemResourcesTaskGroup().WithDependencies(
+			deployReferencedResources,
+			waitUntilOperatingSystemConfigReady,
+			waitUntilControlPlaneReady,
+			waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
+			waitUntilGardenerResourceManagerReady,
+			initializeShootClients,
+			waitUntilOperatingSystemConfigReady,
+		))
 		_ = g.Add(flow.Task{
 			Name: "Deploying shoot cluster identity",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
@@ -648,39 +635,10 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			SkipIf:       b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
-		deployShootSystemResources = g.AddGroup(b.ReconcileSystemResourcesTaskGroup().WithDependencies(
-			waitUntilControlPlaneReady,
-			waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-			waitUntilGardenerResourceManagerReady,
-			initializeShootClients,
-			waitUntilOperatingSystemConfigReady,
-		))
 		_ = g.Add(flow.Task{
 			Name:         "Populating static manifests from seed to shoot",
 			Fn:           flow.TaskFn(b.PopulateStaticManifestsFromSeedToShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, waitUntilShootNamespacesReady),
-		})
-		deployCoreDNS = g.Add(flow.Task{
-			Name: "Deploying CoreDNS system component",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if err := b.DeployCoreDNS(ctx); err != nil {
-					return err
-				}
-				if controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartCoreAddons) {
-					return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskRestartCoreAddons)
-				}
-				return nil
-			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				waitUntilGardenerResourceManagerReady, initializeShootClients, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
-		})
-		deployNodeLocalDNS = g.Add(flow.Task{
-			Name:   "Reconcile node-local-dns system component",
-			Fn:     flow.TaskFn(b.ReconcileNodeLocalDNS),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				deployGardenerResourceManager, initializeShootClients, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady, waitUntilNetworkIsReady),
 		})
 		deployMetricsServer = g.Add(flow.Task{
 			Name: "Deploying metrics-server system component",
@@ -715,29 +673,13 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				deployGardenerResourceManager, waitUntilOperatingSystemConfigReady, waitUntilShootNamespacesReady),
 		})
-		deployKubeProxy = g.Add(flow.Task{
-			Name:   "Deploying kube-proxy system component",
-			Fn:     flow.TaskFn(b.DeployKubeProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || !flowCtx.kubeProxyEnabled,
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				deployGardenerResourceManager, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
-		})
-		_ = g.Add(flow.Task{
-			Name: "Deleting stale kube-proxy DaemonSets",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.SystemComponents.KubeProxy.DeleteStaleResources(ctx)
-			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || !flowCtx.kubeProxyEnabled,
-			Dependencies: flow.NewTaskIDs(deployKubeProxy),
-		})
-		_ = g.Add(flow.Task{
-			Name: "Deleting kube-proxy system component",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.SystemComponents.KubeProxy.Destroy(ctx)
-			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.kubeProxyEnabled,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler),
-		})
+		reconcileSystemComponents = g.AddGroup(b.ReconcileSystemComponentsTaskGroup(flowCtx.kubeProxyEnabled, flowCtx.skipReadiness).WithDependencies(
+			waitUntilControlPlaneReady,
+			waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
+			initializeShootClients,
+			ensureShootClusterIdentity,
+			deployKubeScheduler,
+		))
 		deployAPIServerProxy = g.Add(flow.Task{
 			Name:   "Deploying apiserver-proxy",
 			Fn:     flow.TaskFn(b.DeployAPIServerProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -783,16 +725,13 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		})
 
 		syncPointAllSystemComponentsDeployed = flow.NewTaskIDs(
-			waitUntilNetworkIsReady,
+			reconcileSystemComponents,
 			deployAPIServerProxy,
 			deployShootSystemResources,
-			deployCoreDNS,
 			deployNodeExporter,
-			deployNodeLocalDNS,
 			deployMetricsServer,
 			waitUntilVPNShootReady,
 			deployNodeProblemDetector,
-			deployKubeProxy,
 			deployBlackboxExporter,
 			deployKubernetesDashboard,
 			deployNginxIngressAddon,
@@ -808,7 +747,6 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			waitUntilInfrastructureReady,
 			initializeShootClients,
 			waitUntilOperatingSystemConfigReady,
-			waitUntilNetworkIsReady,
 			createNewServiceAccountSecrets,
 			scaleClusterAutoscalerToZero,
 		))
@@ -860,7 +798,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Name:         "Waiting until the Kubernetes API server can connect to the Shoot workers",
 			Fn:           b.WaitUntilTunnelConnectionExists,
 			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
-			Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, waitUntilNetworkIsReady, waitUntilWorkerReady),
+			Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, reconcileSystemComponents, waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Waiting until all shoot worker nodes have updated the operating system config",
@@ -1032,7 +970,7 @@ func (r *Reconciler) setupReconcileSelfHostedShootFlow(ctx context.Context, b *b
 		_                                = g.AddGroup(b.ReconcileInfrastructureTaskGroup(flowCtx.skipReadiness))
 		_                                = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
 		_                                = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
-		reconcileSystemComponents        = g.AddGroup(b.ReconcileSystemComponentsTaskGroup())
+		reconcileSystemComponents        = g.AddGroup(b.ReconcileSystemComponentsTaskGroup(flowCtx.kubeProxyEnabled, flowCtx.skipReadiness))
 
 		deployBackupBucketInGarden = g.Add(flow.Task{
 			Name:         "Deploying BackupBucket for ETCD data",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -443,20 +443,9 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
-		deployControlPlane = g.Add(flow.Task{
-			Name:         "Deploying shoot control plane components",
-			Fn:           flow.TaskFn(b.DeployControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
-		})
-		waitUntilControlPlaneReady = g.Add(flow.Task{
-			Name: "Waiting until shoot control plane has been reconciled",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.Extensions.ControlPlane.Wait(ctx)
-			}),
-			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness,
-			Dependencies: flow.NewTaskIDs(deployControlPlane),
-		})
+		waitUntilControlPlaneReady = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness).WithDependencies(
+			deployReferencedResources,
+		))
 		deployShootNamespaces = g.Add(flow.Task{
 			Name:         "Deploying shoot namespaces system component",
 			Fn:           flow.TaskFn(b.Shoot.Components.SystemComponents.Namespaces.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -1097,7 +1086,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskRestartControlPlanePods)
 			}),
 			SkipIf:       !flowCtx.requestControlPlanePodsRestart,
-			Dependencies: flow.NewTaskIDs(deployKubeControllerManager, deployControlPlane),
+			Dependencies: flow.NewTaskIDs(deployKubeControllerManager, waitUntilControlPlaneReady),
 		})
 	)
 
@@ -1121,7 +1110,7 @@ func (r *Reconciler) setupReconcileSelfHostedShootFlow(ctx context.Context, b *b
 		reconcileGardenerResourceManager = g.AddGroup(b.ReconcileGardenerResourceManagerTaskGroup(true, shootIsGarden))
 		_                                = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())
 		_                                = g.AddGroup(b.ReconcileInfrastructureTaskGroup(flowCtx.skipReadiness))
-		_                                = g.AddGroup(b.ReconcileControlPlaneTaskGroup())
+		_                                = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
 		_                                = g.AddGroup(b.ReconcileShootNamespacesTaskGroup())
 		reconcileSystemComponents        = g.AddGroup(b.ReconcileSystemComponentsTaskGroup())
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -446,18 +446,8 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		waitUntilControlPlaneReady = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness).WithDependencies(
 			deployReferencedResources,
 		))
-		deployShootNamespaces = g.Add(flow.Task{
-			Name:         "Deploying shoot namespaces system component",
-			Fn:           flow.TaskFn(b.Shoot.Components.SystemComponents.Namespaces.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
-		})
-		waitUntilShootNamespacesReady = g.Add(flow.Task{
-			Name:         "Waiting until shoot namespaces have been reconciled",
-			Fn:           b.Shoot.Components.SystemComponents.Namespaces.Wait,
-			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
-			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, deployShootNamespaces),
-		})
-		deployVPNSeedServer = g.Add(flow.Task{
+		waitUntilShootNamespacesReady = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
+		deployVPNSeedServer           = g.Add(flow.Task{
 			Name:         "Deploying vpn-seed-server",
 			Fn:           flow.TaskFn(b.DeployVPNServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsWorkerless,
@@ -1111,7 +1101,7 @@ func (r *Reconciler) setupReconcileSelfHostedShootFlow(ctx context.Context, b *b
 		_                                = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())
 		_                                = g.AddGroup(b.ReconcileInfrastructureTaskGroup(flowCtx.skipReadiness))
 		_                                = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
-		_                                = g.AddGroup(b.ReconcileShootNamespacesTaskGroup())
+		_                                = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
 		reconcileSystemComponents        = g.AddGroup(b.ReconcileSystemComponentsTaskGroup())
 
 		deployBackupBucketInGarden = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -236,12 +236,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn:           flow.TaskFn(b.EnsureShootClusterIdentity).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
-		deployCloudProviderSecret = g.Add(flow.Task{
-			Name:         "Deploying cloud provider account secret",
-			Fn:           flow.TaskFn(b.DeployCloudProviderSecret).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(deployNamespace),
-		})
+		deployCloudProviderSecret                    = g.AddGroup(b.DeployCloudProviderSecretTaskGroup())
 		reconcileIstioInternalLoadbalancingConfigMap = g.Add(flow.Task{
 			Name:         "Reconcile Istio internal load balancing ConfigMap",
 			Fn:           flow.TaskFn(b.ReconcileIstioInternalLoadBalancingConfigMap).RetryUntilTimeout(defaultInterval, defaultTimeout),

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -633,36 +633,13 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			SkipIf:       flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterKAPI),
 		})
-		deployOperatingSystemConfig = g.Add(flow.Task{
-			Name:         "Deploying operating system specific configuration for shoot workers",
-			Fn:           flow.TaskFn(b.DeployOperatingSystemConfig).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady, deleteBastions, waitUntilExtensionResourcesAfterKAPIReady),
-		})
-		waitUntilOperatingSystemConfigReady = g.Add(flow.Task{
-			Name: "Waiting until operating system configurations for worker nodes have been reconciled",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.Extensions.OperatingSystemConfig.Wait(ctx)
-			}),
-			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfig),
-		})
-		deleteStaleOperatingSystemConfigResources = g.Add(flow.Task{
-			Name: "Delete stale operating system config resources",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.Extensions.OperatingSystemConfig.DeleteStaleResources(ctx)
-			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfig),
-		})
-		_ = g.Add(flow.Task{
-			Name: "Waiting until stale operating system config resources are deleted",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.Extensions.OperatingSystemConfig.WaitCleanupStaleResources(ctx)
-			}),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
-			Dependencies: flow.NewTaskIDs(deleteStaleOperatingSystemConfigResources),
-		})
+		waitUntilOperatingSystemConfigReady = g.AddGroup(b.ReconcileOperatingSystemConfigTaskGroup(flowCtx.skipReadiness).WithDependencies(
+			deployReferencedResources,
+			waitUntilInfrastructureReady,
+			waitUntilControlPlaneReady,
+			deleteBastions,
+			waitUntilExtensionResourcesAfterKAPIReady,
+		))
 		deployNetwork = g.Add(flow.Task{
 			Name:         "Deploying shoot network plugin",
 			Fn:           flow.TaskFn(b.DeployNetwork).RetryUntilTimeout(defaultInterval, defaultTimeout),

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -849,12 +849,14 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			SkipIf:       b.Shoot.IsWorkerless || !b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployManagedResourceForGardenerNodeAgent),
 		})
-		deployMachineControllerManager = g.Add(flow.Task{
-			Name:         "Deploying machine-controller-manager",
-			Fn:           flow.TaskFn(b.DeployMachineControllerManager),
-			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(deployCloudProviderSecret, deployReferencedResources, waitUntilInfrastructureReady, initializeShootClients, waitUntilOperatingSystemConfigReady, waitUntilNetworkIsReady, createNewServiceAccountSecrets, scaleClusterAutoscalerToZero),
-		})
+		deployMachineControllerManager = g.AddGroup(b.ReconcileMachineControllerManagerTaskGroup().WithDependencies(
+			waitUntilInfrastructureReady,
+			initializeShootClients,
+			waitUntilOperatingSystemConfigReady,
+			waitUntilNetworkIsReady,
+			createNewServiceAccountSecrets,
+			scaleClusterAutoscalerToZero,
+		))
 		deployWorker = g.Add(flow.Task{
 			Name:         "Configuring shoot worker pools",
 			Fn:           flow.TaskFn(b.DeployWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),

--- a/pkg/gardenlet/operation/botanist/botanist.go
+++ b/pkg/gardenlet/operation/botanist/botanist.go
@@ -21,6 +21,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -196,6 +197,25 @@ func (b *Botanist) SetInPlaceUpdatePendingWorkers(ctx context.Context, worker *e
 			shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate = append(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate, poolName)
 		}
 
+		return nil
+	})
+}
+
+// RemoveTaskAnnotation removes the provided task annotations from the Shoot.
+func (b *Botanist) RemoveTaskAnnotation(ctx context.Context, tasksToRemove ...string) error {
+	// Check if shoot generation was changed mid-air, i.e., whether we need to wait for the next reconciliation until we
+	// can safely remove the task annotations to ensure all required tasks are executed.
+	shoot := &gardencorev1beta1.Shoot{}
+	if err := b.GardenClient.Get(ctx, client.ObjectKeyFromObject(b.Shoot.GetInfo()), shoot); err != nil {
+		return err
+	}
+
+	if shoot.Generation != b.Shoot.GetInfo().Generation {
+		return nil
+	}
+
+	return b.Shoot.UpdateInfo(ctx, b.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
+		controllerutils.RemoveTasks(shoot.Annotations, tasksToRemove...)
 		return nil
 	})
 }

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -386,7 +386,7 @@ func (b *Botanist) ReconcileWorkerTaskGroup(skipReadiness bool) flow.TaskGroup {
 			Fn: func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.Worker.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)
 			},
-			SkipIf:       !b.Shoot.HasManagedInfrastructure(),
+			SkipIf:       !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployWorker),
 		})
 		deployExtensionResourcesAfterWorker = g.Add(flow.Task{
@@ -445,7 +445,7 @@ func (b *Botanist) ReconcileWorkerTaskGroup(skipReadiness bool) flow.TaskGroup {
 
 				return nil
 			},
-			SkipIf:       !b.Shoot.HasManagedInfrastructure(),
+			SkipIf:       !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless || skipReadiness,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
 		})
 	)

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -203,11 +203,12 @@ func (b *Botanist) ReconcileSystemResourcesTaskGroup() flow.TaskGroup {
 			Fn: func(ctx context.Context) error {
 				return seedsystem.New(b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, seedsystem.Values{ManagePriorityClasses: true}).Deploy(ctx)
 			},
+			SkipIf: !b.Shoot.IsSelfHosted(),
 		})
 		_ = g.Add(flow.Task{
 			Name:   "Deploying shoot system resources",
 			Fn:     b.DeployShootSystem,
-			SkipIf: gardenadmBootstrap,
+			SkipIf: gardenadmBootstrap || b.Shoot.HibernationEnabled,
 		})
 	)
 

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/autoscaling/vpa"
@@ -355,7 +356,7 @@ const TaskGroupReconcileWorker flow.TaskID = "TaskGroupReconcileWorker"
 // ReconcileWorkerTaskGroup returns the flow.TaskGroup for deploying the Worker extension resource. It waits until its
 // status was updated with the latest machine deployments, deploys cluster-autoscaler and finally waits for the pools
 // to get reconciled.
-func (b *Botanist) ReconcileWorkerTaskGroup() flow.TaskGroup {
+func (b *Botanist) ReconcileWorkerTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileWorker).WithDependencies(
 			TaskGroupInitializeSecretsManagement,
@@ -363,12 +364,18 @@ func (b *Botanist) ReconcileWorkerTaskGroup() flow.TaskGroup {
 			TaskGroupReconcileGardenerResourceManager,
 			TaskGroupReconcileInfrastructure,
 			TaskGroupReconcileMachineControllerManager,
+			TaskGroupReconcileSystemResources,
 		)
+
+		shootHasPendingInPlaceUpdateWorkers = func(shoot *gardencorev1beta1.Shoot) bool {
+			return shoot.Status.InPlaceUpdates != nil && shoot.Status.InPlaceUpdates.PendingWorkerUpdates != nil &&
+				(len(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate) > 0 || len(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate) > 0)
+		}
 
 		deployWorker = g.Add(flow.Task{
 			Name:   "Configuring worker pools",
 			Fn:     b.DeployWorker,
-			SkipIf: !b.Shoot.HasManagedInfrastructure(),
+			SkipIf: !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless,
 		})
 		waitUntilWorkerStatusUpdate = g.Add(flow.Task{
 			Name: "Waiting until worker resource status is updated with latest machine deployments",
@@ -378,16 +385,61 @@ func (b *Botanist) ReconcileWorkerTaskGroup() flow.TaskGroup {
 			SkipIf:       !b.Shoot.HasManagedInfrastructure(),
 			Dependencies: flow.NewTaskIDs(deployWorker),
 		})
+		deployExtensionResourcesAfterWorker = g.Add(flow.Task{
+			Name:         "Deploying extension resources after workers",
+			Fn:           b.DeployExtensionsAfterWorker,
+			SkipIf:       b.isGardenadmBootstrap() || b.Shoot.IsWorkerless,
+			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Waiting until extension resources handled after workers are ready",
+			Fn:           b.Shoot.Components.Extensions.Extension.WaitAfterWorker,
+			SkipIf:       b.isGardenadmBootstrap() || b.Shoot.IsWorkerless || skipReadiness,
+			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterWorker),
+		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying cluster-autoscaler",
 			Fn:           b.DeployClusterAutoscaler,
-			SkipIf:       !b.Shoot.HasManagedInfrastructure(),
+			SkipIf:       !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Waiting until worker pools have been reconciled",
 			Fn: func(ctx context.Context) error {
-				return b.Shoot.Components.Extensions.Worker.Wait(ctx)
+				if err := b.Shoot.Components.Extensions.Worker.Wait(ctx); err != nil {
+					return err
+				}
+
+				// If the worker is ready, all the AutoInPlaceUpdate worker pools should be updated already, so we can remove them from the status.
+				if shootHasPendingInPlaceUpdateWorkers(b.Shoot.GetInfo()) {
+					// gardenlet's shoot status reconciler might concurrently update the status, so we need to use optimistic locking.
+					if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, false, true, func(shoot *gardencorev1beta1.Shoot) error {
+						shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate = nil
+
+						if len(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate) == 0 {
+							shoot.Status.InPlaceUpdates.PendingWorkerUpdates = nil
+						}
+
+						if shoot.Status.InPlaceUpdates.PendingWorkerUpdates == nil {
+							shoot.Status.InPlaceUpdates = nil
+						}
+
+						return nil
+					}); err != nil {
+						return fmt.Errorf("failed to remove pending AutoInPlaceUpdate worker pools from status: %w", err)
+					}
+				}
+
+				// If there are no pending workers rollouts for in-place updates, we can remove the force in-place update annotation.
+				if (b.Shoot.GetInfo().Status.InPlaceUpdates == nil || b.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates == nil) &&
+					kubernetesutils.HasMetaDataAnnotation(b.Shoot.GetInfo(), v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationForceInPlaceUpdate) {
+					return b.Shoot.UpdateInfo(ctx, b.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
+						delete(shoot.Annotations, v1beta1constants.GardenerOperation)
+						return nil
+					})
+				}
+
+				return nil
 			},
 			SkipIf:       !b.Shoot.HasManagedInfrastructure(),
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/logging/fluentoperator"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
 	seedsystem "github.com/gardener/gardener/pkg/component/seed/system"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerextensions "github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -111,7 +112,7 @@ func (b *Botanist) ReconcileCustomResourceDefinitionsTaskGroup() flow.TaskGroup 
 		})
 	}
 
-	return flow.NewTaskGroup(TaskGroupReconcileCustomResourceDefinitions, tasks...)
+	return flow.NewTaskGroup(TaskGroupReconcileCustomResourceDefinitions, tasks...).SkipIf(!b.Shoot.IsSelfHosted())
 }
 
 // TaskGroupReconcileClusterResource is a flow.TaskID for a logical flow.TaskGroup.
@@ -124,7 +125,7 @@ func (b *Botanist) ReconcileClusterResourceTaskGroup() flow.TaskGroup {
 		Fn: func(ctx context.Context) error {
 			return gardenerextensions.SyncClusterResourceToSeed(ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, b.Shoot.GetInfo(), b.Shoot.CloudProfile, nil)
 		},
-	}).WithDependencies(TaskGroupReconcileCustomResourceDefinitions)
+	}).WithDependencies(TaskGroupReconcileCustomResourceDefinitions).SkipIf(!b.Shoot.IsSelfHosted())
 }
 
 // TaskGroupInitializeSecretsManagement is a flow.TaskID for a logical flow.TaskGroup.

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -222,7 +222,7 @@ func (b *Botanist) ReconcileMachineControllerManagerTaskGroup() flow.TaskGroup {
 	return flow.NewTaskGroup(TaskGroupReconcileMachineControllerManager, flow.Task{
 		Name:   "Deploying machine-controller-manager",
 		Fn:     flow.TaskFn(b.DeployMachineControllerManager).RetryUntilTimeout(time.Second, time.Minute),
-		SkipIf: !b.Shoot.HasManagedInfrastructure(),
+		SkipIf: !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless,
 	}).WithDependencies(
 		TaskGroupInitializeSecretsManagement,
 		TaskGroupDeployCloudProviderSecret,

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -143,38 +143,40 @@ const TaskGroupReconcileGardenerResourceManager flow.TaskID = "TaskGroupReconcil
 
 // ReconcileGardenerResourceManagerTaskGroup returns the flow.TaskGroup for deploying the gardener-resource-manager
 // instances. It waits for their readiness and also deploys the seed and shoot system resources afterwards.
-func (b *Botanist) ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, shootIsGarden bool) flow.TaskGroup {
+func (b *Botanist) ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, skipRuntimeResourceManager, skipReadiness bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileGardenerResourceManager).WithDependencies(
 			TaskGroupDeployNamespaces,
 			TaskGroupInitializeSecretsManagement,
 			TaskGroupReconcileCustomResourceDefinitions,
 		)
-		gardenadmBootstrap = b.Shoot.IsSelfHosted() && !b.Shoot.RunsControlPlane()
 
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name: "Deploying gardener-resource-manager",
 			Fn: func(ctx context.Context) error {
-				b.Shoot.Components.ControlPlane.ResourceManager.SetBootstrapControlPlaneNode(!podNetworkAvailable)
-
-				if shootIsGarden || gardenadmBootstrap {
-					return b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx)
+				if b.Shoot.IsSelfHosted() {
+					b.Shoot.Components.ControlPlane.ResourceManager.SetBootstrapControlPlaneNode(!podNetworkAvailable)
+					if !skipRuntimeResourceManager {
+						b.Shoot.Components.ControlPlane.RuntimeResourceManager.SetBootstrapControlPlaneNode(!podNetworkAvailable)
+					}
 				}
 
-				b.Shoot.Components.ControlPlane.RuntimeResourceManager.SetBootstrapControlPlaneNode(!podNetworkAvailable)
+				if skipRuntimeResourceManager {
+					return b.DeployGardenerResourceManager(ctx)
+				}
 
 				// Deploy sequentially: only `RuntimeResourceManager` installs the `ManagedResource` CRD, and
 				// `ResourceManager.Deploy` creates a `ManagedResource` object on the same client.
 				return flow.Sequential(
-					b.Shoot.Components.ControlPlane.RuntimeResourceManager.Deploy,
-					b.Shoot.Components.ControlPlane.ResourceManager.Deploy,
+					b.DeployRuntimeGardenerResourceManager,
+					b.DeployGardenerResourceManager,
 				)(ctx)
 			},
 		})
 		_ = g.Add(flow.Task{
 			Name: "Waiting until gardener-resource-manager reports readiness",
 			Fn: func(ctx context.Context) error {
-				if shootIsGarden || gardenadmBootstrap {
+				if skipRuntimeResourceManager {
 					return b.Shoot.Components.ControlPlane.ResourceManager.Wait(ctx)
 				}
 
@@ -183,6 +185,7 @@ func (b *Botanist) ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable
 					b.Shoot.Components.ControlPlane.ResourceManager.Wait,
 				)(ctx)
 			},
+			SkipIf:       b.Shoot.HibernationEnabled || skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
 	)

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -402,7 +402,7 @@ const TaskGroupReconcileShootNamespaces flow.TaskID = "TaskGroupReconcileShootNa
 
 // ReconcileShootNamespacesTaskGroup returns the flow.TaskGroup for deploying the shoot namespaces and waiting for their
 // readiness.
-func (b *Botanist) ReconcileShootNamespacesTaskGroup() flow.TaskGroup {
+func (b *Botanist) ReconcileShootNamespacesTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileShootNamespaces).WithDependencies(TaskGroupReconcileGardenerResourceManager)
 
@@ -413,6 +413,7 @@ func (b *Botanist) ReconcileShootNamespacesTaskGroup() flow.TaskGroup {
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until shoot namespaces have been reconciled",
 			Fn:           b.Shoot.Components.SystemComponents.Namespaces.Wait,
+			SkipIf:       b.Shoot.HibernationEnabled || skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployShootNamespaces),
 		})
 	)

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -235,23 +235,29 @@ const TaskGroupReconcileInfrastructure flow.TaskID = "TaskGroupReconcileInfrastr
 
 // ReconcileInfrastructureTaskGroup returns the flow.TaskGroup for deploying the Infrastructure extension resource and
 // waiting for its readiness.
-func (b *Botanist) ReconcileInfrastructureTaskGroup() flow.TaskGroup {
+func (b *Botanist) ReconcileInfrastructureTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileInfrastructure).WithDependencies(
 			TaskGroupInitializeSecretsManagement,
 			TaskGroupDeployCloudProviderSecret,
-			TaskGroupReconcileGardenerResourceManager,
 		)
 
 		deployInfrastructure = g.Add(flow.Task{
 			Name:   "Deploying Shoot infrastructure",
 			Fn:     b.DeployInfrastructure,
-			SkipIf: !b.Shoot.HasManagedInfrastructure(),
+			SkipIf: !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless,
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Waiting until Shoot infrastructure has been reconciled",
-			Fn:           b.WaitForInfrastructure,
-			SkipIf:       !b.Shoot.HasManagedInfrastructure(),
+			Name: "Waiting until Shoot infrastructure has been reconciled",
+			Fn: func(ctx context.Context) error {
+				if !skipReadiness {
+					if err := b.WaitForInfrastructure(ctx); err != nil {
+						return err
+					}
+				}
+				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskDeployInfrastructure)
+			},
+			SkipIf:       !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployInfrastructure),
 		})
 	)

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -57,7 +57,7 @@ func (b *Botanist) DeployCloudProviderSecretTaskGroup() flow.TaskGroup {
 	return flow.NewTaskGroup(TaskGroupDeployCloudProviderSecret, flow.Task{
 		Name:   "Deploying cloud provider account secret",
 		Fn:     b.DeployCloudProviderSecret,
-		SkipIf: b.Shoot.Credentials == nil,
+		SkipIf: b.Shoot.Credentials == nil || b.Shoot.IsWorkerless,
 	}).WithDependencies(TaskGroupDeployNamespaces)
 }
 

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -477,36 +477,83 @@ func (b *Botanist) ReconcileShootNamespacesTaskGroup(skipReadiness bool) flow.Ta
 const TaskGroupReconcileSystemComponents flow.TaskID = "TaskGroupReconcileSystemComponents"
 
 // ReconcileSystemComponentsTaskGroup returns the flow.TaskGroup for reconciling shoot system components.
-func (b *Botanist) ReconcileSystemComponentsTaskGroup() flow.TaskGroup {
+func (b *Botanist) ReconcileSystemComponentsTaskGroup(kubeProxyEnabled, skipReadiness bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileSystemComponents).WithDependencies(
 			TaskGroupReconcileInfrastructure,
+			TaskGroupReconcileGardenerResourceManager,
 			TaskGroupReconcileShootNamespaces,
 		)
 
-		_ = g.Add(flow.Task{
-			Name:   "Deploying kube-proxy system component",
-			Fn:     b.DeployKubeProxy,
-			SkipIf: !v1beta1helper.KubeProxyEnabled(b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy),
-		})
 		deployNetwork = g.Add(flow.Task{
-			Name: "Deploying shoot network plugin",
-			Fn:   b.DeployNetwork,
+			Name:   "Deploying shoot network plugin",
+			Fn:     b.DeployNetwork,
+			SkipIf: b.Shoot.IsWorkerless,
 		})
 		waitUntilNetworkReady = g.Add(flow.Task{
-			Name:         "Waiting until shoot network plugin has been reconciled",
-			Fn:           b.Shoot.Components.Extensions.Network.Wait,
+			Name: "Waiting until shoot network plugin has been reconciled",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.Extensions.Network.Wait(ctx)
+			},
+			SkipIf:       b.Shoot.IsWorkerless || skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployNetwork),
 		})
+
+		deployKubeProxy = g.Add(flow.Task{
+			Name:   "Deploying kube-proxy system component",
+			Fn:     b.DeployKubeProxy,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || !kubeProxyEnabled,
+		})
+		_ = g.Add(flow.Task{
+			Name: "Deleting stale kube-proxy DaemonSets",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.SystemComponents.KubeProxy.DeleteStaleResources(ctx)
+			},
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || !kubeProxyEnabled,
+			Dependencies: flow.NewTaskIDs(deployKubeProxy),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Deleting kube-proxy system component",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.SystemComponents.KubeProxy.Destroy(ctx)
+			},
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || kubeProxyEnabled,
+		})
+
+		_ = g.Add(flow.Task{
+			Name:         "Check CoreDNS migration status",
+			Fn:           b.CheckDNSServiceMigration,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			Dependencies: flow.NewTaskIDs(waitUntilNetworkReady),
+		})
 		deployCoreDNS = g.Add(flow.Task{
-			Name:         "Deploying CoreDNS system component",
-			Fn:           b.DeployCoreDNS,
+			Name: "Deploying CoreDNS system component",
+			Fn: func(ctx context.Context) error {
+				if err := b.DeployCoreDNS(ctx); err != nil {
+					return err
+				}
+				if controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartCoreAddons) {
+					return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskRestartCoreAddons)
+				}
+				return nil
+			},
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilNetworkReady),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Waiting until CoreDNS system component is ready",
-			Fn:           b.Shoot.Components.SystemComponents.CoreDNS.Wait,
+			Name: "Waiting until CoreDNS system component is ready",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.SystemComponents.CoreDNS.Wait(ctx)
+			},
 			Dependencies: flow.NewTaskIDs(deployCoreDNS),
+			SkipIf:       !b.Shoot.IsSelfHosted(),
+		})
+
+		_ = g.Add(flow.Task{
+			Name:         "Reconcile node-local-dns system component",
+			Fn:           b.ReconcileNodeLocalDNS,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			Dependencies: flow.NewTaskIDs(waitUntilNetworkReady),
 		})
 	)
 

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -270,7 +270,7 @@ const TaskGroupReconcileControlPlane flow.TaskID = "TaskGroupReconcileControlPla
 
 // ReconcileControlPlaneTaskGroup returns the flow.TaskGroup for deploying the ControlPlane extension resource and
 // waiting for its readiness.
-func (b *Botanist) ReconcileControlPlaneTaskGroup() flow.TaskGroup {
+func (b *Botanist) ReconcileControlPlaneTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileControlPlane).WithDependencies(
 			TaskGroupInitializeSecretsManagement,
@@ -280,12 +280,16 @@ func (b *Botanist) ReconcileControlPlaneTaskGroup() flow.TaskGroup {
 		)
 
 		deployControlPlane = g.Add(flow.Task{
-			Name: "Deploying shoot control plane components",
-			Fn:   b.DeployControlPlane,
+			Name:   "Deploying shoot control plane components",
+			Fn:     b.DeployControlPlane,
+			SkipIf: b.Shoot.IsWorkerless,
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Waiting until shoot control plane has been reconciled",
-			Fn:           b.Shoot.Components.Extensions.ControlPlane.Wait,
+			Name: "Waiting until shoot control plane has been reconciled",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.Extensions.ControlPlane.Wait(ctx)
+			},
+			SkipIf:       b.Shoot.IsWorkerless || skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployControlPlane),
 		})
 	)

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -195,8 +195,7 @@ const TaskGroupReconcileSystemResources flow.TaskID = "TaskGroupReconcileSystemR
 // ReconcileSystemResourcesTaskGroup returns the flow.TaskGroup for deploying the system resources.
 func (b *Botanist) ReconcileSystemResourcesTaskGroup() flow.TaskGroup {
 	var (
-		g                  = flow.NewTaskGroup(TaskGroupReconcileSystemResources).WithDependencies(TaskGroupReconcileGardenerResourceManager)
-		gardenadmBootstrap = b.Shoot.IsSelfHosted() && !b.Shoot.RunsControlPlane()
+		g = flow.NewTaskGroup(TaskGroupReconcileSystemResources).WithDependencies(TaskGroupReconcileGardenerResourceManager)
 
 		_ = g.Add(flow.Task{
 			Name: "Deploying seed system resources",
@@ -208,7 +207,7 @@ func (b *Botanist) ReconcileSystemResourcesTaskGroup() flow.TaskGroup {
 		_ = g.Add(flow.Task{
 			Name:   "Deploying shoot system resources",
 			Fn:     b.DeployShootSystem,
-			SkipIf: gardenadmBootstrap || b.Shoot.HibernationEnabled,
+			SkipIf: b.isGardenadmBootstrap() || b.Shoot.HibernationEnabled,
 		})
 	)
 
@@ -299,7 +298,7 @@ const TaskGroupReconcileOperatingSystemConfig flow.TaskID = "TaskGroupReconcileO
 
 // ReconcileOperatingSystemConfigTaskGroup returns the flow.TaskGroup for deploying the OperatingSystemConfig extension
 // resource and waiting for its readiness.
-func (b *Botanist) ReconcileOperatingSystemConfigTaskGroup() flow.TaskGroup {
+func (b *Botanist) ReconcileOperatingSystemConfigTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileOperatingSystemConfig).WithDependencies(
 			TaskGroupInitializeSecretsManagement,
@@ -308,13 +307,38 @@ func (b *Botanist) ReconcileOperatingSystemConfigTaskGroup() flow.TaskGroup {
 		)
 
 		deployOperatingSystemConfig = g.Add(flow.Task{
-			Name: "Deploying OperatingSystemConfig for control plane machines",
-			Fn:   b.Shoot.Components.Extensions.OperatingSystemConfig.Deploy,
+			Name: "Deploying OperatingSystemConfig resources for worker pools",
+			Fn: func(ctx context.Context) error {
+				if b.isGardenadmBootstrap() {
+					return b.Shoot.Components.Extensions.OperatingSystemConfig.Deploy(ctx)
+				}
+				return b.DeployOperatingSystemConfig(ctx)
+			},
+			SkipIf: b.Shoot.IsWorkerless,
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Waiting until OperatingSystemConfig for control plane machines has been reconciled",
-			Fn:           b.Shoot.Components.Extensions.OperatingSystemConfig.Wait,
+			Name: "Waiting until OperatingSystemConfig for worker pools have been reconciled",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.Extensions.OperatingSystemConfig.Wait(ctx)
+			},
+			SkipIf:       b.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfig),
+		})
+		deleteStaleOperatingSystemConfigResources = g.Add(flow.Task{
+			Name: "Delete stale OperatingSystemConfig resources",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.Extensions.OperatingSystemConfig.DeleteStaleResources(ctx)
+			},
+			SkipIf:       b.Shoot.IsWorkerless || b.isGardenadmBootstrap(),
+			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfig),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Waiting until stale OperatingSystemConfig resources are deleted",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.Extensions.OperatingSystemConfig.WaitCleanupStaleResources(ctx)
+			},
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || skipReadiness || b.isGardenadmBootstrap(),
+			Dependencies: flow.NewTaskIDs(deleteStaleOperatingSystemConfigResources),
 		})
 	)
 
@@ -511,4 +535,8 @@ func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd boo
 	)
 
 	return g
+}
+
+func (b *Botanist) isGardenadmBootstrap() bool {
+	return b.Shoot.IsSelfHosted() && !b.Shoot.RunsControlPlane()
 }

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -131,6 +131,23 @@ func (b *Botanist) DefaultRuntimeGardenerResourceManager() (resourcemanager.Inte
 	})
 }
 
+// DeployRuntimeGardenerResourceManager deploys the runtime gardener-resource-manager
+func (b *Botanist) DeployRuntimeGardenerResourceManager(ctx context.Context) error {
+	return shared.DeployGardenerResourceManager(
+		ctx,
+		b.SeedClientSet.Client(),
+		b.Clock,
+		b.SecretsManager,
+		b.Shoot.Components.ControlPlane.RuntimeResourceManager,
+		v1beta1constants.GardenNamespace,
+		func(ctx context.Context) (int32, error) {
+			return b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameGardenerResourceManager, 2)
+		},
+		func() string { return b.Shoot.ComputeInClusterAPIServerAddress(true) },
+		b.Shoot.IsSelfHosted(),
+	)
+}
+
 // DeployGardenerResourceManager deploys the gardener-resource-manager
 func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 	return shared.DeployGardenerResourceManager(
@@ -143,7 +160,9 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 		func(ctx context.Context) (int32, error) {
 			return b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameGardenerResourceManager, 2)
 		},
-		func() string { return b.Shoot.ComputeInClusterAPIServerAddress(true) })
+		func() string { return b.Shoot.ComputeInClusterAPIServerAddress(true) },
+		b.Shoot.IsSelfHosted(),
+	)
 }
 
 // ScaleGardenerResourceManagerToOne scales the gardener-resource-manager deployment

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -1155,6 +1155,7 @@ func (r *Reconciler) deployVirtualGardenGardenerResourceManager(secretsManager s
 			func() string {
 				return operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer
 			},
+			false,
 		)
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> ✅ This PR depends on https://github.com/gardener/gardener/pull/15368 which must be merged first. Hence, it remains in draft state until then.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
With this PR, we integrate the flow task groups introduced in #15368 and #15311 into the flow for hosted shoots in `gardenlet`'s `Shoot` controller.

The next step is to continue this journey by moving more tasks into groups. Eventually, we would like to come up with one single flow that is executed for both hosted and self-hosted shoots (whilst some of the tasks/groups might be skipped if they are not applicable for the respective scenario).

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
