### PR TITLE
Wait for `kube-root-ca.crt` `ConfigMap`s to contain the new CA bundle before rolling workers

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -218,6 +218,10 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 	var (
 		deployExtensionAfterKAPIMsg = "Deploying extension resources after kube-apiserver"
 		waitExtensionAfterKAPIMsg   = "Waiting until extension resources handled after kube-apiserver are ready"
+
+		rotationPreparingPhases = sets.New(gardencorev1beta1.RotationPreparing, gardencorev1beta1.RotationPreparingWithoutWorkersRollout)
+		caRotationPreparing     = rotationPreparingPhases.Has(v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials))
+		saKeyRotationPreparing  = rotationPreparingPhases.Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials))
 	)
 	if b.Shoot.HibernationEnabled {
 		deployExtensionAfterKAPIMsg = "Hibernating extension resources before kube-apiserver hibernation"
@@ -606,12 +610,11 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 			Fn:           flow.TaskFn(b.DeployKubeControllerManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilGardenerResourceManagerReady),
 		})
+
 		waitUntilKubeControllerManagerReady = g.Add(flow.Task{
-			Name: "Waiting until kube-controller-manager reports readiness",
-			Fn:   b.Shoot.Components.ControlPlane.KubeControllerManager.Wait,
-			SkipIf: flowCtx.skipReadiness ||
-				(!sets.New(gardencorev1beta1.RotationPreparing, gardencorev1beta1.RotationPreparingWithoutWorkersRollout).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)) &&
-					!sets.New(gardencorev1beta1.RotationPreparing, gardencorev1beta1.RotationPreparingWithoutWorkersRollout).Has(v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials))),
+			Name:         "Waiting until kube-controller-manager reports readiness",
+			Fn:           b.Shoot.Components.ControlPlane.KubeControllerManager.Wait,
+			SkipIf:       flowCtx.skipReadiness || (!saKeyRotationPreparing && !caRotationPreparing),
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager),
 		})
 		createNewServiceAccountSecrets = g.Add(flow.Task{
@@ -619,10 +622,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.CreateNewServiceAccountSecrets(ctx, b.Logger, b.ShootClientSet.Client(), b.SecretsManager)
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf: !sets.New(
-				gardencorev1beta1.RotationPreparing,
-				gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
-			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)),
+			SkipIf:       !saKeyRotationPreparing,
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilKubeControllerManagerReady),
 		})
 		_ = g.Add(flow.Task{
@@ -634,12 +634,9 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilKubeControllerManagerReady),
 		})
 		waitUntilKubeRootCAConfigMapsUpdated = g.Add(flow.Task{
-			Name: "Waiting until kube-root-ca.crt ConfigMaps have been updated with new CA bundle",
-			Fn:   flow.TaskFn(b.WaitUntilKubeRootCAConfigMapsUpdated).RetryUntilTimeout(30*time.Second, 5*time.Minute),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness || !sets.New(
-				gardencorev1beta1.RotationPreparing,
-				gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
-			).Has(v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials)),
+			Name:         "Waiting until kube-root-ca.crt ConfigMaps have been updated with new CA bundle",
+			Fn:           flow.TaskFn(b.WaitUntilKubeRootCAConfigMapsUpdated).RetryUntilTimeout(30*time.Second, 5*time.Minute),
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness || !caRotationPreparing,
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilKubeControllerManagerReady),
 		})
 		deleteBastions = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -609,10 +609,9 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 		waitUntilKubeControllerManagerReady = g.Add(flow.Task{
 			Name: "Waiting until kube-controller-manager reports readiness",
 			Fn:   b.Shoot.Components.ControlPlane.KubeControllerManager.Wait,
-			SkipIf: flowCtx.skipReadiness || !sets.New(
-				gardencorev1beta1.RotationPreparing,
-				gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
-			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)),
+			SkipIf: flowCtx.skipReadiness ||
+				(!sets.New(gardencorev1beta1.RotationPreparing, gardencorev1beta1.RotationPreparingWithoutWorkersRollout).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)) &&
+					!sets.New(gardencorev1beta1.RotationPreparing, gardencorev1beta1.RotationPreparingWithoutWorkersRollout).Has(v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials))),
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager),
 		})
 		createNewServiceAccountSecrets = g.Add(flow.Task{
@@ -632,6 +631,15 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 				return secretsrotation.DeleteOldServiceAccountSecrets(ctx, b.Logger, b.ShootClientSet.Client(), b.Shoot.GetInfo().Status.Credentials.Rotation.ServiceAccountKey.LastInitiationFinishedTime.Time)
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
 			SkipIf:       v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting,
+			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilKubeControllerManagerReady),
+		})
+		waitUntilKubeRootCAConfigMapsUpdated = g.Add(flow.Task{
+			Name: "Waiting until kube-root-ca.crt ConfigMaps have been updated with new CA bundle",
+			Fn:   flow.TaskFn(b.WaitUntilKubeRootCAConfigMapsUpdated).RetryUntilTimeout(30*time.Second, 5*time.Minute),
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness || !sets.New(
+				gardencorev1beta1.RotationPreparing,
+				gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
+			).Has(v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials)),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilKubeControllerManagerReady),
 		})
 		deleteBastions = g.Add(flow.Task{
@@ -869,7 +877,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 			Name:         "Configuring shoot worker pools",
 			Fn:           flow.TaskFn(b.DeployWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(deployMachineControllerManager, deployShootSystemResources),
+			Dependencies: flow.NewTaskIDs(deployMachineControllerManager, deployShootSystemResources, waitUntilKubeRootCAConfigMapsUpdated),
 		})
 		waitUntilWorkerStatusUpdate = g.Add(flow.Task{
 			Name: "Waiting until worker resource status is updated with latest machine deployments",

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
@@ -112,13 +112,13 @@ func (b *Botanist) WaitUntilKubeRootCAConfigMapsUpdated(ctx context.Context) err
 
 	for _, configMap := range configMapList.Items {
 		taskFns = append(taskFns, func(ctx context.Context) error {
-			if err := limiter.Wait(ctx); err != nil {
-				return fmt.Errorf("error while waiting for limiter: %w", err)
-			}
-
 			if caBundleInConfigMap, ok := configMap.Data[secretsutils.DataKeyCertificateCA]; !ok || !bytes.Equal([]byte(caBundleInConfigMap), caBundleSecret.Data[secretsutils.DataKeyCertificateBundle]) {
 				notReady.Add(1)
 				return nil
+			}
+
+			if err := limiter.Wait(ctx); err != nil {
+				return fmt.Errorf("error while waiting for limiter: %w", err)
 			}
 
 			patch := client.MergeFrom(configMap.DeepCopy())

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager.go
@@ -5,16 +5,29 @@
 package botanist
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"sync/atomic"
 
+	"golang.org/x/time/rate"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	kubecontrollermanager "github.com/gardener/gardener/pkg/component/kubernetes/controllermanager"
 	"github.com/gardener/gardener/pkg/component/shared"
+	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
+
+const kubeRootCAConfigMapUpdateQPS = 100
 
 // DefaultKubeControllerManager returns a deployer for the kube-controller-manager.
 func (b *Botanist) DefaultKubeControllerManager() (kubecontrollermanager.Interface, error) {
@@ -65,4 +78,61 @@ func (b *Botanist) WaitForKubeControllerManagerToBeActive(ctx context.Context) e
 // ScaleKubeControllerManagerToOne scales kube-controller-manager replicas to one.
 func (b *Botanist) ScaleKubeControllerManagerToOne(ctx context.Context) error {
 	return kubernetesutils.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.ControlPlaneNamespace, Name: v1beta1constants.DeploymentNameKubeControllerManager}, 1)
+}
+
+// WaitUntilKubeRootCAConfigMapsUpdated verifies that all kube-root-ca.crt ConfigMaps in all namespaces of the shoot
+// cluster contain the CA bundle published by kube-controller-manager. It labels each confirmed ConfigMap with
+// credentials.gardener.cloud/ca-bundle-name so that retries skip already-verified ConfigMaps. This should only be
+// called during the 'Preparing' phase of the CA rotation operation, after kube-controller-manager is ready.
+func (b *Botanist) WaitUntilKubeRootCAConfigMapsUpdated(ctx context.Context) error {
+	caBundleSecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameCACluster)
+	if !found {
+		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
+	}
+
+	configMapList := &corev1.ConfigMapList{}
+	if err := b.ShootClientSet.Client().List(ctx, configMapList,
+		client.MatchingFields{"metadata.name": "kube-root-ca.crt"},
+		client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(utils.MustNewRequirement(secretsrotation.LabelKeyCABundleName, selection.NotEquals, caBundleSecret.Name))},
+	); err != nil {
+		return fmt.Errorf("failed listing kube-root-ca.crt ConfigMaps with outdated CA bundle: %w", err)
+	}
+
+	if len(configMapList.Items) == 0 {
+		return nil
+	}
+
+	b.Logger.Info("Found kube-root-ca.crt ConfigMaps not yet confirmed to contain the new CA bundle", "number", len(configMapList.Items))
+
+	var (
+		limiter  = rate.NewLimiter(rate.Limit(kubeRootCAConfigMapUpdateQPS), kubeRootCAConfigMapUpdateQPS)
+		notReady atomic.Int32
+		taskFns  []flow.TaskFn
+	)
+
+	for _, configMap := range configMapList.Items {
+		taskFns = append(taskFns, func(ctx context.Context) error {
+			if err := limiter.Wait(ctx); err != nil {
+				return fmt.Errorf("error while waiting for limiter: %w", err)
+			}
+
+			if caBundleInConfigMap, ok := configMap.Data[secretsutils.DataKeyCertificateCA]; !ok || !bytes.Equal([]byte(caBundleInConfigMap), caBundleSecret.Data[secretsutils.DataKeyCertificateBundle]) {
+				notReady.Add(1)
+				return nil
+			}
+
+			patch := client.MergeFrom(configMap.DeepCopy())
+			metav1.SetMetaDataLabel(&configMap.ObjectMeta, secretsrotation.LabelKeyCABundleName, caBundleSecret.Name)
+			return b.ShootClientSet.Client().Patch(ctx, &configMap, patch)
+		})
+	}
+
+	if err := flow.Parallel(taskFns...)(ctx); err != nil {
+		return fmt.Errorf("error while ensuring kube-root-ca.crt ConfigMaps are updated: %w", err)
+	}
+
+	if n := notReady.Load(); n > 0 {
+		return fmt.Errorf("%d kube-root-ca.crt ConfigMap(s) do not yet contain the expected CA bundle", n)
+	}
+	return nil
 }

--- a/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/gardenlet/operation/botanist/kubecontrollermanager_test.go
@@ -16,12 +16,14 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
@@ -31,6 +33,10 @@ import (
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	secretsrotation "github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 )
 
 var _ = Describe("KubeControllerManager", func() {
@@ -316,6 +322,118 @@ var _ = Describe("KubeControllerManager", func() {
 			}).Build()
 			botanist.SeedClientSet = fakekubernetes.NewClientSetBuilder().WithClient(fakeClientWithErr).Build()
 			Expect(botanist.ScaleKubeControllerManagerToOne(ctx)).To(MatchError(fakeErr))
+		})
+	})
+
+	Describe("#WaitUntilKubeRootCAConfigMapsUpdated", func() {
+		var (
+			runtimeClient      client.Client
+			shootClient        client.Client
+			fakeSecretsManager secretsmanager.Interface
+
+			kubeAPIServerNamespace = "shoot--foo--bar"
+			bundleContent          = []byte("-----BEGIN CERTIFICATE-----\nMIIBundleCA\n-----END CERTIFICATE-----\n")
+		)
+
+		BeforeEach(func() {
+			runtimeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+			shootClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.ShootScheme).WithIndex(&corev1.ConfigMap{}, "metadata.name", func(obj client.Object) []string {
+				return []string{obj.GetName()}
+			}).Build()
+			fakeSecretsManager = fakesecretsmanager.New(runtimeClient, kubeAPIServerNamespace)
+
+			botanist.Logger = logr.Discard()
+			botanist.SecretsManager = fakeSecretsManager
+			botanist.ShootClientSet = fakekubernetes.NewClientSetBuilder().WithClient(shootClient).Build()
+
+			Expect(runtimeClient.Create(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta1constants.SecretNameCACluster,
+					Namespace: kubeAPIServerNamespace,
+				},
+				Data: map[string][]byte{
+					secretsutils.DataKeyCertificateBundle: bundleContent,
+				},
+			})).To(Succeed())
+		})
+
+		It("should succeed immediately when there are no ConfigMaps", func() {
+			Expect(botanist.WaitUntilKubeRootCAConfigMapsUpdated(ctx)).To(Succeed())
+		})
+
+		It("should succeed immediately when all kube-root-ca.crt ConfigMaps are already labeled", func() {
+			Expect(shootClient.Create(ctx, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-root-ca.crt",
+					Namespace: "ns1",
+					Labels:    map[string]string{secretsrotation.LabelKeyCABundleName: v1beta1constants.SecretNameCACluster},
+				},
+				Data: map[string]string{secretsutils.DataKeyCertificateCA: string(bundleContent)},
+			})).To(Succeed())
+
+			Expect(botanist.WaitUntilKubeRootCAConfigMapsUpdated(ctx)).To(Succeed())
+		})
+
+		It("should label ConfigMaps that contain the expected bundle", func() {
+			cm1 := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "kube-root-ca.crt", Namespace: "ns1"},
+				Data:       map[string]string{secretsutils.DataKeyCertificateCA: string(bundleContent)},
+			}
+			Expect(shootClient.Create(ctx, cm1)).To(Succeed())
+
+			Expect(botanist.WaitUntilKubeRootCAConfigMapsUpdated(ctx)).To(Succeed())
+
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(cm1), cm1)).To(Succeed())
+			Expect(cm1.Labels).To(HaveKeyWithValue(secretsrotation.LabelKeyCABundleName, v1beta1constants.SecretNameCACluster))
+		})
+
+		It("should return an error when a ConfigMap has no ca.crt data", func() {
+			Expect(shootClient.Create(ctx, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "kube-root-ca.crt", Namespace: "ns1"},
+			})).To(Succeed())
+
+			Expect(botanist.WaitUntilKubeRootCAConfigMapsUpdated(ctx)).To(MatchError(ContainSubstring("1 kube-root-ca.crt ConfigMap(s) do not yet contain the expected CA bundle")))
+		})
+
+		It("should return an error when a ConfigMap does not contain the expected bundle", func() {
+			Expect(shootClient.Create(ctx, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "kube-root-ca.crt", Namespace: "ns1"},
+				Data:       map[string]string{secretsutils.DataKeyCertificateCA: "old-ca-only"},
+			})).To(Succeed())
+
+			Expect(botanist.WaitUntilKubeRootCAConfigMapsUpdated(ctx)).To(MatchError(ContainSubstring("1 kube-root-ca.crt ConfigMap(s) do not yet contain the expected CA bundle")))
+		})
+
+		It("should only process unlabeled ConfigMaps and ignore non-kube-root-ca.crt ConfigMaps", func() {
+			cmLabeled := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-root-ca.crt",
+					Namespace: "ns1",
+					Labels:    map[string]string{secretsrotation.LabelKeyCABundleName: v1beta1constants.SecretNameCACluster},
+				},
+				Data: map[string]string{secretsutils.DataKeyCertificateCA: string(bundleContent)},
+			}
+			cmUnlabeled := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "kube-root-ca.crt", Namespace: "ns2"},
+				Data:       map[string]string{secretsutils.DataKeyCertificateCA: string(bundleContent)},
+			}
+			cmOtherName := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-other-configmap", Namespace: "ns3"},
+			}
+			Expect(shootClient.Create(ctx, cmLabeled)).To(Succeed())
+			Expect(shootClient.Create(ctx, cmUnlabeled)).To(Succeed())
+			Expect(shootClient.Create(ctx, cmOtherName)).To(Succeed())
+
+			Expect(botanist.WaitUntilKubeRootCAConfigMapsUpdated(ctx)).To(Succeed())
+
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(cmLabeled), cmLabeled)).To(Succeed())
+			Expect(cmLabeled.Labels).To(HaveKeyWithValue(secretsrotation.LabelKeyCABundleName, v1beta1constants.SecretNameCACluster))
+
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(cmUnlabeled), cmUnlabeled)).To(Succeed())
+			Expect(cmUnlabeled.Labels).To(HaveKeyWithValue(secretsrotation.LabelKeyCABundleName, v1beta1constants.SecretNameCACluster))
+
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(cmOtherName), cmOtherName)).To(Succeed())
+			Expect(cmOtherName.Labels).NotTo(HaveKey(secretsrotation.LabelKeyCABundleName))
 		})
 	})
 })

