### PR TITLE
Enable default revive rules with a golangci-lint linter (revive)

### DIFF
--- a/.golangci.yaml.in
+++ b/.golangci.yaml.in
@@ -259,13 +259,10 @@ linters:
     misspell:
       mode: restricted # only check comments
     revive:
+      enable-default-rules: true
       rules:
-        - name: context-as-argument
         - name: duplicated-imports
         - name: early-return
-        - name: exported
-        - name: unreachable-code
-        - name: unused-parameter
     custom:
       logcheck:
         path: <<LOGCHECK_PLUGIN_PATH>>/logcheck.so

--- a/extensions/pkg/webhook/cloudprovider/mock/mocks.go
+++ b/extensions/pkg/webhook/cloudprovider/mock/mocks.go
@@ -43,15 +43,15 @@ func (m *MockEnsurer) EXPECT() *MockEnsurerMockRecorder {
 }
 
 // EnsureCloudProviderSecret mocks base method.
-func (m *MockEnsurer) EnsureCloudProviderSecret(ctx context.Context, gctx context0.GardenContext, new, old *v1.Secret) error {
+func (m *MockEnsurer) EnsureCloudProviderSecret(ctx context.Context, gctx context0.GardenContext, newSecret, oldSecret *v1.Secret) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureCloudProviderSecret", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureCloudProviderSecret", ctx, gctx, newSecret, oldSecret)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureCloudProviderSecret indicates an expected call of EnsureCloudProviderSecret.
-func (mr *MockEnsurerMockRecorder) EnsureCloudProviderSecret(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureCloudProviderSecret(ctx, gctx, newSecret, oldSecret any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureCloudProviderSecret", reflect.TypeOf((*MockEnsurer)(nil).EnsureCloudProviderSecret), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureCloudProviderSecret", reflect.TypeOf((*MockEnsurer)(nil).EnsureCloudProviderSecret), ctx, gctx, newSecret, oldSecret)
 }

--- a/extensions/pkg/webhook/cloudprovider/mutator.go
+++ b/extensions/pkg/webhook/cloudprovider/mutator.go
@@ -20,7 +20,7 @@ import (
 
 // Ensurer ensures that the cloudprovider secret conforms to the provider requirements.
 type Ensurer interface {
-	EnsureCloudProviderSecret(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *corev1.Secret) error
+	EnsureCloudProviderSecret(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newSecret, oldSecret *corev1.Secret) error
 }
 
 // NewMutator creates a new cloudprovider mutator.
@@ -39,12 +39,12 @@ type mutator struct {
 }
 
 // Mutate validates and if needed mutates the given object.
-func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
-	if new.GetDeletionTimestamp() != nil {
+func (m *mutator) Mutate(ctx context.Context, newObj, oldObj client.Object) error {
+	if newObj.GetDeletionTimestamp() != nil {
 		return nil
 	}
 
-	newSecret, ok := new.(*corev1.Secret)
+	newSecret, ok := newObj.(*corev1.Secret)
 	if !ok {
 		return fmt.Errorf("could not mutate: object is not of type %q", "Secret")
 	}
@@ -53,14 +53,14 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 	}
 
 	var oldSecret *corev1.Secret
-	if old != nil {
-		oldSecret, ok = old.(*corev1.Secret)
+	if oldObj != nil {
+		oldSecret, ok = oldObj.(*corev1.Secret)
 		if !ok {
 			return fmt.Errorf("could not mutate: old object could not be casted to type %q", "Secret")
 		}
 	}
 
-	etcx := extensionscontextwebhook.NewGardenContext(m.client, new)
+	etcx := extensionscontextwebhook.NewGardenContext(m.client, newObj)
 	webhook.LogMutation(m.logger, newSecret.Kind, newSecret.Namespace, newSecret.Name)
 	return m.ensurer.EnsureCloudProviderSecret(ctx, etcx, newSecret, oldSecret)
 }

--- a/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
@@ -49,157 +49,157 @@ func (m *MockEnsurer) EXPECT() *MockEnsurerMockRecorder {
 }
 
 // EnsureAdditionalFiles mocks base method.
-func (m *MockEnsurer) EnsureAdditionalFiles(ctx context.Context, gctx context0.GardenContext, new, old *[]v1alpha10.File) error {
+func (m *MockEnsurer) EnsureAdditionalFiles(ctx context.Context, gctx context0.GardenContext, newFiles, oldFiles *[]v1alpha10.File) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureAdditionalFiles", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureAdditionalFiles", ctx, gctx, newFiles, oldFiles)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureAdditionalFiles indicates an expected call of EnsureAdditionalFiles.
-func (mr *MockEnsurerMockRecorder) EnsureAdditionalFiles(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureAdditionalFiles(ctx, gctx, newFiles, oldFiles any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalFiles", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalFiles), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalFiles", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalFiles), ctx, gctx, newFiles, oldFiles)
 }
 
 // EnsureAdditionalProvisionFiles mocks base method.
-func (m *MockEnsurer) EnsureAdditionalProvisionFiles(ctx context.Context, gctx context0.GardenContext, new, old *[]v1alpha10.File) error {
+func (m *MockEnsurer) EnsureAdditionalProvisionFiles(ctx context.Context, gctx context0.GardenContext, newFiles, oldFiles *[]v1alpha10.File) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureAdditionalProvisionFiles", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureAdditionalProvisionFiles", ctx, gctx, newFiles, oldFiles)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureAdditionalProvisionFiles indicates an expected call of EnsureAdditionalProvisionFiles.
-func (mr *MockEnsurerMockRecorder) EnsureAdditionalProvisionFiles(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureAdditionalProvisionFiles(ctx, gctx, newFiles, oldFiles any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalProvisionFiles", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalProvisionFiles), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalProvisionFiles", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalProvisionFiles), ctx, gctx, newFiles, oldFiles)
 }
 
 // EnsureAdditionalProvisionUnits mocks base method.
-func (m *MockEnsurer) EnsureAdditionalProvisionUnits(ctx context.Context, gctx context0.GardenContext, new, old *[]v1alpha10.Unit) error {
+func (m *MockEnsurer) EnsureAdditionalProvisionUnits(ctx context.Context, gctx context0.GardenContext, newUnits, oldUnits *[]v1alpha10.Unit) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureAdditionalProvisionUnits", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureAdditionalProvisionUnits", ctx, gctx, newUnits, oldUnits)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureAdditionalProvisionUnits indicates an expected call of EnsureAdditionalProvisionUnits.
-func (mr *MockEnsurerMockRecorder) EnsureAdditionalProvisionUnits(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureAdditionalProvisionUnits(ctx, gctx, newUnits, oldUnits any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalProvisionUnits", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalProvisionUnits), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalProvisionUnits", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalProvisionUnits), ctx, gctx, newUnits, oldUnits)
 }
 
 // EnsureAdditionalUnits mocks base method.
-func (m *MockEnsurer) EnsureAdditionalUnits(ctx context.Context, gctx context0.GardenContext, new, old *[]v1alpha10.Unit) error {
+func (m *MockEnsurer) EnsureAdditionalUnits(ctx context.Context, gctx context0.GardenContext, newUnits, oldUnits *[]v1alpha10.Unit) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureAdditionalUnits", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureAdditionalUnits", ctx, gctx, newUnits, oldUnits)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureAdditionalUnits indicates an expected call of EnsureAdditionalUnits.
-func (mr *MockEnsurerMockRecorder) EnsureAdditionalUnits(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureAdditionalUnits(ctx, gctx, newUnits, oldUnits any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalUnits", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalUnits), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalUnits", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalUnits), ctx, gctx, newUnits, oldUnits)
 }
 
 // EnsureCRIConfig mocks base method.
-func (m *MockEnsurer) EnsureCRIConfig(ctx context.Context, gctx context0.GardenContext, new, old *v1alpha10.CRIConfig) error {
+func (m *MockEnsurer) EnsureCRIConfig(ctx context.Context, gctx context0.GardenContext, newCRIConfig, oldCRIConfig *v1alpha10.CRIConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureCRIConfig", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureCRIConfig", ctx, gctx, newCRIConfig, oldCRIConfig)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureCRIConfig indicates an expected call of EnsureCRIConfig.
-func (mr *MockEnsurerMockRecorder) EnsureCRIConfig(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureCRIConfig(ctx, gctx, newCRIConfig, oldCRIConfig any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureCRIConfig", reflect.TypeOf((*MockEnsurer)(nil).EnsureCRIConfig), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureCRIConfig", reflect.TypeOf((*MockEnsurer)(nil).EnsureCRIConfig), ctx, gctx, newCRIConfig, oldCRIConfig)
 }
 
 // EnsureClusterAutoscalerDeployment mocks base method.
-func (m *MockEnsurer) EnsureClusterAutoscalerDeployment(ctx context.Context, gctx context0.GardenContext, new, old *v1.Deployment) error {
+func (m *MockEnsurer) EnsureClusterAutoscalerDeployment(ctx context.Context, gctx context0.GardenContext, newDeployment, oldDeployment *v1.Deployment) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureClusterAutoscalerDeployment", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureClusterAutoscalerDeployment", ctx, gctx, newDeployment, oldDeployment)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureClusterAutoscalerDeployment indicates an expected call of EnsureClusterAutoscalerDeployment.
-func (mr *MockEnsurerMockRecorder) EnsureClusterAutoscalerDeployment(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureClusterAutoscalerDeployment(ctx, gctx, newDeployment, oldDeployment any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureClusterAutoscalerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureClusterAutoscalerDeployment), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureClusterAutoscalerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureClusterAutoscalerDeployment), ctx, gctx, newDeployment, oldDeployment)
 }
 
 // EnsureETCD mocks base method.
-func (m *MockEnsurer) EnsureETCD(ctx context.Context, gctx context0.GardenContext, new, old *v1alpha1.Etcd) error {
+func (m *MockEnsurer) EnsureETCD(ctx context.Context, gctx context0.GardenContext, newEtcd, oldEtcd *v1alpha1.Etcd) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureETCD", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureETCD", ctx, gctx, newEtcd, oldEtcd)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureETCD indicates an expected call of EnsureETCD.
-func (mr *MockEnsurerMockRecorder) EnsureETCD(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureETCD(ctx, gctx, newEtcd, oldEtcd any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureETCD", reflect.TypeOf((*MockEnsurer)(nil).EnsureETCD), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureETCD", reflect.TypeOf((*MockEnsurer)(nil).EnsureETCD), ctx, gctx, newEtcd, oldEtcd)
 }
 
 // EnsureGardenerResourceManagerDeployment mocks base method.
-func (m *MockEnsurer) EnsureGardenerResourceManagerDeployment(ctx context.Context, gctx context0.GardenContext, new, old *v1.Deployment) error {
+func (m *MockEnsurer) EnsureGardenerResourceManagerDeployment(ctx context.Context, gctx context0.GardenContext, newDeployment, oldDeployment *v1.Deployment) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureGardenerResourceManagerDeployment", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureGardenerResourceManagerDeployment", ctx, gctx, newDeployment, oldDeployment)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureGardenerResourceManagerDeployment indicates an expected call of EnsureGardenerResourceManagerDeployment.
-func (mr *MockEnsurerMockRecorder) EnsureGardenerResourceManagerDeployment(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureGardenerResourceManagerDeployment(ctx, gctx, newDeployment, oldDeployment any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureGardenerResourceManagerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureGardenerResourceManagerDeployment), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureGardenerResourceManagerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureGardenerResourceManagerDeployment), ctx, gctx, newDeployment, oldDeployment)
 }
 
 // EnsureKubeAPIServerDeployment mocks base method.
-func (m *MockEnsurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx context0.GardenContext, new, old *v1.Deployment) error {
+func (m *MockEnsurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx context0.GardenContext, newDeployment, oldDeployment *v1.Deployment) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeAPIServerDeployment", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureKubeAPIServerDeployment", ctx, gctx, newDeployment, oldDeployment)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureKubeAPIServerDeployment indicates an expected call of EnsureKubeAPIServerDeployment.
-func (mr *MockEnsurerMockRecorder) EnsureKubeAPIServerDeployment(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubeAPIServerDeployment(ctx, gctx, newDeployment, oldDeployment any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeAPIServerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeAPIServerDeployment), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeAPIServerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeAPIServerDeployment), ctx, gctx, newDeployment, oldDeployment)
 }
 
 // EnsureKubeControllerManagerDeployment mocks base method.
-func (m *MockEnsurer) EnsureKubeControllerManagerDeployment(ctx context.Context, gctx context0.GardenContext, new, old *v1.Deployment) error {
+func (m *MockEnsurer) EnsureKubeControllerManagerDeployment(ctx context.Context, gctx context0.GardenContext, newDeployment, oldDeployment *v1.Deployment) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeControllerManagerDeployment", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureKubeControllerManagerDeployment", ctx, gctx, newDeployment, oldDeployment)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureKubeControllerManagerDeployment indicates an expected call of EnsureKubeControllerManagerDeployment.
-func (mr *MockEnsurerMockRecorder) EnsureKubeControllerManagerDeployment(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubeControllerManagerDeployment(ctx, gctx, newDeployment, oldDeployment any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeControllerManagerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeControllerManagerDeployment), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeControllerManagerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeControllerManagerDeployment), ctx, gctx, newDeployment, oldDeployment)
 }
 
 // EnsureKubeSchedulerDeployment mocks base method.
-func (m *MockEnsurer) EnsureKubeSchedulerDeployment(ctx context.Context, gctx context0.GardenContext, new, old *v1.Deployment) error {
+func (m *MockEnsurer) EnsureKubeSchedulerDeployment(ctx context.Context, gctx context0.GardenContext, newDeployment, oldDeployment *v1.Deployment) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeSchedulerDeployment", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureKubeSchedulerDeployment", ctx, gctx, newDeployment, oldDeployment)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureKubeSchedulerDeployment indicates an expected call of EnsureKubeSchedulerDeployment.
-func (mr *MockEnsurerMockRecorder) EnsureKubeSchedulerDeployment(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubeSchedulerDeployment(ctx, gctx, newDeployment, oldDeployment any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeSchedulerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeSchedulerDeployment), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeSchedulerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeSchedulerDeployment), ctx, gctx, newDeployment, oldDeployment)
 }
 
 // EnsureKubeletCloudProviderConfig mocks base method.
@@ -217,102 +217,102 @@ func (mr *MockEnsurerMockRecorder) EnsureKubeletCloudProviderConfig(ctx, gctx, k
 }
 
 // EnsureKubeletConfiguration mocks base method.
