### PR TITLE
[release-v1.146] Automated cherry pick of #15204: [GEP-28] Do not regenerate the Shoot `.status.uid` during control plane Node restoration

### DIFF
--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -392,13 +392,19 @@ func initializeShootResource(resources gardenadm.Resources, fs afero.Afero, runs
 	shoot.Status.Gardener = gardencorev1beta1.Gardener{Name: "gardenadm", Version: version.Get().GitVersion}
 
 	if runsControlPlane {
-		// This UID is used to compute the name of the BackupEntry object. Persist the generated UID on the machine in case
-		// `gardenadm init` is retried/executed multiple times (otherwise, we'd always generate a new one).
-		uid, err := shootUID(fs)
-		if err != nil {
-			return fmt.Errorf("failed fetching shoot UID: %w", err)
+		// The Shoot UID determines the BackupBucket/BackupEntry names and thus the etcd backup location,
+		// so it must stay stable across invocations.
+		//
+		// - `gardenadm restore`: UID comes from the Shoot status exported by `gardenadm discover existing`; preserve it.
+		// - `gardenadm init`: no UID on the Shoot, so reuse the one persisted at /var/lib/gardenadm/shoot-uid,
+		//   or generate and persist a new one (keeps retries of `gardenadm init` idempotent).
+		if shoot.Status.UID == "" {
+			uid, err := shootUID(fs)
+			if err != nil {
+				return fmt.Errorf("failed fetching shoot UID: %w", err)
+			}
+			shoot.Status.UID = uid
 		}
-		shoot.Status.UID = uid
 
 		if v1beta1helper.HasManagedInfrastructure(resources.Shoot) && resources.ShootState == nil {
 			return fmt.Errorf("shoot has managed infrastructure, but ShootState is missing " +

--- a/pkg/gardenadm/botanist/botanist_test.go
+++ b/pkg/gardenadm/botanist/botanist_test.go
@@ -118,31 +118,55 @@ metadata:
 				Expect(b.Shoot.ControlPlaneNamespace).To(Equal("kube-system"))
 			})
 
-			It("should generate a UID for the shoot and write it to the host", func() {
-				fs := afero.NewMemMapFs()
-				DeferCleanup(test.WithVar(&NewFs, func() afero.Fs { return fs }))
+			When("the Shoot does not have status UID set", func() {
+				It("should generate a UID for the shoot and write it to the host", func() {
+					fs := afero.NewMemMapFs()
+					DeferCleanup(test.WithVar(&NewFs, func() afero.Fs { return fs }))
 
-				By("Generate new shoot UID and write it to the host")
-				b, err := NewGardenadmBotanistFromManifests(ctx, log, nil, configDir, true)
-				Expect(err).NotTo(HaveOccurred())
+					By("Generate new shoot UID and write it to the host")
+					b, err := NewGardenadmBotanistFromManifests(ctx, log, nil, configDir, true)
+					Expect(err).NotTo(HaveOccurred())
 
-				uid := b.Shoot.GetInfo().Status.UID
-				Expect(uid).NotTo(BeEmpty())
+					uid := b.Shoot.GetInfo().Status.UID
+					Expect(uid).NotTo(BeEmpty())
 
-				path := filepath.Join(string(filepath.Separator), "var", "lib", "gardenadm", "shoot-uid")
-				content, err := b.FS.ReadFile(path)
-				Expect(err).NotTo(HaveOccurred())
+					path := filepath.Join(string(filepath.Separator), "var", "lib", "gardenadm", "shoot-uid")
+					content, err := b.FS.ReadFile(path)
+					Expect(err).NotTo(HaveOccurred())
 
-				Expect(string(content)).To(Equal(string(uid)))
+					Expect(string(content)).To(Equal(string(uid)))
 
-				By("Do not regenerate shoot UID when file is present on host")
-				b, err = NewGardenadmBotanistFromManifests(ctx, log, nil, configDir, true)
-				Expect(err).NotTo(HaveOccurred())
+					By("Do not regenerate shoot UID when file is present on host")
+					b, err = NewGardenadmBotanistFromManifests(ctx, log, nil, configDir, true)
+					Expect(err).NotTo(HaveOccurred())
 
-				Expect(b.Shoot.GetInfo().Status.UID).To(Equal(uid))
-				content, err = b.FS.ReadFile(path)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(content)).To(Equal(string(uid)))
+					Expect(b.Shoot.GetInfo().Status.UID).To(Equal(uid))
+					content, err = b.FS.ReadFile(path)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(content)).To(Equal(string(uid)))
+				})
+			})
+
+			When("the Shoot has status UID set", func() {
+				It("should not overwrite the already set UID", func() {
+					const uid = "some-uid"
+					shootFile := fsys[configDir+"/shoot.yaml"]
+					shootFile.Data = append(shootFile.Data, []byte(`status:
+  uid: `+uid+`
+`)...)
+
+					fs := afero.NewMemMapFs()
+					DeferCleanup(test.WithVar(&NewFs, func() afero.Fs { return fs }))
+
+					By("Ensure the shoot UID is preserved")
+					b, err := NewGardenadmBotanistFromManifests(ctx, log, nil, configDir, true)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(string(b.Shoot.GetInfo().Status.UID)).To(Equal(uid))
+
+					path := filepath.Join(string(filepath.Separator), "var", "lib", "gardenadm", "shoot-uid")
+					Expect(b.FS.ReadFile(path)).Error().To(MatchError(os.IsNotExist, "IsNotExist"))
+				})
 			})
 		})
 


### PR DESCRIPTION
/kind enhancement
/area disaster-recovery
/area ipcei

Cherry pick of #15204 on release-v1.146.

#15204: [GEP-28] Do not regenerate the Shoot `.status.uid` during control plane Node restoration

**Release Notes:**
```other operator
NONE
```
