### PR TITLE
Exclude terminal pods from Deployment health check and garbage-collect them

### DIFF
--- a/pkg/utils/kubernetes/health/deployment.go
+++ b/pkg/utils/kubernetes/health/deployment.go
@@ -146,7 +146,7 @@ func DeploymentHasExactNumberOfPods(ctx context.Context, reader client.Reader, d
 
 	var numberOfRelevantPods int32
 	for _, pod := range podList.Items {
-		if !IsPodStale(pod.Status.Reason) && !IsPodCompleted(pod.Status.Conditions) && !IsPodDisrupted(pod.Status.Conditions) {
+		if !IsPodTerminal(pod.Status.Phase) && !IsPodStale(pod.Status.Reason) && !IsPodCompleted(pod.Status.Conditions) && !IsPodDisrupted(pod.Status.Conditions) {
 			numberOfRelevantPods++
 		}
 	}

--- a/pkg/utils/kubernetes/health/deployment_test.go
+++ b/pkg/utils/kubernetes/health/deployment_test.go
@@ -339,6 +339,23 @@ var _ = Describe("Deployment", func() {
 			Expect(ok).To(BeTrue())
 		})
 
+		It("should consider the deployment as updated even though there are still pods in a terminal phase", func() {
+			p1 := pod.DeepCopy()
+			p1.Status.Phase = corev1.PodFailed
+			Expect(fakeClient.Create(ctx, p1)).To(Succeed())
+
+			p2 := pod.DeepCopy()
+			p2.Status.Phase = corev1.PodSucceeded
+			Expect(fakeClient.Create(ctx, p2)).To(Succeed())
+
+			p3 := pod.DeepCopy()
+			Expect(fakeClient.Create(ctx, p3)).To(Succeed())
+
+			ok, err := health.DeploymentHasExactNumberOfPods(ctx, fakeClient, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
 		It("should consider the deployment as updated even though there are still disrupted pods", func() {
 			p1 := pod.DeepCopy()
 			p1.Status.Conditions = []corev1.PodCondition{{Type: "DisruptionTarget", Status: "True", Reason: "TerminationByKubelet"}}

--- a/pkg/utils/kubernetes/health/pod.go
+++ b/pkg/utils/kubernetes/health/pod.go
@@ -76,6 +76,12 @@ func IsPodDisrupted(conditions []corev1.PodCondition) bool {
 	})
 }
 
+// IsPodTerminal returns true when the pod is in a terminal phase (Succeeded or Failed), i.e. all of its containers
+// have terminated and will not be restarted.
+func IsPodTerminal(phase corev1.PodPhase) bool {
+	return phase == corev1.PodSucceeded || phase == corev1.PodFailed
+}
+
 // IsPodCompleted returns true when the pod ready condition indicates completeness.
 func IsPodCompleted(conditions []corev1.PodCondition) bool {
 	return slices.ContainsFunc(conditions, func(condition corev1.PodCondition) bool {

--- a/pkg/utils/kubernetes/health/pod_test.go
+++ b/pkg/utils/kubernetes/health/pod_test.go
@@ -73,4 +73,16 @@ var _ = Describe("Pod", func() {
 		Entry("Not completed", []corev1.PodCondition{{Type: "Ready", Status: "False", Reason: "Failed"}}, BeFalse()),
 		Entry("Completed", []corev1.PodCondition{{Type: "Ready", Status: "False", Reason: "PodCompleted"}}, BeTrue()),
 	)
+
+	DescribeTable("#IsPodTerminal",
+		func(phase corev1.PodPhase, matcher types.GomegaMatcher) {
+			Expect(health.IsPodTerminal(phase)).To(matcher)
+		},
+
+		Entry("Pending", corev1.PodPending, BeFalse()),
+		Entry("Running", corev1.PodRunning, BeFalse()),
+		Entry("Unknown", corev1.PodUnknown, BeFalse()),
+		Entry("Succeeded", corev1.PodSucceeded, BeTrue()),
+		Entry("Failed", corev1.PodFailed, BeTrue()),
+	)
 })

--- a/pkg/utils/kubernetes/pod.go
+++ b/pkg/utils/kubernetes/pod.go
@@ -236,7 +236,7 @@ func DeleteStalePods(ctx context.Context, log logr.Logger, c client.Client, pods
 // `.spec.ttlSecondsAfterFinished`).
 func isTerminalReplicaSetOwnedPod(pod *corev1.Pod) bool {
 	controller := metav1.GetControllerOf(pod)
-	return health.IsPodTerminal(pod.Status.Phase) && controller != nil && controller.Kind == "ReplicaSet"
+	return health.IsPodTerminal(pod.Status.Phase) && controller != nil && controller.Kind == "ReplicaSet" && controller.APIVersion == appsv1.SchemeGroupVersion.String()
 }
 
 // shouldObjectBeRemoved determines whether the given object should be gone now.

--- a/pkg/utils/kubernetes/pod.go
+++ b/pkg/utils/kubernetes/pod.go
@@ -216,8 +216,8 @@ func DeleteStalePods(ctx context.Context, log logr.Logger, c client.Client, pods
 			continue
 		}
 
-		if health.IsPodStale(pod.Status.Reason) || health.IsPodDisrupted(pod.Status.Conditions) {
-			logger.V(1).Info("Deleting stale or disrupted pod", "reason", pod.Status.Reason)
+		if health.IsPodStale(pod.Status.Reason) || health.IsPodDisrupted(pod.Status.Conditions) || isTerminalReplicaSetOwnedPod(&pod) {
+			logger.V(1).Info("Deleting stale, disrupted, or terminal pod", "phase", pod.Status.Phase, "reason", pod.Status.Reason)
 			if err := c.Delete(ctx, &pod); client.IgnoreNotFound(err) != nil {
 				result = multierror.Append(result, err)
 			}
@@ -225,6 +225,18 @@ func DeleteStalePods(ctx context.Context, log logr.Logger, c client.Client, pods
 	}
 
 	return result
+}
+
+// isTerminalReplicaSetOwnedPod returns true for pods in a terminal phase (Succeeded or Failed) which are controlled by
+// a ReplicaSet. Such pods have already been replaced by their ReplicaSet (the ReplicaSet controller only counts active
+// pods towards its desired replicas), but they are only garbage-collected by the kube-controller-manager once the
+// number of terminated pods exceeds `--terminated-pod-gc-threshold` (default `12500`) - in clusters with few terminated
+// pods, this threshold is never reached, so such pods linger indefinitely. Pods controlled by other owners (e.g., Jobs)
+// are not considered because their terminal pods are managed by their respective controllers (e.g., via the Job's
+// `.spec.ttlSecondsAfterFinished`).
+func isTerminalReplicaSetOwnedPod(pod *corev1.Pod) bool {
+	controller := metav1.GetControllerOf(pod)
+	return health.IsPodTerminal(pod.Status.Phase) && controller != nil && controller.Kind == "ReplicaSet"
 }
 
 // shouldObjectBeRemoved determines whether the given object should be gone now.

--- a/pkg/utils/kubernetes/pod_test.go
+++ b/pkg/utils/kubernetes/pod_test.go
@@ -456,7 +456,7 @@ var _ = Describe("Pod Utils", func() {
 				preemptedPod = &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{Name: "preempted", Namespace: "default"},
 					Status: corev1.PodStatus{
-						Phase: "Succeeded",
+						Phase: corev1.PodSucceeded,
 						Conditions: []corev1.PodCondition{
 							{Type: "DisruptionTarget", Status: "True", Reason: "TerminationByKubelet"},
 						},
@@ -470,7 +470,7 @@ var _ = Describe("Pod Utils", func() {
 							{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "foo", Controller: new(true)},
 						},
 					},
-					Status: corev1.PodStatus{Phase: "Failed"},
+					Status: corev1.PodStatus{Phase: corev1.PodFailed},
 				}
 				succeededReplicaSetPod = &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -480,7 +480,7 @@ var _ = Describe("Pod Utils", func() {
 							{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "foo", Controller: new(true)},
 						},
 					},
-					Status: corev1.PodStatus{Phase: "Succeeded"},
+					Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
 				}
 				failedJobPod = &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -490,7 +490,7 @@ var _ = Describe("Pod Utils", func() {
 							{APIVersion: "batch/v1", Kind: "Job", Name: "foo", Controller: new(true)},
 						},
 					},
-					Status: corev1.PodStatus{Phase: "Failed"},
+					Status: corev1.PodStatus{Phase: corev1.PodFailed},
 				}
 				pods = []corev1.Pod{*normalPod, *stalePod, *preemptedPod, *failedReplicaSetPod, *succeededReplicaSetPod, *failedJobPod}
 				// There is no good way with the fake client to test the deletion of the pods stuck in termination

--- a/pkg/utils/kubernetes/pod_test.go
+++ b/pkg/utils/kubernetes/pod_test.go
@@ -27,7 +27,6 @@ import (
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	fakerestclient "k8s.io/client-go/rest/fake"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -468,7 +467,7 @@ var _ = Describe("Pod Utils", func() {
 						Name:      "failed-replicaset-owned",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "foo", Controller: ptr.To(true)},
+							{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "foo", Controller: new(true)},
 						},
 					},
 					Status: corev1.PodStatus{Phase: "Failed"},
@@ -478,7 +477,7 @@ var _ = Describe("Pod Utils", func() {
 						Name:      "succeeded-replicaset-owned",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "foo", Controller: ptr.To(true)},
+							{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "foo", Controller: new(true)},
 						},
 					},
 					Status: corev1.PodStatus{Phase: "Succeeded"},
@@ -488,7 +487,7 @@ var _ = Describe("Pod Utils", func() {
 						Name:      "failed-job-owned",
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
-							{APIVersion: "batch/v1", Kind: "Job", Name: "foo", Controller: ptr.To(true)},
+							{APIVersion: "batch/v1", Kind: "Job", Name: "foo", Controller: new(true)},
 						},
 					},
 					Status: corev1.PodStatus{Phase: "Failed"},

--- a/pkg/utils/kubernetes/pod_test.go
+++ b/pkg/utils/kubernetes/pod_test.go
@@ -27,6 +27,7 @@ import (
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	fakerestclient "k8s.io/client-go/rest/fake"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -462,7 +463,37 @@ var _ = Describe("Pod Utils", func() {
 						},
 					},
 				}
-				pods = []corev1.Pod{*normalPod, *stalePod, *preemptedPod}
+				failedReplicaSetPod = &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "failed-replicaset-owned",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "foo", Controller: ptr.To(true)},
+						},
+					},
+					Status: corev1.PodStatus{Phase: "Failed"},
+				}
+				succeededReplicaSetPod = &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "succeeded-replicaset-owned",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "foo", Controller: ptr.To(true)},
+						},
+					},
+					Status: corev1.PodStatus{Phase: "Succeeded"},
+				}
+				failedJobPod = &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "failed-job-owned",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{APIVersion: "batch/v1", Kind: "Job", Name: "foo", Controller: ptr.To(true)},
+						},
+					},
+					Status: corev1.PodStatus{Phase: "Failed"},
+				}
+				pods = []corev1.Pod{*normalPod, *stalePod, *preemptedPod, *failedReplicaSetPod, *succeededReplicaSetPod, *failedJobPod}
 				// There is no good way with the fake client to test the deletion of the pods stuck in termination
 				// We'd have to use a mock client, but we actually want to avoid its usage.
 			)
