### PR TITLE
Sync `hack/cherry-pick-pull.sh` with upstream and re-apply Gardener modifications

### DIFF
--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -311,8 +311,8 @@ Before you initiate a cherry pick, make sure that the following prerequisites ar
 - Have the `gardener/gardener` repository cloned as follows:
   - the `origin` remote should point to your fork (alternatively this can be overwritten by passing `FORK_REMOTE=<fork-remote>`).
   - the `upstream` remote should point to the Gardener GitHub org (alternatively this can be overwritten by passing `UPSTREAM_REMOTE=<upstream-remote>`).
-- Have `hub` installed. On macOS, `hub` can be installed via homebrew using the [hub formula](https://formulae.brew.sh/formula/hub). For other OS, follow the [`hub` installation instructions](https://github.com/mislav/hub?tab=readme-ov-file#installation).
-- A GitHub token which has permissions to create a PR in an upstream branch.
+- Have the GitHub CLI (`gh`) installed. On macOS, `gh` can be installed via homebrew using the [gh formula](https://formulae.brew.sh/formula/gh). For other OS, follow the [`gh` installation instructions](https://github.com/cli/cli#installation).
+- Authenticate with the GitHub CLI by running `gh auth login` and following the prompts.
 
 #### Run the Cherry Pick Script
 
@@ -331,9 +331,5 @@ Before you initiate a cherry pick, make sure that the following prerequisites ar
   - You will need to run the cherry pick script separately for each patch
     release you want to cherry pick to. Cherry picks should be applied to all
     active release branches where the fix is applicable.
-
-  - When asked for your GitHub password, provide the created GitHub token
-    rather than your actual GitHub password.
-    Refer [https://github.com/github/hub/issues/2655#issuecomment-735836048](https://github.com/github/hub/issues/2655#issuecomment-735836048)
 
 - [cherry-pick-script](../../hack/cherry-pick-pull.sh)

--- a/hack/cherry-pick-pull.sh
+++ b/hack/cherry-pick-pull.sh
@@ -38,7 +38,6 @@ STARTINGBRANCH=$(git symbolic-ref --short HEAD)
 declare -r STARTINGBRANCH
 declare -r REBASEMAGIC="${REPO_ROOT}/.git/rebase-apply"
 DRY_RUN=${DRY_RUN:-""}
-REGENERATE_DOCS=${REGENERATE_DOCS:-""}
 UPSTREAM_REMOTE=${UPSTREAM_REMOTE:-upstream}
 FORK_REMOTE=${FORK_REMOTE:-origin}
 MAIN_REPO_ORG=${MAIN_REPO_ORG:-$(git remote get-url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $3}')}
@@ -69,13 +68,10 @@ if [[ "$#" -lt 2 ]]; then
   echo "  This is useful for creating patches to a release branch without making a PR."
   echo "  When DRY_RUN is set the script will leave you in a branch containing the commits you cherry-picked."
   echo
-  echo "  Set the REGENERATE_DOCS environment var to regenerate documentation for the target branch after picking the specified commits."
-  echo "  This is useful when picking commits containing changes to API documentation."
-  echo
   echo "  Set UPSTREAM_REMOTE (default: upstream) and FORK_REMOTE (default: origin)"
   echo "  to override the default remote names to what you have locally."
   echo
-  echo "  For merge process info, see https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md"
+  echo "  For merge process info, see https://github.com/gardener/gardener/blob/master/docs/development/process.md#cherry-picks"
   exit 2
 fi
 
@@ -230,17 +226,6 @@ gitamcleanup=false
 if [[ -z "$(git log "${BRANCH}..HEAD" --oneline)" ]]; then
   echo "!!! No new commits after cherry-pick — patch is already applied to ${BRANCH}. Nothing to do."
   exit 0
-fi
-
-# Re-generate docs (if needed)
-if [[ -n "${REGENERATE_DOCS}" ]]; then
-  echo
-  echo "Regenerating docs..."
-  if ! hack/generate-docs.sh; then
-    echo
-    echo "hack/generate-docs.sh FAILED to complete."
-    exit 1
-  fi
 fi
 
 if [[ -n "${DRY_RUN}" ]]; then

--- a/hack/cherry-pick-pull.sh
+++ b/hack/cherry-pick-pull.sh
@@ -38,6 +38,7 @@ STARTINGBRANCH=$(git symbolic-ref --short HEAD)
 declare -r STARTINGBRANCH
 declare -r REBASEMAGIC="${REPO_ROOT}/.git/rebase-apply"
 DRY_RUN=${DRY_RUN:-""}
+REGENERATE_DOCS=${REGENERATE_DOCS:-""}
 UPSTREAM_REMOTE=${UPSTREAM_REMOTE:-upstream}
 FORK_REMOTE=${FORK_REMOTE:-origin}
 MAIN_REPO_ORG=${MAIN_REPO_ORG:-$(git remote get-url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $3}')}
@@ -51,8 +52,8 @@ if [[ -z ${GITHUB_USER:-} ]]; then
   exit 1
 fi
 
-if ! which hub > /dev/null; then
-  echo "Can't find 'hub' tool in PATH, please install from https://github.com/github/hub"
+if ! command -v gh > /dev/null; then
+  echo "Can't find 'gh' tool in PATH, please install from https://github.com/cli/cli"
   exit 1
 fi
 
@@ -68,10 +69,18 @@ if [[ "$#" -lt 2 ]]; then
   echo "  This is useful for creating patches to a release branch without making a PR."
   echo "  When DRY_RUN is set the script will leave you in a branch containing the commits you cherry-picked."
   echo
+  echo "  Set the REGENERATE_DOCS environment var to regenerate documentation for the target branch after picking the specified commits."
+  echo "  This is useful when picking commits containing changes to API documentation."
+  echo
   echo "  Set UPSTREAM_REMOTE (default: upstream) and FORK_REMOTE (default: origin)"
   echo "  to override the default remote names to what you have locally."
+  echo
+  echo "  For merge process info, see https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md"
   exit 2
 fi
+
+# Checks if you are logged in. Will error/bail if you are not.
+gh auth status
 
 if git_status=$(git status --porcelain --untracked=no 2>/dev/null) && [[ -n "${git_status}" ]]; then
   echo "!!! Dirty tree. Clean up and try again."
@@ -111,7 +120,6 @@ declare -r NEWBRANCHUNIQ
 echo "+++ Creating local branch ${NEWBRANCHUNIQ}"
 
 cleanbranch=""
-prtext=""
 gitamcleanup=false
 function return_to_kansas {
   if [[ "${gitamcleanup}" == "true" ]]; then
@@ -128,9 +136,6 @@ function return_to_kansas {
     if [[ -n "${cleanbranch}" ]]; then
       git branch -D "${cleanbranch}" >/dev/null 2>&1 || true
     fi
-    if [[ -n "${prtext}" ]]; then
-      rm "${prtext}"
-    fi
   fi
 }
 trap return_to_kansas EXIT
@@ -144,18 +149,12 @@ function make-a-pr() {
   echo
   echo "+++ Creating a pull request on GitHub at ${GITHUB_USER}:${NEWBRANCH}"
 
-  # This looks like an unnecessary use of a tmpfile, but it avoids
-  # https://github.com/github/hub/issues/976 Otherwise stdin is stolen
-  # when we shove the heredoc at hub directly, tickling the ioctl
-  # crash.
-  prtext="$(mktemp -t prtext.XXXX)" # cleaned in return_to_kansas
   local numandtitle
   numandtitle=$(printf '%s\n' "${SUBJECTS[@]}")
-  relnotes=$(printf "${RELEASE_NOTES[@]}")
-  labels=$(printf "${LABELS[@]}")
-  cat >"${prtext}" <<EOF
-[${rel}] Automated cherry pick of ${numandtitle}
+  local labels
+  labels=$(printf '%s\n' "${LABELS[@]}")
 
+  prtext=$(cat <<EOF
 ${labels}
 
 Cherry pick of ${PULLSUBJ} on ${rel}.
@@ -163,10 +162,11 @@ Cherry pick of ${PULLSUBJ} on ${rel}.
 ${numandtitle}
 
 **Release Notes:**
-${relnotes}
+$(printf '%s\n' "${RELEASE_NOTES[@]}")
 EOF
+)
 
-  hub pull-request -F "${prtext}" -h "${GITHUB_USER}:${NEWBRANCH}" -b "${MAIN_REPO_ORG}:${rel}"
+  gh pr create --title="[${rel}] Automated cherry pick of ${numandtitle}" --body="${prtext}" --head "${GITHUB_USER}:${NEWBRANCH}" --base "${rel}" --repo="${MAIN_REPO_ORG}/${MAIN_REPO_NAME}"
 }
 
 git checkout -b "${NEWBRANCHUNIQ}" "${BRANCH}"
@@ -192,7 +192,7 @@ for pull in "${PULLS[@]}"; do
       (git status --porcelain | grep ^U) || echo "!!! None. Did you git am --continue?"
       echo
       echo "+++ Please resolve the conflicts in another window (and remember to 'git add / git am --continue')"
-      read -p "+++ Proceed (anything but 'y' aborts the cherry-pick)? [y/n] " -r
+      read -p "+++ Proceed (anything other than 'y' aborts the cherry-pick)? [y/n] " -r
       echo
       if ! [[ "${REPLY}" =~ ^[yY]$ ]]; then
         echo "Aborting." >&2
@@ -207,20 +207,41 @@ for pull in "${PULLS[@]}"; do
   }
 
   # set the subject
-  pr_info=$(curl "https://api.github.com/repos/${MAIN_REPO_ORG}/${MAIN_REPO_NAME}/pulls/${pull}" -sS)
-  subject=$(echo ${pr_info} | jq -cr '.title')
+  subject=$(gh pr view "$pull" --json title --jq '.["title"]')
   SUBJECTS+=("#${pull}: ${subject}")
-  labels=$(echo ${pr_info} | jq '.labels[].name' -cr | grep -P '^(area|kind)' | sed -e 's|/| |' -e 's|^|/|g')
-  LABELS+=("${labels}")
+
+  # set the release note
+  release_note=$(gh pr view "$pull" --json body --jq '.body' | tr -d '\r' | awk "/^\`\`\` *${RELEASE_NOTE_CATEGORY} ${RELEASE_NOTE_TARGET_GROUP}/{f=1} f; /^\`\`\`$/{f=0}" || true)
+  RELEASE_NOTES+=("${release_note}")
+
+  # collect area/* and kind/* labels from the original PR as prow commands
+  while IFS= read -r label; do
+    if [[ -n "${label}" ]]; then
+      LABELS+=("${label}")
+    fi
+  done < <(gh pr view "$pull" --json labels --jq '.labels[].name | select(startswith("area/") or startswith("kind/"))' --repo="${MAIN_REPO_ORG}/${MAIN_REPO_NAME}" \
+    | sed -e 's|/| |' -e 's|^|/|g')
 
   # remove the patch file from /tmp
   rm -f "/tmp/${pull}.patch"
-
-  # get the release notes
-  notes=$(echo ${pr_info} | jq '.body' | grep -Po "\`\`\` *${RELEASE_NOTE_CATEGORY} ${RELEASE_NOTE_TARGET_GROUP}.*?\`\`\`" || true)
-  RELEASE_NOTES+=("${notes}")
 done
 gitamcleanup=false
+
+if [[ -z "$(git log "${BRANCH}..HEAD" --oneline)" ]]; then
+  echo "!!! No new commits after cherry-pick — patch is already applied to ${BRANCH}. Nothing to do."
+  exit 0
+fi
+
+# Re-generate docs (if needed)
+if [[ -n "${REGENERATE_DOCS}" ]]; then
+  echo
+  echo "Regenerating docs..."
+  if ! hack/generate-docs.sh; then
+    echo
+    echo "hack/generate-docs.sh FAILED to complete."
+    exit 1
+  fi
+fi
 
 if [[ -n "${DRY_RUN}" ]]; then
   echo "!!! Skipping git push and PR creation because you set DRY_RUN."

--- a/hack/cherry-pick-pull.sh
+++ b/hack/cherry-pick-pull.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # This file was copied from the kubernetes/kubernetes project
-# https://github.com/kubernetes/kubernetes/blob/v1.20.0/hack/cherry_pick_pull.sh
+# https://github.com/kubernetes/kubernetes/blob/v1.36.3/hack/cherry_pick_pull.sh
 #
 # Modifications Copyright SAP SE or an SAP affiliate company and Gardener contributors
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Replaces the deprecated `hub` CLI tool with `gh` in `hack/cherry-pick-pull.sh`. The `hub` tool is no longer maintained and `gh` is the recommended GitHub CLI. Additionally improves the script to detect already-applied patches early and exit with a clear message instead of pushing an empty branch and failing on PR creation.

**Which issue(s) this PR fixes**:
Fixes #13892

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Replaced deprecated `hub` CLI with `gh` in `hack/cherry-pick-pull.sh` and improved patch detection to exit early when a patch is already applied to the target branch.
```
