### PR TITLE
Update the docs for configuring feature gates in the local setup

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -87,15 +87,13 @@ ip6tables -t nat -A POSTROUTING -o $(ip route | grep '^default') -s fd00:10::/64
 
 ## Configure Feature Gates (Optional)
 
-You can optionally configure [feature gates](./feature_gates.md) on different components of your local Gardener deployment. The feature gates can be set by editing respective resource manifests before [setting up Gardener](#setting-up-gardener). They can also be configured dynamically on the running deployment by editing respective resources on the appropriate clusters. The files and the resources to edit for configuring feature gates on respective Gardener components are detailed in the table below.
+You can optionally configure [feature gates](./feature_gates.md) on different components of your local Gardener deployment. The feature gates can be set by editing respective resource manifests before [setting up Gardener](#setting-up-gardener). They can also be configured dynamically on the running deployment by editing respective resources on the appropriate clusters, or by running either `make gardener-up` or `make gardener-dev` after updating the `featureGates` configurations in respective files. The files and the resources to edit for configuring feature gates on respective Gardener components are detailed in the table below.
 
 | Gardener components | Resource manifests | Respective resources for dynamic configuration |
 | --- | --- | --- |
 | `gardener-operator` | [`charts/gardener/operator/values.yaml`](../../charts/gardener/operator/values.yaml) (`config.featureGates`) | N/A |
 | `gardenlet` | [`dev-setup/gardenlet/base/gardenlet.yaml`](../../dev-setup/gardenlet/base/gardenlet.yaml) |  `gardenlet` resource on the virtual garden cluster |
 | `gardener-apiserver` and `gardener-controller-manager` | [`dev-setup/garden/base/garden.yaml`](../../dev-setup/garden/base/garden.yaml) | `garden` resource on the runtime cluster |
-
-> To configure `gardener-operator` feature gates in the running local setup, run `make gardener-up` or `make gardener-dev` after updating the `featureGates` configuration in [`charts/gardener/operator/values.yaml`](../../charts/gardener/operator/values.yaml). This will restart the `gardener-operator` with the updated configuration.
 
 ## Setting Up Gardener
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -87,13 +87,13 @@ ip6tables -t nat -A POSTROUTING -o $(ip route | grep '^default') -s fd00:10::/64
 
 ## Configure Feature Gates (Optional)
 
-You can optionally configure [feature gates](./feature_gates.md) on different components of your local Gardener deployment. The feature gates can be set by editing respective resource manifests before [setting up Gardener](#setting-up-gardener). They can also be configured dynamically on the running deployment by editing respective resources on the appropriate clusters, or by running either `make gardener-up` or `make gardener-dev` after updating the `featureGates` configurations in respective files. The files and the resources to edit for configuring feature gates on respective Gardener components are detailed in the table below.
+You can optionally configure [feature gates](./feature_gates.md) on different components of your local Gardener deployment. The feature gates can be set by editing respective resource manifests before [setting up Gardener](#setting-up-gardener). They can also be configured dynamically on the running deployment by editing respective resources on the appropriate clusters, or by running relevant `make` targets after updating the `featureGates` configurations in respective files. The files, `make` targets and the resources to edit for configuring feature gates on respective Gardener components are detailed in the table below.
 
-| Gardener components | Resource manifests | Respective resources for dynamic configuration |
-| --- | --- | --- |
-| `gardener-operator` | [`charts/gardener/operator/values.yaml`](../../charts/gardener/operator/values.yaml) (`config.featureGates`) | N/A |
-| `gardenlet` | [`dev-setup/gardenlet/base/gardenlet.yaml`](../../dev-setup/gardenlet/base/gardenlet.yaml) |  `gardenlet` resource on the virtual garden cluster |
-| `gardener-apiserver` and `gardener-controller-manager` | [`dev-setup/garden/base/garden.yaml`](../../dev-setup/garden/base/garden.yaml) | `garden` resource on the runtime cluster |
+| Gardener components                                    | Resource manifests                                                                                                | Respective `make` targets      | Respective resources                               |
+|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|--------------------------------|----------------------------------------------------|
+| `gardener-operator`                                    | [`charts/gardener/operator/values.yaml` ]( ../../charts/gardener/operator/values.yaml ) ( `config.featureGates` ) | `operator-up` / `operator-dev` |  N/A                                               |
+| `gardener-apiserver` and `gardener-controller-manager` | [`dev-setup/garden/base/garden.yaml`](../../dev-setup/garden/base/garden.yaml)                                    | `garden-up`                    | `garden` resource on the runtime cluster           |
+| `gardenlet`                                            | [`dev-setup/gardenlet/base/gardenlet.yaml`](../../dev-setup/gardenlet/base/gardenlet.yaml)                        | `seed-up` / `seed-dev`         | `gardenlet` resource on the virtual garden cluster |
 
 ## Setting Up Gardener
 


### PR DESCRIPTION
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR adds the respective `make` targets for dynamically configuring feature gates for different Gardener components on a running local Gardener deployment.

**Which issue(s) this PR fixes**:
Follow up for https://github.com/gardener/gardener/pull/15412 
The PR was merged before [the suggestion](https://github.com/gardener/gardener/pull/15412#discussion_r3704114863) could be applied.

**Special notes for your reviewer**:
/cc @timebertt @RadaBDimitrova 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```