--- a/pkg/utils/gardener/secretsrotation/constants.go
+++ b/pkg/utils/gardener/secretsrotation/constants.go
@@ -13,6 +13,10 @@ const (
 	// AnnotationKeyEtcdSnapshotted is an annotation indicating that ETCD snapshot was completed
 	AnnotationKeyEtcdSnapshotted = "credentials.gardener.cloud/etcd-snapshotted"
 
+	// LabelKeyCABundleName is a label key used to mark kube-root-ca.crt ConfigMaps that have already been confirmed
+	// to contain a specific CA bundle. The label value is the name of the CA bundle secret.
+	LabelKeyCABundleName = "credentials.gardener.cloud/ca-bundle-name"
+
 	labelKeyRotationKeyName = "credentials.gardener.cloud/key-name"
 	rotationQPS             = 100
 )


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:

During the `RotationPreparing` phase of CA rotation, `kube-controller-manager`'s `RootCACertificatePublisherController` must propagate the new CA bundle to the `kube-root-ca.crt` `ConfigMap` in every namespace before worker pools roll. Nodes that join before the `ConfigMap`s are updated only receive the old CA, which becomes invalid after rotation completes and breaks service account token validation.

A new `WaitUntilKubeRootCAConfigMapsUpdated` flow task blocks `deployWorker` until all `kube-root-ca.crt` `ConfigMap`s are confirmed to contain the expected bundle. Confirmed `ConfigMap`s are labeled with `credentials.gardener.cloud/ca-bundle-name=<bundle-secret-name>` so retries skip already-verified ones. Note that `RootCACertificatePublisherController` runs with only a [single worker](https://github.com/kubernetes/kubernetes/blob/0e5f0f9374ca822d0a5619088d4a00f335b8bafd/cmd/kube-controller-manager/app/certificates.go#L275-L287), so propagation can be slow in clusters with many namespaces or `ConfigMap` admission webhooks — hence the 5-minute retry window.

**Which issue(s) this PR fixes**:
Fixes #15301

**Special notes for your reviewer**:

**Release note**:
```bugfix user
Worker nodes no longer risk joining the cluster with a stale CA during `RotationPreparing` — the gardenlet now waits until all `kube-root-ca.crt` `ConfigMap`s contain the new CA bundle before rolling worker pools.
```