@@ -470,12 +501,18 @@ var _ = Describe("Pod Utils", func() {
 			Expect(fakeClient.Create(ctx, normalPod)).To(Succeed())
 			Expect(fakeClient.Create(ctx, stalePod)).To(Succeed())
 			Expect(fakeClient.Create(ctx, preemptedPod)).To(Succeed())
+			Expect(fakeClient.Create(ctx, failedReplicaSetPod)).To(Succeed())
+			Expect(fakeClient.Create(ctx, succeededReplicaSetPod)).To(Succeed())
+			Expect(fakeClient.Create(ctx, failedJobPod)).To(Succeed())
 
 			Expect(DeleteStalePods(ctx, logr.Discard(), fakeClient, pods)).To(Succeed())
 
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(normalPod), &corev1.Pod{})).To(Succeed())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(stalePod), &corev1.Pod{})).To(BeNotFoundError())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(preemptedPod), &corev1.Pod{})).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(failedReplicaSetPod), &corev1.Pod{})).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(succeededReplicaSetPod), &corev1.Pod{})).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(failedJobPod), &corev1.Pod{})).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind bug

**What this PR does / why we need it**:

`Deployment`s whose pods end up in a terminal phase (`Failed`/`Succeeded`) with an empty `.status.reason` — e.g. a leader-election-based controller (`csi-snapshot-controller`, `vpa-updater`) that loses its lease during a brief kube-apiserver connectivity disruption and exits non-zero — are reported as progressing forever by `DeploymentHasExactNumberOfPods` (`there are still non-terminated old pods`), even though the `ReplicaSet` has long created a healthy replacement and the `Deployment` is fully rolled out and `Available`.