-func (m *MockEnsurer) EnsureKubeletConfiguration(ctx context.Context, gctx context0.GardenContext, kubeletVersion *semver.Version, new, old *v1beta1.KubeletConfiguration) error {
+func (m *MockEnsurer) EnsureKubeletConfiguration(ctx context.Context, gctx context0.GardenContext, kubeletVersion *semver.Version, newKubeletConfig, oldKubeletConfig *v1beta1.KubeletConfiguration) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeletConfiguration", ctx, gctx, kubeletVersion, new, old)
+	ret := m.ctrl.Call(m, "EnsureKubeletConfiguration", ctx, gctx, kubeletVersion, newKubeletConfig, oldKubeletConfig)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureKubeletConfiguration indicates an expected call of EnsureKubeletConfiguration.
-func (mr *MockEnsurerMockRecorder) EnsureKubeletConfiguration(ctx, gctx, kubeletVersion, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubeletConfiguration(ctx, gctx, kubeletVersion, newKubeletConfig, oldKubeletConfig any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeletConfiguration", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeletConfiguration), ctx, gctx, kubeletVersion, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeletConfiguration", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeletConfiguration), ctx, gctx, kubeletVersion, newKubeletConfig, oldKubeletConfig)
 }
 
 // EnsureKubeletServiceUnitOptions mocks base method.
-func (m *MockEnsurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx context0.GardenContext, kubeletVersion *semver.Version, new, old []*unit.UnitOption) ([]*unit.UnitOption, error) {
+func (m *MockEnsurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx context0.GardenContext, kubeletVersion *semver.Version, newUnitOptions, oldUnitOptions []*unit.UnitOption) ([]*unit.UnitOption, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubeletServiceUnitOptions", ctx, gctx, kubeletVersion, new, old)
+	ret := m.ctrl.Call(m, "EnsureKubeletServiceUnitOptions", ctx, gctx, kubeletVersion, newUnitOptions, oldUnitOptions)
 	ret0, _ := ret[0].([]*unit.UnitOption)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnsureKubeletServiceUnitOptions indicates an expected call of EnsureKubeletServiceUnitOptions.
-func (mr *MockEnsurerMockRecorder) EnsureKubeletServiceUnitOptions(ctx, gctx, kubeletVersion, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubeletServiceUnitOptions(ctx, gctx, kubeletVersion, newUnitOptions, oldUnitOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeletServiceUnitOptions", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeletServiceUnitOptions), ctx, gctx, kubeletVersion, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubeletServiceUnitOptions", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubeletServiceUnitOptions), ctx, gctx, kubeletVersion, newUnitOptions, oldUnitOptions)
 }
 
 // EnsureKubernetesGeneralConfiguration mocks base method.
-func (m *MockEnsurer) EnsureKubernetesGeneralConfiguration(ctx context.Context, gctx context0.GardenContext, new, old *string) error {
+func (m *MockEnsurer) EnsureKubernetesGeneralConfiguration(ctx context.Context, gctx context0.GardenContext, newData, oldData *string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureKubernetesGeneralConfiguration", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureKubernetesGeneralConfiguration", ctx, gctx, newData, oldData)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureKubernetesGeneralConfiguration indicates an expected call of EnsureKubernetesGeneralConfiguration.
-func (mr *MockEnsurerMockRecorder) EnsureKubernetesGeneralConfiguration(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureKubernetesGeneralConfiguration(ctx, gctx, newData, oldData any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubernetesGeneralConfiguration", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubernetesGeneralConfiguration), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubernetesGeneralConfiguration", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubernetesGeneralConfiguration), ctx, gctx, newData, oldData)
 }
 
 // EnsureMachineControllerManagerDeployment mocks base method.
-func (m *MockEnsurer) EnsureMachineControllerManagerDeployment(ctx context.Context, gctx context0.GardenContext, new, old *v1.Deployment) error {
+func (m *MockEnsurer) EnsureMachineControllerManagerDeployment(ctx context.Context, gctx context0.GardenContext, newDeployment, oldDeployment *v1.Deployment) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureMachineControllerManagerDeployment", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureMachineControllerManagerDeployment", ctx, gctx, newDeployment, oldDeployment)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureMachineControllerManagerDeployment indicates an expected call of EnsureMachineControllerManagerDeployment.
-func (mr *MockEnsurerMockRecorder) EnsureMachineControllerManagerDeployment(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureMachineControllerManagerDeployment(ctx, gctx, newDeployment, oldDeployment any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureMachineControllerManagerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureMachineControllerManagerDeployment), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureMachineControllerManagerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureMachineControllerManagerDeployment), ctx, gctx, newDeployment, oldDeployment)
 }
 
 // EnsureMachineControllerManagerVPA mocks base method.
-func (m *MockEnsurer) EnsureMachineControllerManagerVPA(ctx context.Context, gctx context0.GardenContext, new, old *v10.VerticalPodAutoscaler) error {
+func (m *MockEnsurer) EnsureMachineControllerManagerVPA(ctx context.Context, gctx context0.GardenContext, newVPA, oldVPA *v10.VerticalPodAutoscaler) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureMachineControllerManagerVPA", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureMachineControllerManagerVPA", ctx, gctx, newVPA, oldVPA)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureMachineControllerManagerVPA indicates an expected call of EnsureMachineControllerManagerVPA.
-func (mr *MockEnsurerMockRecorder) EnsureMachineControllerManagerVPA(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureMachineControllerManagerVPA(ctx, gctx, newVPA, oldVPA any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureMachineControllerManagerVPA", reflect.TypeOf((*MockEnsurer)(nil).EnsureMachineControllerManagerVPA), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureMachineControllerManagerVPA", reflect.TypeOf((*MockEnsurer)(nil).EnsureMachineControllerManagerVPA), ctx, gctx, newVPA, oldVPA)
 }
 
 // EnsureVPNSeedServerDeployment mocks base method.
-func (m *MockEnsurer) EnsureVPNSeedServerDeployment(ctx context.Context, gctx context0.GardenContext, new, old *v1.Deployment) error {
+func (m *MockEnsurer) EnsureVPNSeedServerDeployment(ctx context.Context, gctx context0.GardenContext, newDeployment, oldDeployment *v1.Deployment) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureVPNSeedServerDeployment", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureVPNSeedServerDeployment", ctx, gctx, newDeployment, oldDeployment)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureVPNSeedServerDeployment indicates an expected call of EnsureVPNSeedServerDeployment.
-func (mr *MockEnsurerMockRecorder) EnsureVPNSeedServerDeployment(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureVPNSeedServerDeployment(ctx, gctx, newDeployment, oldDeployment any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureVPNSeedServerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureVPNSeedServerDeployment), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureVPNSeedServerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureVPNSeedServerDeployment), ctx, gctx, newDeployment, oldDeployment)
 }
 
 // EnsureVPNSeedServerStatefulSet mocks base method.
-func (m *MockEnsurer) EnsureVPNSeedServerStatefulSet(ctx context.Context, gctx context0.GardenContext, new, old *v1.StatefulSet) error {
+func (m *MockEnsurer) EnsureVPNSeedServerStatefulSet(ctx context.Context, gctx context0.GardenContext, newStatefulSet, oldStatefulSet *v1.StatefulSet) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureVPNSeedServerStatefulSet", ctx, gctx, new, old)
+	ret := m.ctrl.Call(m, "EnsureVPNSeedServerStatefulSet", ctx, gctx, newStatefulSet, oldStatefulSet)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureVPNSeedServerStatefulSet indicates an expected call of EnsureVPNSeedServerStatefulSet.
-func (mr *MockEnsurerMockRecorder) EnsureVPNSeedServerStatefulSet(ctx, gctx, new, old any) *gomock.Call {
+func (mr *MockEnsurerMockRecorder) EnsureVPNSeedServerStatefulSet(ctx, gctx, newStatefulSet, oldStatefulSet any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureVPNSeedServerStatefulSet", reflect.TypeOf((*MockEnsurer)(nil).EnsureVPNSeedServerStatefulSet), ctx, gctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureVPNSeedServerStatefulSet", reflect.TypeOf((*MockEnsurer)(nil).EnsureVPNSeedServerStatefulSet), ctx, gctx, newStatefulSet, oldStatefulSet)
 }
 
 // ShouldProvisionKubeletCloudProviderConfig mocks base method.

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -37,61 +37,61 @@ import (
 type Ensurer interface {
 	// EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureKubeAPIServerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error
+	EnsureKubeAPIServerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureKubeControllerManagerDeployment ensures that the kube-controller-manager deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureKubeControllerManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error
+	EnsureKubeControllerManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureKubeSchedulerDeployment ensures that the kube-scheduler deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureKubeSchedulerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error
+	EnsureKubeSchedulerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureClusterAutoscalerDeployment ensures that the cluster-autoscaler deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureClusterAutoscalerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error
+	EnsureClusterAutoscalerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureMachineControllerManagerDeployment ensures that the machine-controller-manager deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureMachineControllerManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error
+	EnsureMachineControllerManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureMachineControllerManagerVPA ensures that the machine-controller-manager VPA settings conform to the provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureMachineControllerManagerVPA(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *vpaautoscalingv1.VerticalPodAutoscaler) error
+	EnsureMachineControllerManagerVPA(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newVPA, oldVPA *vpaautoscalingv1.VerticalPodAutoscaler) error
 	// EnsureETCD ensures that the etcds conform to the respective provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureETCD(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *druidcorev1alpha1.Etcd) error
+	EnsureETCD(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newEtcd, oldEtcd *druidcorev1alpha1.Etcd) error
 	// EnsureVPNSeedServerDeployment ensures that the vpn-seed-server deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureVPNSeedServerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error
+	EnsureVPNSeedServerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureVPNSeedServerStatefulSet ensures that the vpn-seed-server deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureVPNSeedServerStatefulSet(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.StatefulSet) error
+	EnsureVPNSeedServerStatefulSet(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newStatefulSet, oldStatefulSet *appsv1.StatefulSet) error
 	// EnsureKubeletServiceUnitOptions ensures that the kubelet.service unit options conform to the provider requirements.
-	EnsureKubeletServiceUnitOptions(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, new, old []*unit.UnitOption) ([]*unit.UnitOption, error)
+	EnsureKubeletServiceUnitOptions(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, newUnitOptions, oldUnitOptions []*unit.UnitOption) ([]*unit.UnitOption, error)
 	// EnsureKubeletConfiguration ensures that the kubelet configuration conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureKubeletConfiguration(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, new, old *kubeletconfigv1beta1.KubeletConfiguration) error
+	EnsureKubeletConfiguration(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, newKubeletConfig, oldKubeletConfig *kubeletconfigv1beta1.KubeletConfiguration) error
 	// ShouldProvisionKubeletCloudProviderConfig returns true if the cloud provider config file should be added to the kubelet configuration.
 	ShouldProvisionKubeletCloudProviderConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version) bool
 	// EnsureKubeletCloudProviderConfig ensures that the cloud provider config file content conforms to the provider requirements.
 	EnsureKubeletCloudProviderConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, configContent *string, namespace string) error
 	// EnsureKubernetesGeneralConfiguration ensures that the kubernetes general configuration conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureKubernetesGeneralConfiguration(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *string) error
+	EnsureKubernetesGeneralConfiguration(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newData, oldData *string) error
 	// EnsureAdditionalUnits ensures additional systemd units
 	// "old" might be "nil" and must always be checked.
-	EnsureAdditionalUnits(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *[]extensionsv1alpha1.Unit) error
+	EnsureAdditionalUnits(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newUnits, oldUnits *[]extensionsv1alpha1.Unit) error
 	// EnsureAdditionalFiles ensures additional systemd files
 	// "old" might be "nil" and must always be checked.
-	EnsureAdditionalFiles(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *[]extensionsv1alpha1.File) error
+	EnsureAdditionalFiles(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newFiles, oldFiles *[]extensionsv1alpha1.File) error
 	// EnsureAdditionalProvisionUnits ensures additional systemd units for the 'provision' OSC
 	// "old" might be "nil" and must always be checked.
-	EnsureAdditionalProvisionUnits(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *[]extensionsv1alpha1.Unit) error
+	EnsureAdditionalProvisionUnits(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newUnits, oldUnits *[]extensionsv1alpha1.Unit) error
 	// EnsureAdditionalProvisionFiles ensures additional systemd files for the 'provision' OSC
 	// "old" might be "nil" and must always be checked.
-	EnsureAdditionalProvisionFiles(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *[]extensionsv1alpha1.File) error
+	EnsureAdditionalProvisionFiles(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newFiles, oldFiles *[]extensionsv1alpha1.File) error
 	// EnsureCRIConfig ensures the CRI config.
 	// "old" might be "nil" and must always be checked.
-	EnsureCRIConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *extensionsv1alpha1.CRIConfig) error
+	EnsureCRIConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newCRIConfig, oldCRIConfig *extensionsv1alpha1.CRIConfig) error
 	// EnsureGardenerResourceManagerDeployment ensures that the Resource Manager deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
-	EnsureGardenerResourceManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error
+	EnsureGardenerResourceManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 }
 
 // NewMutator creates a new controlplane mutator.
@@ -123,19 +123,19 @@ type mutator struct {
 }
 
 // Mutate validates and if needed mutates the given object.
-func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
+func (m *mutator) Mutate(ctx context.Context, newObj, oldObj client.Object) error {
 	// If the object does have a deletion timestamp then we don't want to mutate anything.
-	if new.GetDeletionTimestamp() != nil {
+	if newObj.GetDeletionTimestamp() != nil {
 		return nil
 	}
-	gctx := extensionscontextwebhook.NewGardenContext(m.client, new)
+	gctx := extensionscontextwebhook.NewGardenContext(m.client, newObj)
 
-	switch x := new.(type) {
+	switch x := newObj.(type) {
 	case *appsv1.Deployment:
 		var oldDep *appsv1.Deployment
-		if old != nil {
+		if oldObj != nil {
 			var ok bool
-			oldDep, ok = old.(*appsv1.Deployment)
+			oldDep, ok = oldObj.(*appsv1.Deployment)
 			if !ok {
 				return errors.New("could not cast old object to appsv1.Deployment")
 			}
@@ -166,9 +166,9 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 		}
 	case *appsv1.StatefulSet:
 		var oldSet *appsv1.StatefulSet
-		if old != nil {
+		if oldObj != nil {
 			var ok bool
-			oldSet, ok = old.(*appsv1.StatefulSet)
+			oldSet, ok = oldObj.(*appsv1.StatefulSet)
 			if !ok {
 				return errors.New("could not cast old object to appsv1.StatefulSet")
 			}
@@ -181,9 +181,9 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 
 	case *vpaautoscalingv1.VerticalPodAutoscaler:
 		var oldVPA *vpaautoscalingv1.VerticalPodAutoscaler
-		if old != nil {
+		if oldObj != nil {
 			var ok bool
-			oldVPA, ok = old.(*vpaautoscalingv1.VerticalPodAutoscaler)
+			oldVPA, ok = oldObj.(*vpaautoscalingv1.VerticalPodAutoscaler)
 			if !ok {
 				return errors.New("could not cast old object to vpaautoscalingv1.VerticalPodAutoscaler")
 			}
@@ -198,9 +198,9 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 		switch x.Name {
 		case v1beta1constants.ETCDMain, operatorv1alpha1.VirtualGardenETCDMain, v1beta1constants.ETCDEvents, operatorv1alpha1.VirtualGardenETCDEvents:
 			var oldEtcd *druidcorev1alpha1.Etcd
-			if old != nil {
+			if oldObj != nil {
 				var ok bool
-				oldEtcd, ok = old.(*druidcorev1alpha1.Etcd)
+				oldEtcd, ok = oldObj.(*druidcorev1alpha1.Etcd)
 				if !ok {
 					return errors.New("could not cast old object to druidcorev1alpha1.Etcd")
 				}
@@ -211,9 +211,9 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 		}
 	case *extensionsv1alpha1.OperatingSystemConfig:
 		var oldOSC *extensionsv1alpha1.OperatingSystemConfig
-		if old != nil {
+		if oldObj != nil {
 			var ok bool
-			oldOSC, ok = old.(*extensionsv1alpha1.OperatingSystemConfig)
+			oldOSC, ok = oldObj.(*extensionsv1alpha1.OperatingSystemConfig)
 			if !ok {
 				return errors.New("could not cast old object to extensionsv1alpha1.OperatingSystemConfig")
 			}

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -36,61 +36,61 @@ import (
 // are mutated accordingly.
 type Ensurer interface {
 	// EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldDeployment" might be "nil" and must always be checked.
 	EnsureKubeAPIServerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureKubeControllerManagerDeployment ensures that the kube-controller-manager deployment conforms to the provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldDeployment" might be "nil" and must always be checked.
 	EnsureKubeControllerManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureKubeSchedulerDeployment ensures that the kube-scheduler deployment conforms to the provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldDeployment" might be "nil" and must always be checked.
 	EnsureKubeSchedulerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureClusterAutoscalerDeployment ensures that the cluster-autoscaler deployment conforms to the provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldDeployment" might be "nil" and must always be checked.
 	EnsureClusterAutoscalerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureMachineControllerManagerDeployment ensures that the machine-controller-manager deployment conforms to the provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldDeployment" might be "nil" and must always be checked.
 	EnsureMachineControllerManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureMachineControllerManagerVPA ensures that the machine-controller-manager VPA settings conform to the provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldVPA" might be "nil" and must always be checked.
 	EnsureMachineControllerManagerVPA(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newVPA, oldVPA *vpaautoscalingv1.VerticalPodAutoscaler) error
 	// EnsureETCD ensures that the etcds conform to the respective provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldEtcd" might be "nil" and must always be checked.
 	EnsureETCD(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newEtcd, oldEtcd *druidcorev1alpha1.Etcd) error
 	// EnsureVPNSeedServerDeployment ensures that the vpn-seed-server deployment conforms to the provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldDeployment" might be "nil" and must always be checked.
 	EnsureVPNSeedServerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 	// EnsureVPNSeedServerStatefulSet ensures that the vpn-seed-server deployment conforms to the provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldStatefulSet" might be "nil" and must always be checked.
 	EnsureVPNSeedServerStatefulSet(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newStatefulSet, oldStatefulSet *appsv1.StatefulSet) error
 	// EnsureKubeletServiceUnitOptions ensures that the kubelet.service unit options conform to the provider requirements.
 	EnsureKubeletServiceUnitOptions(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, newUnitOptions, oldUnitOptions []*unit.UnitOption) ([]*unit.UnitOption, error)
 	// EnsureKubeletConfiguration ensures that the kubelet configuration conforms to the provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldKubeletConfig" might be "nil" and must always be checked.
 	EnsureKubeletConfiguration(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, newKubeletConfig, oldKubeletConfig *kubeletconfigv1beta1.KubeletConfiguration) error
 	// ShouldProvisionKubeletCloudProviderConfig returns true if the cloud provider config file should be added to the kubelet configuration.
 	ShouldProvisionKubeletCloudProviderConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version) bool
 	// EnsureKubeletCloudProviderConfig ensures that the cloud provider config file content conforms to the provider requirements.
 	EnsureKubeletCloudProviderConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, configContent *string, namespace string) error
 	// EnsureKubernetesGeneralConfiguration ensures that the kubernetes general configuration conforms to the provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldData" might be "nil" and must always be checked.
 	EnsureKubernetesGeneralConfiguration(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newData, oldData *string) error
 	// EnsureAdditionalUnits ensures additional systemd units
-	// "old" might be "nil" and must always be checked.
+	// "oldUnits" might be "nil" and must always be checked.
 	EnsureAdditionalUnits(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newUnits, oldUnits *[]extensionsv1alpha1.Unit) error
 	// EnsureAdditionalFiles ensures additional systemd files
-	// "old" might be "nil" and must always be checked.
+	// "oldFiles" might be "nil" and must always be checked.
 	EnsureAdditionalFiles(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newFiles, oldFiles *[]extensionsv1alpha1.File) error
 	// EnsureAdditionalProvisionUnits ensures additional systemd units for the 'provision' OSC
-	// "old" might be "nil" and must always be checked.
+	// "oldUnits" might be "nil" and must always be checked.
 	EnsureAdditionalProvisionUnits(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newUnits, oldUnits *[]extensionsv1alpha1.Unit) error
 	// EnsureAdditionalProvisionFiles ensures additional systemd files for the 'provision' OSC
-	// "old" might be "nil" and must always be checked.
+	// "oldFiles" might be "nil" and must always be checked.
 	EnsureAdditionalProvisionFiles(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newFiles, oldFiles *[]extensionsv1alpha1.File) error
 	// EnsureCRIConfig ensures the CRI config.
-	// "old" might be "nil" and must always be checked.
+	// "oldCRIConfig" might be "nil" and must always be checked.
 	EnsureCRIConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newCRIConfig, oldCRIConfig *extensionsv1alpha1.CRIConfig) error
 	// EnsureGardenerResourceManagerDeployment ensures that the Resource Manager deployment conforms to the provider requirements.
-	// "old" might be "nil" and must always be checked.
+	// "oldDeployment" might be "nil" and must always be checked.
 	EnsureGardenerResourceManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newDeployment, oldDeployment *appsv1.Deployment) error
 }
 

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -136,8 +136,8 @@ var _ = Describe("Mutator", func() {
 			newObj = nil
 		})
 
-		DescribeTable("Should ignore", func(new, old client.Object) {
-			err := mutator.Mutate(context.Background(), new, old)
+		DescribeTable("Should ignore", func(newObj, oldObj client.Object) {
+			err := mutator.Mutate(context.Background(), newObj, oldObj)
 			Expect(err).To(Not(HaveOccurred()))
 		},
 			Entry(

--- a/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -69,8 +69,8 @@ func (e *NoopEnsurer) EnsureVPNSeedServerStatefulSet(_ context.Context, _ extens
 }
 
 // EnsureKubeletServiceUnitOptions ensures that the kubelet.service unit options conform to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeletServiceUnitOptions(_ context.Context, _ extensionscontextwebhook.GardenContext, _ *semver.Version, new, _ []*unit.UnitOption) ([]*unit.UnitOption, error) {
-	return new, nil
+func (e *NoopEnsurer) EnsureKubeletServiceUnitOptions(_ context.Context, _ extensionscontextwebhook.GardenContext, _ *semver.Version, newUnitOptions, _ []*unit.UnitOption) ([]*unit.UnitOption, error) {
+	return newUnitOptions, nil
 }
 
 // EnsureKubeletConfiguration ensures that the kubelet configuration conforms to the provider requirements.

--- a/extensions/pkg/webhook/mock/mocks.go
+++ b/extensions/pkg/webhook/mock/mocks.go
@@ -42,15 +42,15 @@ func (m *MockMutator) EXPECT() *MockMutatorMockRecorder {
 }
 
 // Mutate mocks base method.
-func (m *MockMutator) Mutate(ctx context.Context, new, old client.Object) error {
+func (m *MockMutator) Mutate(ctx context.Context, newObj, oldObj client.Object) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Mutate", ctx, new, old)
+	ret := m.ctrl.Call(m, "Mutate", ctx, newObj, oldObj)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Mutate indicates an expected call of Mutate.
-func (mr *MockMutatorMockRecorder) Mutate(ctx, new, old any) *gomock.Call {
+func (mr *MockMutatorMockRecorder) Mutate(ctx, newObj, oldObj any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mutate", reflect.TypeOf((*MockMutator)(nil).Mutate), ctx, new, old)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mutate", reflect.TypeOf((*MockMutator)(nil).Mutate), ctx, newObj, oldObj)
 }

--- a/extensions/pkg/webhook/network/mutator.go
+++ b/extensions/pkg/webhook/network/mutator.go
@@ -18,7 +18,7 @@ import (
 )
 
 // MutateFn is a function that validates and if needed mutates the given extensionsv1alpha1.Network.
-type MutateFn func(new, old *extensionsv1alpha1.Network) error
+type MutateFn func(newNetwork, oldNetwork *extensionsv1alpha1.Network) error
 
 // NewMutator creates a new network mutator.
 func NewMutator(mgr manager.Manager, logger logr.Logger, mutateFn MutateFn) webhook.Mutator {
@@ -36,24 +36,24 @@ type mutator struct {
 }
 
 // Mutate validates and if needed mutates the given object.
-func (m *mutator) Mutate(_ context.Context, new, old client.Object) error {
+func (m *mutator) Mutate(_ context.Context, newObj, oldObj client.Object) error {
 	var (
 		newNetwork, oldNetwork *extensionsv1alpha1.Network
 		ok                     bool
 	)
 
 	// If the object does have a deletion timestamp then we don't want to mutate anything.
-	if new.GetDeletionTimestamp() != nil {
+	if newObj.GetDeletionTimestamp() != nil {
 		return nil
 	}
 
-	newNetwork, ok = new.(*extensionsv1alpha1.Network)
+	newNetwork, ok = newObj.(*extensionsv1alpha1.Network)
 	if !ok {
 		return fmt.Errorf("could not mutate, object is not of type %q", "Network")
 	}
 
-	if old != nil {
-		oldNetwork, ok = old.(*extensionsv1alpha1.Network)
+	if oldObj != nil {
+		oldNetwork, ok = oldObj.(*extensionsv1alpha1.Network)
 		if !ok {
 			return errors.New("could not cast old object to extensionsv1alpha1.Network")
 		}

--- a/extensions/pkg/webhook/registration_test.go
+++ b/extensions/pkg/webhook/registration_test.go
@@ -62,9 +62,9 @@ var _ = Describe("Registration", func() {
 				configs.MutatingWebhookConfig = &admissionregistrationv1.MutatingWebhookConfiguration{}
 				configs.ValidatingWebhookConfig = &admissionregistrationv1.ValidatingWebhookConfiguration{}
 
-				copy := configs.DeepCopy()
-				Expect(copy.MutatingWebhookConfig).To(Not(ShareSameReferenceAs(configs.MutatingWebhookConfig)))
-				Expect(copy.ValidatingWebhookConfig).To(Not(ShareSameReferenceAs(configs.ValidatingWebhookConfig)))
+				copied := configs.DeepCopy()
+				Expect(copied.MutatingWebhookConfig).To(Not(ShareSameReferenceAs(configs.MutatingWebhookConfig)))
+				Expect(copied.ValidatingWebhookConfig).To(Not(ShareSameReferenceAs(configs.ValidatingWebhookConfig)))
 			})
 		})
 

--- a/extensions/pkg/webhook/webhook.go
+++ b/extensions/pkg/webhook/webhook.go
@@ -65,14 +65,14 @@ type Webhook struct {
 
 // Validator validates objects.
 type Validator interface {
-	Validate(ctx context.Context, new, old client.Object) error
+	Validate(ctx context.Context, newObj, oldObj client.Object) error
 }
 
 // Mutator validates and if needed mutates objects.
 type Mutator interface {
 	// Mutate validates and if needed mutates the given object.
 	// "old" is optional, and it must always be checked for nil.
-	Mutate(ctx context.Context, new, old client.Object) error
+	Mutate(ctx context.Context, newObj, oldObj client.Object) error
 }
 
 // Type contains information about the Kubernetes object types and subresources the webhook acts upon.

--- a/pkg/api/authentication/validation/validation.go
+++ b/pkg/api/authentication/validation/validation.go
@@ -20,8 +20,8 @@ func ValidateKubeconfigRequest(req *authentication.KubeconfigRequest) field.Erro
 	allErrs := field.ErrorList{}
 	specPath := field.NewPath("spec")
 
-	const min = 10 * time.Minute
-	if req.Spec.ExpirationSeconds < int64(min.Seconds()) {
+	const minExpirationDuration = 10 * time.Minute
+	if req.Spec.ExpirationSeconds < int64(minExpirationDuration.Seconds()) {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("expirationSeconds"), req.Spec.ExpirationSeconds, "may not specify a duration less than 10 minutes"))
 	}
 	if req.Spec.ExpirationSeconds > math.MaxUint32 {

--- a/pkg/api/core/helper/cloudprofile.go
+++ b/pkg/api/core/helper/cloudprofile.go
@@ -211,14 +211,14 @@ func ToExpirableVersions(versions []core.MachineImageVersion) []core.ExpirableVe
 
 // GetRemovedVersions finds versions that have been removed in the old compared to the new version slice.
 // returns a map associating the version with its index in the old version slice.
-func GetRemovedVersions(old, new []core.ExpirableVersion) map[string]int {
-	return getVersionDiff(old, new)
+func GetRemovedVersions(oldVersions, newVersions []core.ExpirableVersion) map[string]int {
+	return getVersionDiff(oldVersions, newVersions)
 }
 
-// GetAddedVersions finds versions that have been added in the new compared to the new version slice.
+// GetAddedVersions finds versions that have been added in the new compared to the old version slice.
 // returns a map associating the version with its index in the old version slice.
-func GetAddedVersions(old, new []core.ExpirableVersion) map[string]int {
-	return getVersionDiff(new, old)
+func GetAddedVersions(oldVersions, newVersions []core.ExpirableVersion) map[string]int {
+	return getVersionDiff(newVersions, oldVersions)
 }
 
 // getVersionDiff gets versions that are in v1 but not in v2.
@@ -248,7 +248,7 @@ type MachineImageDiff struct {
 }
 
 // GetMachineImageDiff returns the removed and added machine images and versions from the diff of two slices.
-func GetMachineImageDiff(old, new []core.MachineImage) MachineImageDiff {
+func GetMachineImageDiff(oldImages, newImages []core.MachineImage) MachineImageDiff {
 	diff := MachineImageDiff{
 		RemovedImages:                 sets.Set[string]{},
 		RemovedVersions:               map[string]sets.Set[string]{},
@@ -257,13 +257,13 @@ func GetMachineImageDiff(old, new []core.MachineImage) MachineImageDiff {
 		AddedVersions:                 map[string]sets.Set[string]{},
 	}
 
-	oldImages := utils.CreateMapFromSlice(old, func(image core.MachineImage) string { return image.Name })
-	newImages := utils.CreateMapFromSlice(new, func(image core.MachineImage) string { return image.Name })
+	oldImageMap := utils.CreateMapFromSlice(oldImages, func(image core.MachineImage) string { return image.Name })
+	newImageMap := utils.CreateMapFromSlice(newImages, func(image core.MachineImage) string { return image.Name })
 
-	for imageName, oldImage := range oldImages {
+	for imageName, oldImage := range oldImageMap {
 		oldImageVersions := utils.CreateMapFromSlice(oldImage.Versions, func(version core.MachineImageVersion) string { return version.Version })
 		oldImageVersionsSet := sets.KeySet(oldImageVersions)
-		newImage, exists := newImages[imageName]
+		newImage, exists := newImageMap[imageName]
 		if !exists {
 			// Completely removed images.
 			diff.RemovedImages.Insert(imageName)
@@ -306,8 +306,8 @@ func GetMachineImageDiff(old, new []core.MachineImage) MachineImageDiff {
 		}
 	}
 
-	for imageName, newImage := range newImages {
-		if _, exists := oldImages[imageName]; !exists {
+	for imageName, newImage := range newImageMap {
+		if _, exists := oldImageMap[imageName]; !exists {
 			// Completely new image.
 			newImageVersions := utils.CreateMapFromSlice(newImage.Versions, func(version core.MachineImageVersion) string { return version.Version })
 			newImageVersionsSet := sets.KeySet(newImageVersions)

--- a/pkg/api/core/v1beta1/helper/condition_builder.go
+++ b/pkg/api/core/v1beta1/helper/condition_builder.go
@@ -22,7 +22,7 @@ type ConditionBuilder interface {
 	WithMessage(message string) ConditionBuilder
 	WithCodes(codes ...gardencorev1beta1.ErrorCode) ConditionBuilder
 	WithClock(clock clock.Clock) ConditionBuilder
-	Build() (new gardencorev1beta1.Condition, updated bool)
+	Build() (newCondition gardencorev1beta1.Condition, updated bool)
 }
 
 // defaultConditionBuilder build a Condition.

--- a/pkg/api/core/validation/cloudprofile.go
+++ b/pkg/api/core/validation/cloudprofile.go
@@ -61,18 +61,18 @@ func ValidateCloudProfileStatusUpdate(_, _ *core.CloudProfileStatus) field.Error
 }
 
 // ValidateCloudProfileSpecUpdate validates the spec update of a CloudProfile
-func ValidateCloudProfileSpecUpdate(new, old *core.CloudProfileSpec, fldPath *field.Path) field.ErrorList {
+func ValidateCloudProfileSpecUpdate(newSpec, oldSpec *core.CloudProfileSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, validateCloudProfileLimitsUpdate(new.Limits, old.Limits, fldPath.Child("limits"))...)
-	allErrs = append(allErrs, ValidateCloudProfileExpirableVersionsUpdate(new.Kubernetes.Versions, old.Kubernetes.Versions, fldPath.Child("kubernetes").Child("versions"))...)
+	allErrs = append(allErrs, validateCloudProfileLimitsUpdate(newSpec.Limits, oldSpec.Limits, fldPath.Child("limits"))...)
+	allErrs = append(allErrs, ValidateCloudProfileExpirableVersionsUpdate(newSpec.Kubernetes.Versions, oldSpec.Kubernetes.Versions, fldPath.Child("kubernetes").Child("versions"))...)
 
 	oldMachineImageVersions := map[string]core.MachineImage{}
-	for _, version := range old.MachineImages {
+	for _, version := range oldSpec.MachineImages {
 		oldMachineImageVersions[version.Name] = version
 	}
 
-	for i, newMachineImage := range new.MachineImages {
+	for i, newMachineImage := range newSpec.MachineImages {
 		oldMachineImage, ok := oldMachineImageVersions[newMachineImage.Name]
 		if !ok {
 			continue
@@ -96,16 +96,16 @@ func ValidateCloudProfileSpecUpdate(new, old *core.CloudProfileSpec, fldPath *fi
 }
 
 // ValidateCloudProfileExpirableVersionsUpdate validates the expirable versions update of a CloudProfile expirable version
-func ValidateCloudProfileExpirableVersionsUpdate(new, old []core.ExpirableVersion, fldPath *field.Path) field.ErrorList {
+func ValidateCloudProfileExpirableVersionsUpdate(newVersions, oldVersions []core.ExpirableVersion, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	oldVersions := map[string]core.ExpirableVersion{}
-	for _, version := range old {
-		oldVersions[version.Version] = version
+	oldVersionsMap := map[string]core.ExpirableVersion{}
+	for _, version := range oldVersions {
+		oldVersionsMap[version.Version] = version
 	}
 
-	for i, newVersion := range new {
-		oldVersion, ok := oldVersions[newVersion.Version]
+	for i, newVersion := range newVersions {
+		oldVersion, ok := oldVersionsMap[newVersion.Version]
 		if !ok {
 			continue
 		}

--- a/pkg/api/core/validation/controllerdeployment.go
+++ b/pkg/api/core/validation/controllerdeployment.go
@@ -56,8 +56,8 @@ func ValidateControllerDeployment(controllerDeployment *core.ControllerDeploymen
 }
 
 // ValidateControllerDeploymentUpdate validates a ControllerDeployment object before an update.
-func ValidateControllerDeploymentUpdate(new, _ *core.ControllerDeployment) field.ErrorList {
-	return ValidateControllerDeployment(new)
+func ValidateControllerDeploymentUpdate(newControllerDeployment, _ *core.ControllerDeployment) field.ErrorList {
+	return ValidateControllerDeployment(newControllerDeployment)
 }
 
 // ValidateHelmControllerDeployment validates Helm controller deployment configs.

--- a/pkg/api/core/validation/controllerinstallation.go
+++ b/pkg/api/core/validation/controllerinstallation.go
@@ -27,12 +27,12 @@ func ValidateControllerInstallation(controllerInstallation *core.ControllerInsta
 }
 
 // ValidateControllerInstallationUpdate validates a ControllerInstallation object before an update.
-func ValidateControllerInstallationUpdate(new, old *core.ControllerInstallation) field.ErrorList {
+func ValidateControllerInstallationUpdate(newControllerInstallation, oldControllerInstallation *core.ControllerInstallation) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateControllerInstallationSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateControllerInstallation(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newControllerInstallation.ObjectMeta, &oldControllerInstallation.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateControllerInstallationSpecUpdate(&newControllerInstallation.Spec, &oldControllerInstallation.Spec, newControllerInstallation.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateControllerInstallation(newControllerInstallation)...)
 
 	return allErrs
 }
@@ -69,25 +69,25 @@ func ValidateControllerInstallationSpec(spec *core.ControllerInstallationSpec, f
 }
 
 // ValidateControllerInstallationSpecUpdate validates the spec of a ControllerInstallation object before an update.
-func ValidateControllerInstallationSpecUpdate(new, old *core.ControllerInstallationSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateControllerInstallationSpecUpdate(newSpec, oldSpec *core.ControllerInstallationSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update controller installation spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.RegistrationRef.Name, old.RegistrationRef.Name, fldPath.Child("registrationRef", "name"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.RegistrationRef.Name, oldSpec.RegistrationRef.Name, fldPath.Child("registrationRef", "name"))...)
 
-	if old.SeedRef != nil && new.SeedRef != nil {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.SeedRef.Name, old.SeedRef.Name, fldPath.Child("seedRef", "name"))...)
+	if oldSpec.SeedRef != nil && newSpec.SeedRef != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SeedRef.Name, oldSpec.SeedRef.Name, fldPath.Child("seedRef", "name"))...)
 	}
 
-	if old.ShootRef == nil || new.ShootRef == nil {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.ShootRef, old.ShootRef, fldPath.Child("shootRef"))...)
-	} else if new.ShootRef != nil {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.ShootRef.Name, old.ShootRef.Name, fldPath.Child("shootRef", "name"))...)
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.ShootRef.Namespace, old.ShootRef.Namespace, fldPath.Child("shootRef", "namespace"))...)
+	if oldSpec.ShootRef == nil || newSpec.ShootRef == nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.ShootRef, oldSpec.ShootRef, fldPath.Child("shootRef"))...)
+	} else if newSpec.ShootRef != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.ShootRef.Name, oldSpec.ShootRef.Name, fldPath.Child("shootRef", "name"))...)
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.ShootRef.Namespace, oldSpec.ShootRef.Namespace, fldPath.Child("shootRef", "namespace"))...)
 	}
 
 	return allErrs

--- a/pkg/api/core/validation/controllerregistration.go
+++ b/pkg/api/core/validation/controllerregistration.go
@@ -189,39 +189,39 @@ func ValidateControllerResources(resources []core.ControllerResource, clusterTyp
 }
 
 // ValidateControllerRegistrationUpdate validates a ControllerRegistration object before an update.
-func ValidateControllerRegistrationUpdate(new, old *core.ControllerRegistration) field.ErrorList {
+func ValidateControllerRegistrationUpdate(newControllerRegistration, oldControllerRegistration *core.ControllerRegistration) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateControllerRegistrationSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateControllerRegistration(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newControllerRegistration.ObjectMeta, &oldControllerRegistration.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateControllerRegistrationSpecUpdate(&newControllerRegistration.Spec, &oldControllerRegistration.Spec, newControllerRegistration.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateControllerRegistration(newControllerRegistration)...)
 
 	return allErrs
 }
 
 // ValidateControllerRegistrationSpecUpdate validates a ControllerRegistration spec before an update.
-func ValidateControllerRegistrationSpecUpdate(new, old *core.ControllerRegistrationSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateControllerRegistrationSpecUpdate(newSpec, oldSpec *core.ControllerRegistrationSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update controller registration spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, ValidateControllerResourcesUpdate(new.Resources, old.Resources, fldPath.Child("resources"))...)
+	allErrs = append(allErrs, ValidateControllerResourcesUpdate(newSpec.Resources, oldSpec.Resources, fldPath.Child("resources"))...)
 
 	return allErrs
 }
 
 // ValidateControllerResourcesUpdate validates the update of ControllerResource objects.
-func ValidateControllerResourcesUpdate(new, old []core.ControllerResource, fldPath *field.Path) field.ErrorList {
+func ValidateControllerResourcesUpdate(newResources, oldResources []core.ControllerResource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	kindTypeToPrimary := make(map[string]*bool, len(old))
-	for _, resource := range old {
+	kindTypeToPrimary := make(map[string]*bool, len(oldResources))
+	for _, resource := range oldResources {
 		kindTypeToPrimary[gardenerutils.ExtensionsID(resource.Kind, resource.Type)] = resource.Primary
 	}
-	for i, resource := range new {
+	for i, resource := range newResources {
 		if primary, ok := kindTypeToPrimary[gardenerutils.ExtensionsID(resource.Kind, resource.Type)]; ok {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(resource.Primary, primary, fldPath.Index(i).Child("primary"))...)
 		}

--- a/pkg/api/core/validation/exposureclass.go
+++ b/pkg/api/core/validation/exposureclass.go
@@ -43,10 +43,10 @@ func ValidateExposureClass(exposureClass *core.ExposureClass) field.ErrorList {
 }
 
 // ValidateExposureClassUpdate validates a ExposureClass object before an update.
-func ValidateExposureClassUpdate(new, old *core.ExposureClass) field.ErrorList {
+func ValidateExposureClassUpdate(newExposureClass, oldExposureClass *core.ExposureClass) field.ErrorList {
 	var allErrs = field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(old.Handler, new.Handler, field.NewPath("handler"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(old.Scheduling, new.Scheduling, field.NewPath("scheduling"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldExposureClass.Handler, newExposureClass.Handler, field.NewPath("handler"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldExposureClass.Scheduling, newExposureClass.Scheduling, field.NewPath("scheduling"))...)
 	return allErrs
 }

--- a/pkg/api/core/validation/project_test.go
+++ b/pkg/api/core/validation/project_test.go
@@ -625,10 +625,10 @@ var _ = Describe("Project Validation Tests", func() {
 		})
 
 		DescribeTable("namespace immutability",
-			func(old, new *string, matcher gomegatypes.GomegaMatcher) {
-				project.Spec.Namespace = old
+			func(oldVal, newVal *string, matcher gomegatypes.GomegaMatcher) {
+				project.Spec.Namespace = oldVal
 				newProject := prepareProjectForUpdate(project)
-				newProject.Spec.Namespace = new
+				newProject.Spec.Namespace = newVal
 
 				errList := ValidateProjectUpdate(newProject, project)
 

--- a/pkg/api/core/validation/project_test.go
+++ b/pkg/api/core/validation/project_test.go
@@ -625,10 +625,10 @@ var _ = Describe("Project Validation Tests", func() {
 		})
 
 		DescribeTable("namespace immutability",
-			func(oldVal, newVal *string, matcher gomegatypes.GomegaMatcher) {
-				project.Spec.Namespace = oldVal
+			func(oldNamespace, newNamespace *string, matcher gomegatypes.GomegaMatcher) {
+				project.Spec.Namespace = oldNamespace
 				newProject := prepareProjectForUpdate(project)
-				newProject.Spec.Namespace = newVal
+				newProject.Spec.Namespace = newNamespace
 
 				errList := ValidateProjectUpdate(newProject, project)
 

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -840,22 +840,22 @@ func validateKubeControllerManagerUpdate(newConfig, oldConfig *core.KubeControll
 	return allErrs
 }
 
-func validateDNSUpdate(new, old *core.DNS, seedGotAssigned bool, fldPath *field.Path) field.ErrorList {
+func validateDNSUpdate(newDNS, oldDNS *core.DNS, seedGotAssigned bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if old != nil && new == nil {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new, old, fldPath)...)
+	if oldDNS != nil && newDNS == nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newDNS, oldDNS, fldPath)...)
 	}
 
-	if new != nil && old != nil {
-		if old.Domain != nil && new.Domain != old.Domain {
-			allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Domain, old.Domain, fldPath.Child("domain"))...)
+	if newDNS != nil && oldDNS != nil {
+		if oldDNS.Domain != nil && newDNS.Domain != oldDNS.Domain {
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newDNS.Domain, oldDNS.Domain, fldPath.Child("domain"))...)
 		}
 
 		if seedGotAssigned {
 			var (
-				primaryOld = helper.FindPrimaryDNSProvider(old.Providers)
-				primaryNew = helper.FindPrimaryDNSProvider(new.Providers)
+				primaryOld = helper.FindPrimaryDNSProvider(oldDNS.Providers)
+				primaryNew = helper.FindPrimaryDNSProvider(newDNS.Providers)
 			)
 
 			if primaryOld != nil && primaryNew == nil {
@@ -876,18 +876,18 @@ func validateDNSUpdate(new, old *core.DNS, seedGotAssigned bool, fldPath *field.
 }
 
 // ValidateKubernetesVersionUpdate ensures that new version is newer than old version and does not skip minor versions when not allowed
-func ValidateKubernetesVersionUpdate(new, old string, skipMinorVersionAllowed bool, fldPath *field.Path) field.ErrorList {
+func ValidateKubernetesVersionUpdate(newVersion, oldVersion string, skipMinorVersionAllowed bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if len(new) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, new, "cannot validate kubernetes version upgrade because it is unset"))
+	if len(newVersion) == 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath, newVersion, "cannot validate kubernetes version upgrade because it is unset"))
 		return allErrs
 	}
 
 	// Forbid Kubernetes version downgrade
-	downgrade, err := versionutils.CompareVersions(new, "<", old)
+	downgrade, err := versionutils.CompareVersions(newVersion, "<", oldVersion)
 	if err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath, new, err.Error()))
+		allErrs = append(allErrs, field.Invalid(fldPath, newVersion, err.Error()))
 	}
 	if downgrade {
 		allErrs = append(allErrs, field.Forbidden(fldPath, "kubernetes version downgrade is not supported"))
@@ -895,15 +895,15 @@ func ValidateKubernetesVersionUpdate(new, old string, skipMinorVersionAllowed bo
 
 	if !skipMinorVersionAllowed {
 		// Forbid Kubernetes version upgrade which skips a minor version
-		oldVersion, err := semver.NewVersion(old)
+		oldSemVer, err := semver.NewVersion(oldVersion)
 		if err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath, old, err.Error()))
+			allErrs = append(allErrs, field.Invalid(fldPath, oldVersion, err.Error()))
 		}
-		nextMinorVersion := oldVersion.IncMinor().IncMinor()
+		nextMinorVersion := oldSemVer.IncMinor().IncMinor()
 
-		skippingMinorVersion, err := versionutils.CompareVersions(new, ">=", nextMinorVersion.String())
+		skippingMinorVersion, err := versionutils.CompareVersions(newVersion, ">=", nextMinorVersion.String())
 		if err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath, new, err.Error()))
+			allErrs = append(allErrs, field.Invalid(fldPath, newVersion, err.Error()))
 		}
 		if skippingMinorVersion {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "kubernetes version upgrade cannot skip a minor version"))
@@ -914,21 +914,21 @@ func ValidateKubernetesVersionUpdate(new, old string, skipMinorVersionAllowed bo
 }
 
 // validateMachineImageVersionInPlaceUpdate ensures that the new machine image version is newer than old version in case the strategy is in-place update
-func validateMachineImageVersionInPlaceUpdate(new, old *core.ShootMachineImage, fldPath *field.Path) field.ErrorList {
+func validateMachineImageVersionInPlaceUpdate(newMachineImage, oldMachineImage *core.ShootMachineImage, fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs                = field.ErrorList{}
 		newVersion, oldVersion string
 	)
 
-	if new != nil {
-		newVersion = new.Version
+	if newMachineImage != nil {
+		newVersion = newMachineImage.Version
 	}
-	if old != nil {
-		oldVersion = old.Version
+	if oldMachineImage != nil {
+		oldVersion = oldMachineImage.Version
 	}
 
 	if len(newVersion) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, new, "cannot validate machine image version upgrade because it is unset"))
+		allErrs = append(allErrs, field.Invalid(fldPath, newMachineImage, "cannot validate machine image version upgrade because it is unset"))
 		return allErrs
 	}
 
@@ -1738,36 +1738,36 @@ func validatePercentile(percentile float64, fldPath *field.Path) field.ErrorList
 	return allErrs
 }
 
-func validateHibernationUpdate(new, old *core.Shoot) field.ErrorList {
+func validateHibernationUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 	var (
 		allErrs                     = field.ErrorList{}
 		fldPath                     = field.NewPath("spec", "hibernation", "enabled")
-		hibernationEnabledInOld     = old.Spec.Hibernation != nil && ptr.Deref(old.Spec.Hibernation.Enabled, false)
-		hibernationEnabledInNew     = new.Spec.Hibernation != nil && ptr.Deref(new.Spec.Hibernation.Enabled, false)
+		hibernationEnabledInOld     = oldShoot.Spec.Hibernation != nil && ptr.Deref(oldShoot.Spec.Hibernation.Enabled, false)
+		hibernationEnabledInNew     = newShoot.Spec.Hibernation != nil && ptr.Deref(newShoot.Spec.Hibernation.Enabled, false)
 		encryptedResourcesInOldSpec = sets.New[schema.GroupResource]()
 		encryptedResourcesInStatus  = sets.New[schema.GroupResource]()
 	)
 
-	if old.Spec.Kubernetes.KubeAPIServer != nil && old.Spec.Kubernetes.KubeAPIServer.EncryptionConfig != nil {
-		for _, r := range old.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Resources {
+	if oldShoot.Spec.Kubernetes.KubeAPIServer != nil && oldShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig != nil {
+		for _, r := range oldShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Resources {
 			encryptedResourcesInOldSpec.Insert(schema.ParseGroupResource(r))
 		}
 	}
 
-	if old.Status.Credentials != nil && old.Status.Credentials.EncryptionAtRest != nil {
-		for _, er := range old.Status.Credentials.EncryptionAtRest.Resources {
+	if oldShoot.Status.Credentials != nil && oldShoot.Status.Credentials.EncryptionAtRest != nil {
+		for _, er := range oldShoot.Status.Credentials.EncryptionAtRest.Resources {
 			encryptedResourcesInStatus.Insert(schema.ParseGroupResource(er))
 		}
 	}
 
 	if !hibernationEnabledInOld && hibernationEnabledInNew {
-		if new.Status.Credentials != nil && new.Status.Credentials.Rotation != nil && new.Status.Credentials.Rotation.ETCDEncryptionKey != nil {
-			if etcdEncryptionKeyRotation := new.Status.Credentials.Rotation.ETCDEncryptionKey; etcdEncryptionKeyRotation.Phase == core.RotationPreparing || etcdEncryptionKeyRotation.Phase == core.RotationCompleting {
+		if newShoot.Status.Credentials != nil && newShoot.Status.Credentials.Rotation != nil && newShoot.Status.Credentials.Rotation.ETCDEncryptionKey != nil {
+			if etcdEncryptionKeyRotation := newShoot.Status.Credentials.Rotation.ETCDEncryptionKey; etcdEncryptionKeyRotation.Phase == core.RotationPreparing || etcdEncryptionKeyRotation.Phase == core.RotationCompleting {
 				allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("shoot cannot be hibernated when .status.credentials.rotation.etcdEncryptionKey.phase is %q", string(etcdEncryptionKeyRotation.Phase))))
 			}
 		}
-		if new.Status.Credentials != nil && new.Status.Credentials.Rotation != nil && new.Status.Credentials.Rotation.ServiceAccountKey != nil {
-			if serviceAccountKeyRotation := new.Status.Credentials.Rotation.ServiceAccountKey; sets.New(core.RotationPreparing, core.RotationPreparingWithoutWorkersRollout, core.RotationCompleting).Has(serviceAccountKeyRotation.Phase) {
+		if newShoot.Status.Credentials != nil && newShoot.Status.Credentials.Rotation != nil && newShoot.Status.Credentials.Rotation.ServiceAccountKey != nil {
+			if serviceAccountKeyRotation := newShoot.Status.Credentials.Rotation.ServiceAccountKey; sets.New(core.RotationPreparing, core.RotationPreparingWithoutWorkersRollout, core.RotationCompleting).Has(serviceAccountKeyRotation.Phase) {
 				allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("shoot cannot be hibernated when .status.credentials.rotation.serviceAccountKey.phase is %q", string(serviceAccountKeyRotation.Phase))))
 			}
 		}

--- a/pkg/api/extensions/validation/backupbucket.go
+++ b/pkg/api/extensions/validation/backupbucket.go
@@ -26,12 +26,12 @@ func ValidateBackupBucket(bb *extensionsv1alpha1.BackupBucket) field.ErrorList {
 }
 
 // ValidateBackupBucketUpdate validates a BackupBucket object before an update.
-func ValidateBackupBucketUpdate(new, old *extensionsv1alpha1.BackupBucket) field.ErrorList {
+func ValidateBackupBucketUpdate(newBackupBucket, oldBackupBucket *extensionsv1alpha1.BackupBucket) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateBackupBucketSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateBackupBucket(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newBackupBucket.ObjectMeta, &oldBackupBucket.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateBackupBucketSpecUpdate(&newBackupBucket.Spec, &oldBackupBucket.Spec, newBackupBucket.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateBackupBucket(newBackupBucket)...)
 
 	return allErrs
 }
@@ -56,16 +56,16 @@ func ValidateBackupBucketSpec(spec *extensionsv1alpha1.BackupBucketSpec, fldPath
 }
 
 // ValidateBackupBucketSpecUpdate validates the spec of a BackupBucket object before an update.
-func ValidateBackupBucketSpecUpdate(new, old *extensionsv1alpha1.BackupBucketSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateBackupBucketSpecUpdate(newSpec, oldSpec *extensionsv1alpha1.BackupBucketSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update backup bucket spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Region, old.Region, fldPath.Child("region"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Region, oldSpec.Region, fldPath.Child("region"))...)
 
 	return allErrs
 }

--- a/pkg/api/extensions/validation/backupentry.go
+++ b/pkg/api/extensions/validation/backupentry.go
@@ -26,12 +26,12 @@ func ValidateBackupEntry(be *extensionsv1alpha1.BackupEntry) field.ErrorList {
 }
 
 // ValidateBackupEntryUpdate validates a BackupEntry object before an update.
-func ValidateBackupEntryUpdate(new, old *extensionsv1alpha1.BackupEntry) field.ErrorList {
+func ValidateBackupEntryUpdate(newBackupEntry, oldBackupEntry *extensionsv1alpha1.BackupEntry) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateBackupEntrySpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateBackupEntry(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newBackupEntry.ObjectMeta, &oldBackupEntry.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateBackupEntrySpecUpdate(&newBackupEntry.Spec, &oldBackupEntry.Spec, newBackupEntry.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateBackupEntry(newBackupEntry)...)
 
 	return allErrs
 }
@@ -60,15 +60,15 @@ func ValidateBackupEntrySpec(spec *extensionsv1alpha1.BackupEntrySpec, fldPath *
 }
 
 // ValidateBackupEntrySpecUpdate validates the spec of a BackupEntry object before an update.
-func ValidateBackupEntrySpecUpdate(new, old *extensionsv1alpha1.BackupEntrySpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateBackupEntrySpecUpdate(newSpec, oldSpec *extensionsv1alpha1.BackupEntrySpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update backup entry spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
 
 	return allErrs
 }

--- a/pkg/api/extensions/validation/bastion.go
+++ b/pkg/api/extensions/validation/bastion.go
@@ -26,12 +26,12 @@ func ValidateBastion(bastion *extensionsv1alpha1.Bastion) field.ErrorList {
 }
 
 // ValidateBastionUpdate validates a Bastion object before an update.
-func ValidateBastionUpdate(new, old *extensionsv1alpha1.Bastion) field.ErrorList {
+func ValidateBastionUpdate(newBastion, oldBastion *extensionsv1alpha1.Bastion) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateBastionSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateBastion(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newBastion.ObjectMeta, &oldBastion.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateBastionSpecUpdate(&newBastion.Spec, &oldBastion.Spec, newBastion.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateBastion(newBastion)...)
 
 	return allErrs
 }
@@ -56,16 +56,16 @@ func ValidateBastionSpec(spec *extensionsv1alpha1.BastionSpec, fldPath *field.Pa
 }
 
 // ValidateBastionSpecUpdate validates the spec of a Bastion object before an update.
-func ValidateBastionSpecUpdate(new, old *extensionsv1alpha1.BastionSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateBastionSpecUpdate(newSpec, oldSpec *extensionsv1alpha1.BastionSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update bastion spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.UserData, old.UserData, fldPath.Child("userData"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.UserData, oldSpec.UserData, fldPath.Child("userData"))...)
 
 	return allErrs
 }

--- a/pkg/api/extensions/validation/containerruntime.go
+++ b/pkg/api/extensions/validation/containerruntime.go
@@ -26,12 +26,12 @@ func ValidateContainerRuntime(cr *extensionsv1alpha1.ContainerRuntime) field.Err
 }
 
 // ValidateContainerRuntimeUpdate validates a ContainerRuntime object before an update.
-func ValidateContainerRuntimeUpdate(new, old *extensionsv1alpha1.ContainerRuntime) field.ErrorList {
+func ValidateContainerRuntimeUpdate(newContainerRuntime, oldContainerRuntime *extensionsv1alpha1.ContainerRuntime) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateContainerRuntimeSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateContainerRuntime(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newContainerRuntime.ObjectMeta, &oldContainerRuntime.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateContainerRuntimeSpecUpdate(&newContainerRuntime.Spec, &oldContainerRuntime.Spec, newContainerRuntime.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateContainerRuntime(newContainerRuntime)...)
 
 	return allErrs
 }
@@ -56,16 +56,16 @@ func ValidateContainerRuntimeSpec(spec *extensionsv1alpha1.ContainerRuntimeSpec,
 }
 
 // ValidateContainerRuntimeSpecUpdate validates the spec of a ContainerRuntime object before an update.
-func ValidateContainerRuntimeSpecUpdate(new, old *extensionsv1alpha1.ContainerRuntimeSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateContainerRuntimeSpecUpdate(newSpec, oldSpec *extensionsv1alpha1.ContainerRuntimeSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update container runtime spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.WorkerPool.Name, old.WorkerPool.Name, fldPath.Child("workerPool", "name"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.WorkerPool.Name, oldSpec.WorkerPool.Name, fldPath.Child("workerPool", "name"))...)
 
 	return allErrs
 }

--- a/pkg/api/extensions/validation/controlplane.go
+++ b/pkg/api/extensions/validation/controlplane.go
@@ -26,12 +26,12 @@ func ValidateControlPlane(cp *extensionsv1alpha1.ControlPlane) field.ErrorList {
 }
 
 // ValidateControlPlaneUpdate validates a ControlPlane object before an update.
-func ValidateControlPlaneUpdate(new, old *extensionsv1alpha1.ControlPlane) field.ErrorList {
+func ValidateControlPlaneUpdate(newControlPlane, oldControlPlane *extensionsv1alpha1.ControlPlane) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateControlPlaneSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateControlPlane(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newControlPlane.ObjectMeta, &oldControlPlane.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateControlPlaneSpecUpdate(&newControlPlane.Spec, &oldControlPlane.Spec, newControlPlane.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateControlPlane(newControlPlane)...)
 
 	return allErrs
 }
@@ -56,16 +56,16 @@ func ValidateControlPlaneSpec(spec *extensionsv1alpha1.ControlPlaneSpec, fldPath
 }
 
 // ValidateControlPlaneSpecUpdate validates the spec of a ControlPlane object before an update.
-func ValidateControlPlaneSpecUpdate(new, old *extensionsv1alpha1.ControlPlaneSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateControlPlaneSpecUpdate(newSpec, oldSpec *extensionsv1alpha1.ControlPlaneSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update control plane spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Region, old.Region, fldPath.Child("region"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Region, oldSpec.Region, fldPath.Child("region"))...)
 
 	return allErrs
 }

--- a/pkg/api/extensions/validation/dnsrecord.go
+++ b/pkg/api/extensions/validation/dnsrecord.go
@@ -30,12 +30,12 @@ func ValidateDNSRecord(dns *extensionsv1alpha1.DNSRecord) field.ErrorList {
 }
 
 // ValidateDNSRecordUpdate validates a DNSRecord object before an update.
-func ValidateDNSRecordUpdate(new, old *extensionsv1alpha1.DNSRecord) field.ErrorList {
+func ValidateDNSRecordUpdate(newDNSRecord, oldDNSRecord *extensionsv1alpha1.DNSRecord) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateDNSRecordSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateDNSRecord(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newDNSRecord.ObjectMeta, &oldDNSRecord.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateDNSRecordSpecUpdate(&newDNSRecord.Spec, &oldDNSRecord.Spec, newDNSRecord.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateDNSRecord(newDNSRecord)...)
 
 	return allErrs
 }
@@ -97,17 +97,17 @@ func ValidateDNSRecordSpec(spec *extensionsv1alpha1.DNSRecordSpec, fldPath *fiel
 }
 
 // ValidateDNSRecordSpecUpdate validates the spec of a DNSRecord object before an update.
-func ValidateDNSRecordSpecUpdate(new, old *extensionsv1alpha1.DNSRecordSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateDNSRecordSpecUpdate(newSpec, oldSpec *extensionsv1alpha1.DNSRecordSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update dns record spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Name, old.Name, fldPath.Child("name"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.RecordType, old.RecordType, fldPath.Child("recordType"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Name, oldSpec.Name, fldPath.Child("name"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.RecordType, oldSpec.RecordType, fldPath.Child("recordType"))...)
 
 	return allErrs
 }

--- a/pkg/api/extensions/validation/extension.go
+++ b/pkg/api/extensions/validation/extension.go
@@ -26,12 +26,12 @@ func ValidateExtension(ext *extensionsv1alpha1.Extension) field.ErrorList {
 }
 
 // ValidateExtensionUpdate validates a Extension object before an update.
-func ValidateExtensionUpdate(new, old *extensionsv1alpha1.Extension) field.ErrorList {
+func ValidateExtensionUpdate(newExtension, oldExtension *extensionsv1alpha1.Extension) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateExtensionSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateExtension(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newExtension.ObjectMeta, &oldExtension.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateExtensionSpecUpdate(&newExtension.Spec, &oldExtension.Spec, newExtension.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateExtension(newExtension)...)
 
 	return allErrs
 }
@@ -48,15 +48,15 @@ func ValidateExtensionSpec(spec *extensionsv1alpha1.ExtensionSpec, fldPath *fiel
 }
 
 // ValidateExtensionSpecUpdate validates the spec of a Extension object before an update.
-func ValidateExtensionSpecUpdate(new, old *extensionsv1alpha1.ExtensionSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateExtensionSpecUpdate(newSpec, oldSpec *extensionsv1alpha1.ExtensionSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update extension spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
 
 	return allErrs
 }

--- a/pkg/api/extensions/validation/infrastructure.go
+++ b/pkg/api/extensions/validation/infrastructure.go
@@ -26,12 +26,12 @@ func ValidateInfrastructure(infra *extensionsv1alpha1.Infrastructure) field.Erro
 }
 
 // ValidateInfrastructureUpdate validates an Infrastructure object before an update.
-func ValidateInfrastructureUpdate(new, old *extensionsv1alpha1.Infrastructure) field.ErrorList {
+func ValidateInfrastructureUpdate(newInfrastructure, oldInfrastructure *extensionsv1alpha1.Infrastructure) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateInfrastructureSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateInfrastructure(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newInfrastructure.ObjectMeta, &oldInfrastructure.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateInfrastructureSpecUpdate(&newInfrastructure.Spec, &oldInfrastructure.Spec, newInfrastructure.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateInfrastructure(newInfrastructure)...)
 
 	return allErrs
 }
@@ -56,16 +56,16 @@ func ValidateInfrastructureSpec(spec *extensionsv1alpha1.InfrastructureSpec, fld
 }
 
 // ValidateInfrastructureSpecUpdate validates the spec of an Infrastructure object before an update.
-func ValidateInfrastructureSpecUpdate(new, old *extensionsv1alpha1.InfrastructureSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateInfrastructureSpecUpdate(newSpec, oldSpec *extensionsv1alpha1.InfrastructureSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update infrastructure spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Region, old.Region, fldPath.Child("region"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Region, oldSpec.Region, fldPath.Child("region"))...)
 
 	return allErrs
 }

--- a/pkg/api/extensions/validation/network.go
+++ b/pkg/api/extensions/validation/network.go
@@ -29,12 +29,12 @@ func ValidateNetwork(network *extensionsv1alpha1.Network) field.ErrorList {
 }
 
 // ValidateNetworkUpdate validates a Network object before an update.
-func ValidateNetworkUpdate(new, old *extensionsv1alpha1.Network) field.ErrorList {
+func ValidateNetworkUpdate(newNetwork, oldNetwork *extensionsv1alpha1.Network) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateNetworkSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateNetwork(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newNetwork.ObjectMeta, &oldNetwork.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateNetworkSpecUpdate(&newNetwork.Spec, &oldNetwork.Spec, newNetwork.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateNetwork(newNetwork)...)
 
 	return allErrs
 }
@@ -82,18 +82,18 @@ func ValidateNetworkSpec(spec *extensionsv1alpha1.NetworkSpec, fldPath *field.Pa
 }
 
 // ValidateNetworkSpecUpdate validates the spec of a Network object before an update.
-func ValidateNetworkSpecUpdate(new, old *extensionsv1alpha1.NetworkSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateNetworkSpecUpdate(newSpec, oldSpec *extensionsv1alpha1.NetworkSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update network spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, ValidateIPFamiliesUpdate(new.IPFamilies, old.IPFamilies, fldPath.Child("ipFamilies"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.PodCIDR, old.PodCIDR, fldPath.Child("podCIDR"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.ServiceCIDR, old.ServiceCIDR, fldPath.Child("serviceCIDR"))...)
+	allErrs = append(allErrs, ValidateIPFamiliesUpdate(newSpec.IPFamilies, oldSpec.IPFamilies, fldPath.Child("ipFamilies"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.PodCIDR, oldSpec.PodCIDR, fldPath.Child("podCIDR"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.ServiceCIDR, oldSpec.ServiceCIDR, fldPath.Child("serviceCIDR"))...)
 	return allErrs
 }
 

--- a/pkg/api/extensions/validation/operatingsystemconfig.go
+++ b/pkg/api/extensions/validation/operatingsystemconfig.go
@@ -41,12 +41,12 @@ func ValidateOperatingSystemConfig(osc *extensionsv1alpha1.OperatingSystemConfig
 }
 
 // ValidateOperatingSystemConfigUpdate validates a OperatingSystemConfig object before an update.
-func ValidateOperatingSystemConfigUpdate(new, old *extensionsv1alpha1.OperatingSystemConfig) field.ErrorList {
+func ValidateOperatingSystemConfigUpdate(newOperatingSystemConfig, oldOperatingSystemConfig *extensionsv1alpha1.OperatingSystemConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateOperatingSystemConfigSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateOperatingSystemConfig(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newOperatingSystemConfig.ObjectMeta, &oldOperatingSystemConfig.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateOperatingSystemConfigSpecUpdate(&newOperatingSystemConfig.Spec, &oldOperatingSystemConfig.Spec, newOperatingSystemConfig.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateOperatingSystemConfig(newOperatingSystemConfig)...)
 
 	return allErrs
 }
@@ -384,16 +384,16 @@ func ValidateFiles(files []extensionsv1alpha1.File, fldPath *field.Path) field.E
 }
 
 // ValidateOperatingSystemConfigSpecUpdate validates the spec of a OperatingSystemConfig object before an update.
-func ValidateOperatingSystemConfigSpecUpdate(new, old *extensionsv1alpha1.OperatingSystemConfigSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateOperatingSystemConfigSpecUpdate(newSpec, oldSpec *extensionsv1alpha1.OperatingSystemConfigSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update operatingsystemconfig spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Purpose, old.Purpose, fldPath.Child("purpose"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Purpose, oldSpec.Purpose, fldPath.Child("purpose"))...)
 
 	return allErrs
 }

--- a/pkg/api/extensions/validation/selfhostedshootexposure.go
+++ b/pkg/api/extensions/validation/selfhostedshootexposure.go
@@ -30,12 +30,12 @@ func ValidateSelfHostedShootExposure(exposure *extensionsv1alpha1.SelfHostedShoo
 }
 
 // ValidateSelfHostedShootExposureUpdate validates a SelfHostedShootExposure object before an update.
-func ValidateSelfHostedShootExposureUpdate(new, old *extensionsv1alpha1.SelfHostedShootExposure) field.ErrorList {
+func ValidateSelfHostedShootExposureUpdate(newSelfHostedShootExposure, oldSelfHostedShootExposure *extensionsv1alpha1.SelfHostedShootExposure) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateSelfHostedShootExposureSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateSelfHostedShootExposure(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newSelfHostedShootExposure.ObjectMeta, &oldSelfHostedShootExposure.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateSelfHostedShootExposureSpecUpdate(&newSelfHostedShootExposure.Spec, &oldSelfHostedShootExposure.Spec, newSelfHostedShootExposure.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateSelfHostedShootExposure(newSelfHostedShootExposure)...)
 
 	return allErrs
 }
@@ -103,15 +103,15 @@ func ValidateSelfHostedShootExposureSpec(spec *extensionsv1alpha1.SelfHostedShoo
 }
 
 // ValidateSelfHostedShootExposureSpecUpdate validates the spec of an SelfHostedShootExposure object before an update.
-func ValidateSelfHostedShootExposureSpecUpdate(new, old *extensionsv1alpha1.SelfHostedShootExposureSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateSelfHostedShootExposureSpecUpdate(newSpec, oldSpec *extensionsv1alpha1.SelfHostedShootExposureSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update SelfHostedShootExposure spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
 
 	return allErrs
 }

--- a/pkg/api/extensions/validation/worker.go
+++ b/pkg/api/extensions/validation/worker.go
@@ -29,12 +29,12 @@ func ValidateWorker(worker *extensionsv1alpha1.Worker) field.ErrorList {
 }
 
 // ValidateWorkerUpdate validates a Worker object before an update.
-func ValidateWorkerUpdate(new, old *extensionsv1alpha1.Worker) field.ErrorList {
+func ValidateWorkerUpdate(newWorker, oldWorker *extensionsv1alpha1.Worker) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateWorkerSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateWorker(new)...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newWorker.ObjectMeta, &oldWorker.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateWorkerSpecUpdate(&newWorker.Spec, &oldWorker.Spec, newWorker.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateWorker(newWorker)...)
 
 	return allErrs
 }
@@ -105,16 +105,16 @@ func validateArchitecture(arch *string, fldPath *field.Path) field.ErrorList {
 }
 
 // ValidateWorkerSpecUpdate validates the spec of a Worker object before an update.
-func ValidateWorkerSpecUpdate(new, old *extensionsv1alpha1.WorkerSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+func ValidateWorkerSpecUpdate(newSpec, oldSpec *extensionsv1alpha1.WorkerSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
-		diff := deep.Equal(new, old)
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		diff := deep.Equal(newSpec, oldSpec)
 		return field.ErrorList{field.Forbidden(fldPath, fmt.Sprintf("cannot update worker spec if deletion timestamp is set. Requested changes: %s", strings.Join(diff, ",")))}
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Region, old.Region, fldPath.Child("region"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Type, oldSpec.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Region, oldSpec.Region, fldPath.Child("region"))...)
 
 	return allErrs
 }

--- a/pkg/api/seedmanagement/validation/managedseedset.go
+++ b/pkg/api/seedmanagement/validation/managedseedset.go
@@ -299,14 +299,14 @@ func validatePendingReplica(pendingReplica *seedmanagement.PendingReplica, name 
 	return allErrs
 }
 
-func isDecremented(new, old *int32) bool {
-	if new == nil && old != nil {
+func isDecremented(newCount, oldCount *int32) bool {
+	if newCount == nil && oldCount != nil {
 		return true
 	}
-	if new == nil || old == nil {
+	if newCount == nil || oldCount == nil {
 		return false
 	}
-	return *new < *old
+	return *newCount < *oldCount
 }
 
 // parentNameAndOrdinalRegex is a regular expression that extracts the parent name and ordinal from a replica name.

--- a/pkg/apis/core/types_cloudprofile.go
+++ b/pkg/apis/core/types_cloudprofile.go
@@ -328,8 +328,8 @@ var order = map[VersionClassification]int{
 }
 
 // Compare compares two VersionClassification objects to determine their order.
-func (c1 VersionClassification) Compare(c2 VersionClassification) int {
-	return order[c1] - order[c2]
+func (v VersionClassification) Compare(other VersionClassification) int {
+	return order[v] - order[other]
 }
 
 const (

--- a/pkg/component/autoscaling/pvcautoscaler/assets/doc.go
+++ b/pkg/component/autoscaling/pvcautoscaler/assets/doc.go
@@ -7,5 +7,6 @@
 package assets
 
 import (
+	// Import to register the types for CRD generation.
 	_ "github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 )

--- a/pkg/component/autoscaling/pvcautoscaler/assets/doc.go
+++ b/pkg/component/autoscaling/pvcautoscaler/assets/doc.go
@@ -7,6 +7,5 @@
 package assets
 
 import (
-	// Import to register the types for CRD generation.
-	_ "github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
+	_ "github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1" // Import to register the types for CRD generation.
 )

--- a/pkg/component/autoscaling/pvcautoscaler/assets/doc.go
+++ b/pkg/component/autoscaling/pvcautoscaler/assets/doc.go
@@ -7,5 +7,6 @@
 package assets
 
 import (
-	_ "github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1" // required for generating CRDs
+	// Import to register the types for CRD generation.
+	_ "github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 )

--- a/pkg/component/autoscaling/pvcautoscaler/assets/doc.go
+++ b/pkg/component/autoscaling/pvcautoscaler/assets/doc.go
@@ -7,6 +7,5 @@
 package assets
 
 import (
-	// Import to register the types for CRD generation.
-	_ "github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
+	_ "github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1" // required for generating CRDs
 )

--- a/pkg/component/autoscaling/vpa/templates/doc.go
+++ b/pkg/component/autoscaling/vpa/templates/doc.go
@@ -7,5 +7,5 @@
 package templates
 
 import (
-	_ "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	_ "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2" // required for generating CRDs
 )

--- a/pkg/component/autoscaling/vpa/templates/doc.go
+++ b/pkg/component/autoscaling/vpa/templates/doc.go
@@ -7,6 +7,5 @@
 package templates
 
 import (
-	// Import to register the types for CRD generation.
-	_ "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	_ "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2" // Import to register the types for CRD generation.
 )

--- a/pkg/component/autoscaling/vpa/templates/doc.go
+++ b/pkg/component/autoscaling/vpa/templates/doc.go
@@ -7,5 +7,6 @@
 package templates
 
 import (
-	_ "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2" // required for generating CRDs
+	// Import to register the types for CRD generation.
+	_ "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 )

--- a/pkg/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/component/extensions/dnsrecord/dnsrecord.go
@@ -368,8 +368,8 @@ func (d *dnsRecord) isTimestampInvalidOrAfterLastUpdateTime() bool {
 	return false
 }
 
-func (d *dnsRecord) recordTypeChanged(old, new extensionsv1alpha1.DNSRecordType) bool {
-	return old != new
+func (d *dnsRecord) recordTypeChanged(oldType, newType extensionsv1alpha1.DNSRecordType) bool {
+	return oldType != newType
 }
 
 func newDNSRecord(values *Values) *extensionsv1alpha1.DNSRecord {

--- a/pkg/component/gardener/dashboard/terminal/assets/doc.go
+++ b/pkg/component/gardener/dashboard/terminal/assets/doc.go
@@ -7,6 +7,5 @@
 package assets
 
 import (
-	// Import to register the types for CRD generation.
-	_ "github.com/gardener/terminal-controller-manager/api/v1alpha1"
+	_ "github.com/gardener/terminal-controller-manager/api/v1alpha1" // Import to register the types for CRD generation.
 )

--- a/pkg/component/gardener/dashboard/terminal/assets/doc.go
+++ b/pkg/component/gardener/dashboard/terminal/assets/doc.go
@@ -7,5 +7,6 @@
 package assets
 
 import (
-	_ "github.com/gardener/terminal-controller-manager/api/v1alpha1" // required for generating CRDs
+	// Import to register the types for CRD generation.
+	_ "github.com/gardener/terminal-controller-manager/api/v1alpha1"
 )

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -131,17 +131,17 @@ var _ = Describe("istiod", func() {
 			return string(data)
 		}
 
-		istioIngressAutoscaler = func(min *int, max *int) string {
+		istioIngressAutoscaler = func(minCount *int, maxCount *int) string {
 			data, _ := os.ReadFile("./test_charts/ingress_autoscaler.yaml")
-			str := strings.ReplaceAll(string(data), "<MIN_REPLICAS>", strconv.Itoa(ptr.Deref(min, 2)))
-			str = strings.ReplaceAll(str, "<MAX_REPLICAS>", strconv.Itoa(ptr.Deref(max, 9)))
+			str := strings.ReplaceAll(string(data), "<MIN_REPLICAS>", strconv.Itoa(ptr.Deref(minCount, 2)))
+			str = strings.ReplaceAll(str, "<MAX_REPLICAS>", strconv.Itoa(ptr.Deref(maxCount, 9)))
 			return str
 		}
 
-		istioIngressAutoscalerTLSTerminationHPA = func(min *int, max *int) string {
+		istioIngressAutoscalerTLSTerminationHPA = func(minCount *int, maxCount *int) string {
 			data, _ := os.ReadFile("./test_charts/ingress_autoscaler_tls_termination_hpa.yaml")
-			str := strings.ReplaceAll(string(data), "<MIN_REPLICAS>", strconv.Itoa(ptr.Deref(min, 2)))
-			str = strings.ReplaceAll(str, "<MAX_REPLICAS>", strconv.Itoa(ptr.Deref(max, 9)))
+			str := strings.ReplaceAll(string(data), "<MIN_REPLICAS>", strconv.Itoa(ptr.Deref(minCount, 2)))
+			str = strings.ReplaceAll(str, "<MAX_REPLICAS>", strconv.Itoa(ptr.Deref(maxCount, 9)))
 			return str
 		}
 

--- a/pkg/component/shared/victorialogs.go
+++ b/pkg/component/shared/victorialogs.go
@@ -5,8 +5,7 @@
 package shared
 
 import (
-	// Registers SHA-256 with crypto.RegisterHash so github.com/opencontainers/go-digest can parse sha256 digests in SplitImageRef
-	_ "crypto/sha256"
+	_ "crypto/sha256" // registers SHA-256 with crypto.RegisterHash so github.com/opencontainers/go-digest can parse sha256 digests in SplitImageRef
 	"fmt"
 
 	"github.com/distribution/reference"

--- a/pkg/component/shared/victorialogs.go
+++ b/pkg/component/shared/victorialogs.go
@@ -5,7 +5,8 @@
 package shared
 
 import (
-	_ "crypto/sha256" // for SHA-256 hash registration
+	// Registers SHA-256 with crypto.RegisterHash so github.com/opencontainers/go-digest can parse sha256 digests in SplitImageRef
+	_ "crypto/sha256"
 	"fmt"
 
 	"github.com/distribution/reference"

--- a/pkg/component/shared/victorialogs.go
+++ b/pkg/component/shared/victorialogs.go
@@ -5,7 +5,7 @@
 package shared
 
 import (
-	_ "crypto/sha256"
+	_ "crypto/sha256" // for SHA-256 hash registration
 	"fmt"
 
 	"github.com/distribution/reference"

--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/add.go
@@ -196,19 +196,19 @@ func ShootPredicate(kind Kind) predicate.Predicate {
 	}
 }
 
-func shootNetworkingTypeHasChanged(old, new *gardencorev1beta1.Networking) bool {
-	if old == nil && new == nil {
+func shootNetworkingTypeHasChanged(oldNetworking, newNetworking *gardencorev1beta1.Networking) bool {
+	if oldNetworking == nil && newNetworking == nil {
 		return false
 	}
-	if old == nil && new != nil {
-		// if new is non-nil then return true if new has a type set
-		return new.Type != nil
+	if oldNetworking == nil && newNetworking != nil {
+		// if newNetworking is non-nil then return true if newNetworking has a type set
+		return newNetworking.Type != nil
 	}
-	if old != nil && new == nil {
-		// if old was non-nil and had a type set, return true
-		return old.Type != nil
+	if oldNetworking != nil && newNetworking == nil {
+		// if oldNetworking was non-nil and had a type set, return true
+		return oldNetworking.Type != nil
 	}
-	return !ptr.Equal(old.Type, new.Type)
+	return !ptr.Equal(oldNetworking.Type, newNetworking.Type)
 }
 
 // ResourceReferenceObjectPredicate returns true for objects in garden namespace labeled with

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -769,7 +769,7 @@ func determineKubernetesVersion(kubernetesVersion string, profile *gardencorev1b
 	return version, nil
 }
 
-func shouldKubernetesVersionBeUpdated(kubernetesVersion string, autoUpdate bool, profile *gardencorev1beta1.CloudProfile) (shouldBeUpdated bool, reason string, isExpired bool, error error) {
+func shouldKubernetesVersionBeUpdated(kubernetesVersion string, autoUpdate bool, profile *gardencorev1beta1.CloudProfile) (shouldBeUpdated bool, reason string, isExpired bool, err error) {
 	versionExistsInCloudProfile, version, err := v1beta1helper.KubernetesVersionExistsInCloudProfile(profile, kubernetesVersion)
 	if err != nil {
 		return false, "", false, err

--- a/pkg/gardenlet/bootstrap/certificate/certificate_util.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_util.go
@@ -47,11 +47,11 @@ func nextRotationDeadline(certificate tls.Certificate, validityConfig *gardenlet
 // try to rotate certificates at the same time for the rest of the lifetime
 func jitteryDuration(totalDuration float64, minPercentage, maxPercentage *int32) time.Duration {
 	var (
-		min = ptr.Deref(minPercentage, 70)
-		max = ptr.Deref(maxPercentage, 90)
+		minPercentageVal = ptr.Deref(minPercentage, 70)
+		maxPercentageVal = ptr.Deref(maxPercentage, 90)
 
-		minFactor = 1 - float64(min)/100
-		maxFactor = float64(max-min) / 100
+		minFactor = 1 - float64(minPercentageVal)/100
+		maxFactor = float64(maxPercentageVal-minPercentageVal) / 100
 	)
 
 	return wait.Jitter(time.Duration(totalDuration), maxFactor) - time.Duration(totalDuration*minFactor)

--- a/pkg/gardenlet/bootstrap/certificate/certificate_util.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_util.go
@@ -47,11 +47,11 @@ func nextRotationDeadline(certificate tls.Certificate, validityConfig *gardenlet
 // try to rotate certificates at the same time for the rest of the lifetime
 func jitteryDuration(totalDuration float64, minPercentage, maxPercentage *int32) time.Duration {
 	var (
-		minPercentageVal = ptr.Deref(minPercentage, 70)
-		maxPercentageVal = ptr.Deref(maxPercentage, 90)
+		minPercentageValue = ptr.Deref(minPercentage, 70)
+		maxPercentageValue = ptr.Deref(maxPercentage, 90)
 
-		minFactor = 1 - float64(minPercentageVal)/100
-		maxFactor = float64(maxPercentageVal-minPercentageVal) / 100
+		minFactor = 1 - float64(minPercentageValue)/100
+		maxFactor = float64(maxPercentageValue-minPercentageValue) / 100
 	)
 
 	return wait.Jitter(time.Duration(totalDuration), maxFactor) - time.Duration(totalDuration*minFactor)

--- a/pkg/gardenlet/controller/shoot/care/add_test.go
+++ b/pkg/gardenlet/controller/shoot/care/add_test.go
@@ -58,8 +58,8 @@ var _ = Describe("Add", func() {
 		})
 
 		It("should enqueue the object for Create events according to the calculated duration", func() {
-			DeferCleanup(test.WithVar(&RandomDurationWithMetaDuration, func(max *metav1.Duration) time.Duration {
-				return max.Duration
+			DeferCleanup(test.WithVar(&RandomDurationWithMetaDuration, func(maxDuration *metav1.Duration) time.Duration {
+				return maxDuration.Duration
 			}))
 
 			hdlr.Create(ctx, event.CreateEvent{Object: shoot}, queue)

--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -283,16 +283,16 @@ func (r *Reconciler) NodeReadyForInPlaceUpdate() predicate.Predicate {
 			return nodeHasInPlaceUpdateConditionWithReasonReadyForUpdate(node.Status.Conditions)
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			old, ok := e.ObjectOld.(*corev1.Node)
+			oldNode, ok := e.ObjectOld.(*corev1.Node)
 			if !ok {
 				return false
 			}
-			new, ok := e.ObjectNew.(*corev1.Node)
+			newNode, ok := e.ObjectNew.(*corev1.Node)
 			if !ok {
 				return false
 			}
 
-			return !nodeHasInPlaceUpdateConditionWithReasonReadyForUpdate(old.Status.Conditions) && nodeHasInPlaceUpdateConditionWithReasonReadyForUpdate(new.Status.Conditions)
+			return !nodeHasInPlaceUpdateConditionWithReasonReadyForUpdate(oldNode.Status.Conditions) && nodeHasInPlaceUpdateConditionWithReasonReadyForUpdate(newNode.Status.Conditions)
 		},
 		DeleteFunc: func(_ event.DeleteEvent) bool {
 			return false

--- a/pkg/provider-local/admission/validator/namespacedcloudprofile.go
+++ b/pkg/provider-local/admission/validator/namespacedcloudprofile.go
@@ -42,10 +42,10 @@ type namespacedCloudProfileValidator struct {
 }
 
 // Validate validates the given NamespacedCloudProfile objects.
-func (p *namespacedCloudProfileValidator) Validate(ctx context.Context, new, _ client.Object) error {
-	cloudProfile, ok := new.(*core.NamespacedCloudProfile)
+func (p *namespacedCloudProfileValidator) Validate(ctx context.Context, newNamespacedCloudProfile, _ client.Object) error {
+	cloudProfile, ok := newNamespacedCloudProfile.(*core.NamespacedCloudProfile)
 	if !ok {
-		return fmt.Errorf("wrong object type %T", new)
+		return fmt.Errorf("wrong object type %T", newNamespacedCloudProfile)
 	}
 
 	if cloudProfile.DeletionTimestamp != nil {

--- a/pkg/provider-local/webhook/shoot/mutator.go
+++ b/pkg/provider-local/webhook/shoot/mutator.go
@@ -32,8 +32,8 @@ func NewMutator() extensionswebhook.Mutator {
 	}
 }
 
-func (m *mutator) Mutate(ctx context.Context, new, _ client.Object) error {
-	acc, err := meta.Accessor(new)
+func (m *mutator) Mutate(ctx context.Context, newObj, _ client.Object) error {
+	acc, err := meta.Accessor(newObj)
 	if err != nil {
 		return fmt.Errorf("could not create accessor during webhook: %w", err)
 	}
@@ -43,7 +43,7 @@ func (m *mutator) Mutate(ctx context.Context, new, _ client.Object) error {
 		return nil
 	}
 
-	switch x := new.(type) {
+	switch x := newObj.(type) {
 	case *corev1.ConfigMap:
 		switch {
 		case strings.HasPrefix(x.Name, kubeproxy.ConfigNamePrefix):

--- a/pkg/resourcemanager/predicate/condition_status_test.go
+++ b/pkg/resourcemanager/predicate/condition_status_test.go
@@ -103,13 +103,13 @@ var _ = Describe("#ConditionStatusChanged", func() {
 	})
 
 	DescribeTable("DefaultConditionChange",
-		func(old, new *gardencorev1beta1.Condition, matcher types.GomegaMatcher) {
+		func(oldCondition, newCondition *gardencorev1beta1.Condition, matcher types.GomegaMatcher) {
 			managedResourceNew := managedResource.DeepCopy()
-			if old != nil {
-				managedResource.Status.Conditions = []gardencorev1beta1.Condition{*old}
+			if oldCondition != nil {
+				managedResource.Status.Conditions = []gardencorev1beta1.Condition{*oldCondition}
 			}
-			if new != nil {
-				managedResourceNew.Status.Conditions = []gardencorev1beta1.Condition{*new}
+			if newCondition != nil {
+				managedResourceNew.Status.Conditions = []gardencorev1beta1.Condition{*newCondition}
 			}
 			updateEvent.ObjectOld = managedResource
 			updateEvent.ObjectNew = managedResourceNew
@@ -139,13 +139,13 @@ var _ = Describe("#ConditionStatusChanged", func() {
 	)
 
 	DescribeTable("ConditionChangedToUnhealthy",
-		func(old, new *gardencorev1beta1.Condition, matcher types.GomegaMatcher) {
+		func(oldCondition, newCondition *gardencorev1beta1.Condition, matcher types.GomegaMatcher) {
 			managedResourceNew := managedResource.DeepCopy()
-			if old != nil {
-				managedResource.Status.Conditions = []gardencorev1beta1.Condition{*old}
+			if oldCondition != nil {
+				managedResource.Status.Conditions = []gardencorev1beta1.Condition{*oldCondition}
 			}
-			if new != nil {
-				managedResourceNew.Status.Conditions = []gardencorev1beta1.Condition{*new}
+			if newCondition != nil {
+				managedResourceNew.Status.Conditions = []gardencorev1beta1.Condition{*newCondition}
 			}
 			updateEvent.ObjectNew = managedResourceNew
 

--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -482,14 +482,14 @@ func filterCandidates(shoot *gardencorev1beta1.Shoot, shootList []*gardencorev1b
 func getSeedWithLeastShootsDeployed(seedList []gardencorev1beta1.Seed, shootList []*gardencorev1beta1.Shoot) (*gardencorev1beta1.Seed, error) {
 	var (
 		bestCandidate gardencorev1beta1.Seed
-		min           *int
+		minCount      *int
 		seedUsage     = v1beta1helper.CalculateSeedUsage(shootList)
 	)
 
 	for _, seed := range seedList {
-		if numberOfManagedShoots := seedUsage[seed.Name]; min == nil || numberOfManagedShoots < *min {
+		if numberOfManagedShoots := seedUsage[seed.Name]; minCount == nil || numberOfManagedShoots < *minCount {
 			bestCandidate = seed
-			min = &numberOfManagedShoots
+			minCount = &numberOfManagedShoots
 		}
 	}
 

--- a/pkg/utils/flow/taskfn_test.go
+++ b/pkg/utils/flow/taskfn_test.go
@@ -212,7 +212,7 @@ var _ = Describe("task functions", func() {
 			Eventually(func(g Gomega) {
 				tasks := 0
 				activeTasks.Range(func(_, _ any) bool {
-					tasks += 1
+					tasks++
 					return true
 				})
 				g.Expect(tasks).To(Equal(0))

--- a/pkg/utils/kubernetes/client/client.go
+++ b/pkg/utils/kubernetes/client/client.go
@@ -332,7 +332,7 @@ func ensureCollectionGone(ctx context.Context, c client.Client, log logr.Logger,
 	if err := meta.EachListItem(list, func(object runtime.Object) error {
 		for _, ignore := range ignoreFns {
 			if ignore(log, object.(client.Object)) {
-				ignoredObjects += 1
+				ignoredObjects++
 				return nil
 			}
 		}

--- a/pkg/utils/random.go
+++ b/pkg/utils/random.go
@@ -25,10 +25,10 @@ func GenerateRandomString(n int) (string, error) {
 // The set of allowed characters can be specified. Returns error if there was a problem during the random generation.
 func GenerateRandomStringFromCharset(n int, allowedCharacters string) (string, error) {
 	output := make([]byte, n)
-	max := new(big.Int).SetInt64(int64(len(allowedCharacters)))
+	maxVal := new(big.Int).SetInt64(int64(len(allowedCharacters)))
 
 	for i := range output {
-		randomCharacter, err := cryptorand.Int(cryptorand.Reader, max)
+		randomCharacter, err := cryptorand.Int(cryptorand.Reader, maxVal)
 		if err != nil {
 			return "", err
 		}
@@ -37,20 +37,20 @@ func GenerateRandomStringFromCharset(n int, allowedCharacters string) (string, e
 	return string(output), nil
 }
 
-// RandomDuration takes a time.Duration and computes a non-negative pseudo-random duration in [0,max).
-// It returns 0ns if max is <= 0ns.
-func RandomDuration(max time.Duration) time.Duration {
-	if max.Nanoseconds() <= 0 {
+// RandomDuration takes a time.Duration and computes a non-negative pseudo-random duration in [0,maxDuration).
+// It returns 0ns if maxDuration is <= 0ns.
+func RandomDuration(maxDuration time.Duration) time.Duration {
+	if maxDuration.Nanoseconds() <= 0 {
 		return time.Duration(0)
 	}
-	return time.Duration(mathrand.N(max.Nanoseconds())) // #nosec: G404 -- No cryptographic context.
+	return time.Duration(mathrand.N(maxDuration.Nanoseconds())) // #nosec: G404 -- No cryptographic context.
 }
 
-// RandomDurationWithMetaDuration takes a *metav1.Duration and computes a non-negative pseudo-random duration in [0,max).
-// It returns 0ns if max is nil or <= 0ns.
-func RandomDurationWithMetaDuration(max *metav1.Duration) time.Duration {
-	if max == nil {
+// RandomDurationWithMetaDuration takes a *metav1.Duration and computes a non-negative pseudo-random duration in [0,maxDuration).
+// It returns 0ns if maxDuration is nil or <= 0ns.
+func RandomDurationWithMetaDuration(maxDuration *metav1.Duration) time.Duration {
+	if maxDuration == nil {
 		return time.Duration(0)
 	}
-	return RandomDuration(max.Duration)
+	return RandomDuration(maxDuration.Duration)
 }

--- a/pkg/utils/test/matchers/managedresource_test.go
+++ b/pkg/utils/test/matchers/managedresource_test.go
@@ -157,7 +157,7 @@ var _ = Describe("ManagedResource Object Matcher", func() {
 					ExpectWithOffset(1, managedResource).To(matcher(configMap, deployment, secret))
 
 					deploymentModified := deployment.DeepCopy()
-					deploymentModified.Spec.MinReadySeconds += 1
+					deploymentModified.Spec.MinReadySeconds++
 					ExpectWithOffset(1, managedResource).NotTo(matcher(deploymentModified))
 				})
 			})

--- a/pkg/utils/validation/validation.go
+++ b/pkg/utils/validation/validation.go
@@ -13,24 +13,24 @@ import (
 )
 
 // ShouldEnforceImmutability compares the given slices and returns if a immutability should be enforced.
-// It mainly checks if the order of the same elements in `new` and `old` is the same, i.e. only an addition
-// of elements to `new` is allowed.
-func ShouldEnforceImmutability(new, old []string) bool {
-	sizeDelta := len(new) - len(old)
+// It mainly checks if the order of the same elements in `newValues` and `oldValues` is the same, i.e. only an addition
+// of elements to `newValues` is allowed.
+func ShouldEnforceImmutability(newValues, oldValues []string) bool {
+	sizeDelta := len(newValues) - len(oldValues)
 	if sizeDelta > 0 {
-		newA := new[:len(new)-sizeDelta]
-		if equal(newA, old) {
+		newA := newValues[:len(newValues)-sizeDelta]
+		if equal(newA, oldValues) {
 			return false
 		}
 
-		return ShouldEnforceImmutability(newA, old)
+		return ShouldEnforceImmutability(newA, oldValues)
 	}
 	return sizeDelta < 0 || sizeDelta == 0
 }
 
-func equal(new, old []string) bool {
-	for i := range new {
-		if new[i] != old[i] {
+func equal(newValues, oldValues []string) bool {
+	for i := range newValues {
+		if newValues[i] != oldValues[i] {
 			return false
 		}
 	}

--- a/pkg/utils/validation/validation.go
+++ b/pkg/utils/validation/validation.go
@@ -50,9 +50,8 @@ func ValidateFreeFormText(text string, fldPath *field.Path) field.ErrorList {
 	for _, r := range text {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsSpace(r) || strings.ContainsRune(allowedSpecialCharacters, r) {
 			continue
-		} else {
-			invalidCharacters = append(invalidCharacters, r)
 		}
+		invalidCharacters = append(invalidCharacters, r)
 	}
 
 	if len(invalidCharacters) > 0 {

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -121,15 +121,15 @@ func (r *VersionRange) SupportedVersionRange() string {
 }
 
 // CheckIfMinorVersionUpdate checks if the new version is a minor version update to the old version.
-func CheckIfMinorVersionUpdate(old, new string) (bool, error) {
-	oldVersion, err := semver.NewVersion(Normalize(old))
+func CheckIfMinorVersionUpdate(oldVersion, newVersion string) (bool, error) {
+	oldSemVer, err := semver.NewVersion(Normalize(oldVersion))
 	if err != nil {
-		return false, fmt.Errorf("failed to parse old version %s: %w", old, err)
+		return false, fmt.Errorf("failed to parse old version %s: %w", oldVersion, err)
 	}
-	newVersion, err := semver.NewVersion(Normalize(new))
+	newSemVer, err := semver.NewVersion(Normalize(newVersion))
 	if err != nil {
-		return false, fmt.Errorf("failed to parse new version %s: %w", new, err)
+		return false, fmt.Errorf("failed to parse new version %s: %w", newVersion, err)
 	}
 
-	return oldVersion.Minor() != newVersion.Minor(), nil
+	return oldSemVer.Minor() != newSemVer.Minor(), nil
 }

--- a/plugin/pkg/global/finalizerremoval/admission.go
+++ b/plugin/pkg/global/finalizerremoval/admission.go
@@ -183,11 +183,11 @@ func shootDeletionSucceeded(shoot *core.Shoot) bool {
 		lastOperation.Progress == 100
 }
 
-func isFinalizerRemoved(old, new metav1.Object, finalizerName string) bool {
+func isFinalizerRemoved(oldObj, newObj metav1.Object, finalizerName string) bool {
 	var (
-		oldFinalizers = sets.New(old.GetFinalizers()...)
-		newFinalizer  = sets.New(new.GetFinalizers()...)
+		oldFinalizers = sets.New(oldObj.GetFinalizers()...)
+		newFinalizers = sets.New(newObj.GetFinalizers()...)
 	)
 
-	return oldFinalizers.Has(finalizerName) && !newFinalizer.Has(finalizerName)
+	return oldFinalizers.Has(finalizerName) && !newFinalizers.Has(finalizerName)
 }

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -1554,11 +1554,11 @@ func isGardenadmUser(userInfo user.Info) bool {
 }
 
 // getRemovedMachineCapabilities returns the removed capabilities and their removed values.
-func getRemovedMachineCapabilities(old, new []core.CapabilityDefinition) []core.CapabilityDefinition {
+func getRemovedMachineCapabilities(oldCapabilities, newCapabilities []core.CapabilityDefinition) []core.CapabilityDefinition {
 	var (
 		removedCapabilities []core.CapabilityDefinition
-		oldCapabilitiesMap  = utils.CreateMapFromSlice(old, func(capability core.CapabilityDefinition) string { return capability.Name })
-		newCapabilitiesMap  = utils.CreateMapFromSlice(new, func(capability core.CapabilityDefinition) string { return capability.Name })
+		oldCapabilitiesMap  = utils.CreateMapFromSlice(oldCapabilities, func(capability core.CapabilityDefinition) string { return capability.Name })
+		newCapabilitiesMap  = utils.CreateMapFromSlice(newCapabilities, func(capability core.CapabilityDefinition) string { return capability.Name })
 	)
 
 	for capabilityName, oldCapability := range oldCapabilitiesMap {

--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -514,25 +514,25 @@ func getShootWorkerResources(shoot *core.Shoot, cloudProfile *gardencorev1beta1.
 	return workers
 }
 
-func lifetimeVerificationNeeded(new, old core.Shoot) bool {
-	oldLifetime, ok := old.Annotations[v1beta1constants.ShootExpirationTimestamp]
+func lifetimeVerificationNeeded(newShoot, oldShoot core.Shoot) bool {
+	oldLifetime, ok := oldShoot.Annotations[v1beta1constants.ShootExpirationTimestamp]
 	if !ok {
-		oldLifetime = old.CreationTimestamp.String()
+		oldLifetime = oldShoot.CreationTimestamp.String()
 	}
-	newLifetime := new.Annotations[v1beta1constants.ShootExpirationTimestamp]
+	newLifetime := newShoot.Annotations[v1beta1constants.ShootExpirationTimestamp]
 	return oldLifetime != newLifetime
 }
 
-func quotaVerificationNeeded(new, old core.Shoot) bool {
-	if !helper.NginxIngressEnabled(old.Spec.Addons) && helper.NginxIngressEnabled(new.Spec.Addons) {
+func quotaVerificationNeeded(newShoot, oldShoot core.Shoot) bool {
+	if !helper.NginxIngressEnabled(oldShoot.Spec.Addons) && helper.NginxIngressEnabled(newShoot.Spec.Addons) {
 		return true
 	}
 
 	// Check for diffs on workers
-	for _, worker := range new.Spec.Provider.Workers {
+	for _, worker := range newShoot.Spec.Provider.Workers {
 		oldHasWorker := false
 
-		for _, oldWorker := range old.Spec.Provider.Workers {
+		for _, oldWorker := range oldShoot.Spec.Provider.Workers {
 			if worker.Name == oldWorker.Name {
 				oldHasWorker = true
 

--- a/test/integration/extensions/webhook/cloudprovider/ensurer.go
+++ b/test/integration/extensions/webhook/cloudprovider/ensurer.go
@@ -28,10 +28,10 @@ type ensurer struct {
 // EnsureCloudProviderSecret is implemented on extension side which mutates the cloudprovider secret. contain
 // For testing purpose we are mutating the cloudprovider secret's data to check whether this
 // function is called in webhook.
-func (e *ensurer) EnsureCloudProviderSecret(_ context.Context, _ extensionscontextwebhook.GardenContext, new, _ *corev1.Secret) error {
-	e.logger.Info("Mutate cloudprovider secret", "namespace", new.Namespace, "name", new.Name)
-	new.Data["clientID"] = []byte(`foo`)
-	new.Data["clientSecret"] = []byte(`bar`)
+func (e *ensurer) EnsureCloudProviderSecret(_ context.Context, _ extensionscontextwebhook.GardenContext, newSecret, _ *corev1.Secret) error {
+	e.logger.Info("Mutate cloudprovider secret", "namespace", newSecret.Namespace, "name", newSecret.Name)
+	newSecret.Data["clientID"] = []byte(`foo`)
+	newSecret.Data["clientSecret"] = []byte(`bar`)
 
 	return nil
 }

--- a/test/integration/resourcemanager/health/crds/doc.go
+++ b/test/integration/resourcemanager/health/crds/doc.go
@@ -6,6 +6,5 @@
 package crds
 
 import (
-	// Import to register the types for CRD generation.
-	_ "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	_ "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1" // required for generating CRDs
 )

--- a/test/integration/resourcemanager/health/crds/doc.go
+++ b/test/integration/resourcemanager/health/crds/doc.go
@@ -6,5 +6,5 @@
 package crds
 
 import (
-	_ "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1" // required for generating CRDs
+	_ "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1" // Import to register the types for CRD generation.
 )

--- a/test/integration/resourcemanager/health/crds/doc.go
+++ b/test/integration/resourcemanager/health/crds/doc.go
@@ -6,5 +6,6 @@
 package crds
 
 import (
+	// Import to register the types for CRD generation.
 	_ "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 )

--- a/test/testmachinery/shoots/operations/worker.go
+++ b/test/testmachinery/shoots/operations/worker.go
@@ -49,30 +49,30 @@ var _ = ginkgo.Describe("Shoot worker operation testing", func() {
 			ginkgo.Skip("no workers defined")
 		}
 		var (
-			min = shoot.Spec.Provider.Workers[0].Minimum + 1
-			max = shoot.Spec.Provider.Workers[0].Maximum
+			minWorkers = shoot.Spec.Provider.Workers[0].Minimum + 1
+			maxWorkers = shoot.Spec.Provider.Workers[0].Maximum
 		)
-		if shoot.Spec.Provider.Workers[0].Maximum < min {
-			max = min
+		if shoot.Spec.Provider.Workers[0].Maximum < minWorkers {
+			maxWorkers = minWorkers
 		}
 
-		ginkgo.By(fmt.Sprintf("updating shoot worker to min of %d machines", min))
+		ginkgo.By(fmt.Sprintf("updating shoot worker to min of %d machines", minWorkers))
 		err := f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
-			shoot.Spec.Provider.Workers[0].Minimum = min
-			shoot.Spec.Provider.Workers[0].Maximum = max
+			shoot.Spec.Provider.Workers[0].Minimum = minWorkers
+			shoot.Spec.Provider.Workers[0].Maximum = maxWorkers
 			return nil
 		})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Scale down worker")
 
-		min = shoot.Spec.Provider.Workers[0].Minimum - 1
-		max = shoot.Spec.Provider.Workers[0].Maximum - 1
+		minWorkers = shoot.Spec.Provider.Workers[0].Minimum - 1
+		maxWorkers = shoot.Spec.Provider.Workers[0].Maximum - 1
 
-		ginkgo.By(fmt.Sprintf("updating shoot worker to min of %d machines", min))
+		ginkgo.By(fmt.Sprintf("updating shoot worker to min of %d machines", minWorkers))
 		err = f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
-			shoot.Spec.Provider.Workers[0].Minimum = min
-			shoot.Spec.Provider.Workers[0].Maximum = max
+			shoot.Spec.Provider.Workers[0].Minimum = minWorkers
+			shoot.Spec.Provider.Workers[0].Maximum = maxWorkers
 			return nil
 		})
 		framework.ExpectNoError(err)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Enables default revive linter rules by adding enable-default-rules: true to the revive configuration in .golangci.yaml.in. Previously, explicitly listing rules under rules: inadvertently disabled all default revive rules, causing violations to go undetected. This PR also fixes all resulting violations across the codebase.

**Which issue(s) this PR fixes**:
Fixes #11033

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