Such pods slip through all three existing filters:
- `IsPodStale` — no `Evicted`/`OutOf*`/`NodeAffinity`/`NodeLost`/`Preempting` reason (the pod-level reason is empty for a plain container exit),
- `IsPodCompleted` — no `PodCompleted` ready-condition reason,
- `IsPodDisrupted` — no `DisruptionTarget` condition.

They are also never garbage-collected: the kube-controller-manager's terminated-pod GC only acts above `--terminated-pod-gc-threshold` (default 12500), which clusters with few terminated pods never reach, and gardenlet's `DeleteStalePods` does not match them either. The result is a permanent false `ResourcesProgressing=True` on the owning `ManagedResource` (and, on seeds, a permanent `ControlPlaneHealthy=False` for hosted shoots) until the dead pod is deleted manually.

This PR closes the gap in both places, following the same pattern as #10548 (`Completed` pods, fixes #10476) and #14519 (preempted/disrupted pods, fixes #14518):

1. `DeploymentHasExactNumberOfPods` no longer counts pods in a terminal phase (new helper `health.IsPodTerminal`). This mirrors the upstream ReplicaSet controller, which excludes `Succeeded`/`Failed` pods from its active-pod count (`kubernetes/pkg/controller/controller_utils.go`, `IsPodActive`) — so Gardener's view of "fully rolled out" now matches the controller that actually manages the pods.
2. `DeleteStalePods` (gardenlet seed/shoot care garbage collection) now also deletes terminal-phase pods that are **controlled by a `ReplicaSet`**. These pods have already been replaced by their `ReplicaSet` and serve no purpose. Pods controlled by other owners (e.g. `Job`s) are deliberately not touched — their terminal pods are managed by their own controllers (e.g. via `.spec.ttlSecondsAfterFinished`), and deleting them would discard logs/history users may rely on.

**Which issue(s) this PR fixes**:
Fixes #15425

**Special notes for your reviewer**:

- Related prior art: #10476 / #10548 (Completed pods), #14518 / #14519 (preempted and disrupted pods). This is the same symptom class; the remaining unhandled case is a terminal-phase pod from a plain non-zero container exit.
- The `DeleteStalePods` change is scoped to `ReplicaSet`-controlled pods on purpose; see reasoning above.

**Release note**:
```bugfix operator
Deployments are no longer considered `progressing` due to lingering pods in a terminal phase (e.g. a pod that exited non-zero after losing leader election and was already replaced by its `ReplicaSet`). The Gardenlet garbage collection now also cleans up such terminal pods when they are controlled by a `ReplicaSet`, so affected `ManagedResource`s and shoot `ControlPlaneHealthy` conditions self-heal instead of requiring manual pod deletion.
```
