### PR TITLE
[GEP-28] Support shoot `gardenlet` kubeconfig renewal

### DIFF
--- a/dev-setup/skaffold-operator.yaml
+++ b/dev-setup/skaffold-operator.yaml
@@ -689,6 +689,7 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/routes
             - pkg/features
+            - pkg/gardenlet/bootstrap/util
             - pkg/healthz
             - pkg/logger
             - pkg/operator/client

--- a/hack/usage/rebootstrap-gardenlet.sh
+++ b/hack/usage/rebootstrap-gardenlet.sh
@@ -95,15 +95,17 @@ function validate_requirements() {
   # Determine mode and validate mode-specific options
   local has_seed=false
   local has_shoot=false
-  [[ -n "$SEED_KUBECONFIG" || -n "$SEED_NAME" ]] && has_seed=true
-  [[ -n "$SHOOT_KUBECONFIG" || -n "$SHOOT_NAMESPACE" || -n "$SHOOT_NAME" ]] && has_shoot=true
+  if [[ -n "$SEED_KUBECONFIG" || -n "$SEED_NAME" ]]; then
+    has_seed=true
+  fi
+  if [[ -n "$SHOOT_KUBECONFIG" || -n "$SHOOT_NAMESPACE" || -n "$SHOOT_NAME" ]]; then
+    has_shoot=true
+  fi
 
   if [[ "$has_seed" == "true" && "$has_shoot" == "true" ]]; then
     log_error "--seed-* and --shoot-* options are mutually exclusive."
     exit 1
-  fi
-
-  if [[ "$has_seed" == "false" && "$has_shoot" == "false" ]]; then
+  elif [[ "$has_seed" == "false" && "$has_shoot" == "false" ]]; then
     log_error "Either --seed-kubeconfig/--seed-name or --shoot-kubeconfig/--shoot-namespace/--shoot-name must be provided."
     exit 1
   fi
@@ -127,7 +129,7 @@ function validate_requirements() {
     fi
 
     GARDENLET_NAMESPACE="garden"
-    BOOTSTRAP_KUBECONFIG_SECRET_NAME="gardenlet-bootstrap-kubeconfig"
+    BOOTSTRAP_KUBECONFIG_SECRET_NAME="gardenlet-kubeconfig-bootstrap"
     TARGET_KUBECONFIG="$SEED_KUBECONFIG"
   else
     MODE="shoot"
@@ -187,7 +189,7 @@ function create_bootstrap_token() {
   local token_name="bootstrap-token-${BOOTSTRAP_TOKEN_ID}"
   local description
   if [[ "$MODE" == "seed" ]]; then
-    description="Bootstrap token for gardenlet rebootstrap of seed ${SEED_NAME}"
+    description="Used for reconnecting the gardenlet for seed ${SEED_NAME} to Gardener"
   else
     description="Used for connecting the self-hosted Shoot ${SHOOT_NAMESPACE}/${SHOOT_NAME}"
   fi

--- a/hack/usage/rebootstrap-gardenlet.sh
+++ b/hack/usage/rebootstrap-gardenlet.sh
@@ -16,10 +16,15 @@ NC='\033[0m' # No Color
 GARDEN_KUBECONFIG="${GARDEN_KUBECONFIG:-}"
 SEED_KUBECONFIG="${SEED_KUBECONFIG:-}"
 SEED_NAME="${SEED_NAME:-}"
+SHOOT_KUBECONFIG="${SHOOT_KUBECONFIG:-}"
+SHOOT_NAMESPACE="${SHOOT_NAMESPACE:-}"
+SHOOT_NAME="${SHOOT_NAME:-}"
 BOOTSTRAP_TOKEN_ID=""
 BOOTSTRAP_TOKEN_SECRET=""
-GARDENLET_NAMESPACE="garden"
+GARDENLET_NAMESPACE=""
 GARDENLET_DEPLOYMENT_NAME="gardenlet"
+BOOTSTRAP_KUBECONFIG_SECRET_NAME=""
+MODE="" # "seed" or "shoot"
 
 function log_info() {
   echo -e "${GREEN}[INFO]${NC} $1"
@@ -44,10 +49,18 @@ Prerequisites:
   - kubectl
   - yq (https://github.com/mikefarah/yq)
 
-Required Options:
+Required Options (seed gardenlet):
   --garden-kubeconfig PATH    Path to garden cluster kubeconfig
   --seed-kubeconfig PATH      Path to seed cluster kubeconfig
   --seed-name NAME            Name of the seed
+
+Required Options (shoot gardenlet):
+  --garden-kubeconfig PATH    Path to garden cluster kubeconfig
+  --shoot-kubeconfig PATH     Path to shoot cluster kubeconfig
+  --shoot-namespace NAMESPACE Namespace of the shoot in the garden cluster
+  --shoot-name NAME           Name of the shoot
+
+Note: --seed-* and --shoot-* options are mutually exclusive.
 
 Optional:
   --token-id ID               Bootstrap token ID (6 characters, random if not provided)
@@ -56,7 +69,7 @@ Optional:
 
 Examples:
   $0 --garden-kubeconfig ~/.kube/garden.yaml --seed-kubeconfig ~/.kube/seed.yaml --seed-name my-seed
-  $0 --garden-kubeconfig garden.yaml --seed-kubeconfig seed.yaml --seed-name my-seed
+  $0 --garden-kubeconfig ~/.kube/garden.yaml --shoot-kubeconfig ~/.kube/shoot.yaml --shoot-namespace garden --shoot-name my-shoot
 
 EOF
 }
@@ -79,19 +92,69 @@ function validate_requirements() {
     exit 1
   fi
 
-  if [[ -z "$SEED_KUBECONFIG" ]]; then
-    log_error "Seed kubeconfig is required. Use --seed-kubeconfig option."
+  # Determine mode and validate mode-specific options
+  local has_seed=false
+  local has_shoot=false
+  [[ -n "$SEED_KUBECONFIG" || -n "$SEED_NAME" ]] && has_seed=true
+  [[ -n "$SHOOT_KUBECONFIG" || -n "$SHOOT_NAMESPACE" || -n "$SHOOT_NAME" ]] && has_shoot=true
+
+  if [[ "$has_seed" == "true" && "$has_shoot" == "true" ]]; then
+    log_error "--seed-* and --shoot-* options are mutually exclusive."
     exit 1
   fi
 
-  if [[ ! -f "$SEED_KUBECONFIG" ]]; then
-    log_error "Seed kubeconfig file not found: $SEED_KUBECONFIG"
+  if [[ "$has_seed" == "false" && "$has_shoot" == "false" ]]; then
+    log_error "Either --seed-kubeconfig/--seed-name or --shoot-kubeconfig/--shoot-namespace/--shoot-name must be provided."
     exit 1
   fi
 
-  if [[ -z "$SEED_NAME" ]]; then
-    log_error "Seed name is required. Use --seed-name option."
-    exit 1
+  if [[ "$has_seed" == "true" ]]; then
+    MODE="seed"
+
+    if [[ -z "$SEED_KUBECONFIG" ]]; then
+      log_error "Seed kubeconfig is required. Use --seed-kubeconfig option."
+      exit 1
+    fi
+
+    if [[ ! -f "$SEED_KUBECONFIG" ]]; then
+      log_error "Seed kubeconfig file not found: $SEED_KUBECONFIG"
+      exit 1
+    fi
+
+    if [[ -z "$SEED_NAME" ]]; then
+      log_error "Seed name is required. Use --seed-name option."
+      exit 1
+    fi
+
+    GARDENLET_NAMESPACE="garden"
+    BOOTSTRAP_KUBECONFIG_SECRET_NAME="gardenlet-bootstrap-kubeconfig"
+    TARGET_KUBECONFIG="$SEED_KUBECONFIG"
+  else
+    MODE="shoot"
+
+    if [[ -z "$SHOOT_KUBECONFIG" ]]; then
+      log_error "Shoot kubeconfig is required. Use --shoot-kubeconfig option."
+      exit 1
+    fi
+
+    if [[ ! -f "$SHOOT_KUBECONFIG" ]]; then
+      log_error "Shoot kubeconfig file not found: $SHOOT_KUBECONFIG"
+      exit 1
+    fi
+
+    if [[ -z "$SHOOT_NAMESPACE" ]]; then
+      log_error "Shoot namespace is required. Use --shoot-namespace option."
+      exit 1
+    fi
+
+    if [[ -z "$SHOOT_NAME" ]]; then
+      log_error "Shoot name is required. Use --shoot-name option."
+      exit 1
+    fi
+
+    GARDENLET_NAMESPACE="kube-system"
+    BOOTSTRAP_KUBECONFIG_SECRET_NAME="gardenlet-kubeconfig-bootstrap"
+    TARGET_KUBECONFIG="$SHOOT_KUBECONFIG"
   fi
 
   if ! command -v kubectl &> /dev/null; then
@@ -105,13 +168,12 @@ function validate_requirements() {
     exit 1
   fi
 
-  log_info "All requirements validated successfully"
+  log_info "All requirements validated successfully (mode: $MODE)"
 }
 
 function create_bootstrap_token() {
   log_info "Creating bootstrap token in garden cluster..."
 
-  # Generate token ID and secret if not provided
   if [[ -z "$BOOTSTRAP_TOKEN_ID" ]]; then
     BOOTSTRAP_TOKEN_ID=$(generate_random_string 6)
     log_info "Generated token ID: $BOOTSTRAP_TOKEN_ID"
@@ -123,6 +185,12 @@ function create_bootstrap_token() {
   fi
 
   local token_name="bootstrap-token-${BOOTSTRAP_TOKEN_ID}"
+  local description
+  if [[ "$MODE" == "seed" ]]; then
+    description="Bootstrap token for gardenlet rebootstrap of seed ${SEED_NAME}"
+  else
+    description="Used for connecting the self-hosted Shoot ${SHOOT_NAMESPACE}/${SHOOT_NAME}"
+  fi
 
   # Check if token already exists
   if kubectl --kubeconfig="$GARDEN_KUBECONFIG" -n kube-system get secret "$token_name" &> /dev/null; then
@@ -138,10 +206,9 @@ function create_bootstrap_token() {
     fi
   fi
 
-  # Create bootstrap token secret
   kubectl --kubeconfig="$GARDEN_KUBECONFIG" -n kube-system create secret generic "$token_name" \
     --type=bootstrap.kubernetes.io/token \
-    --from-literal=description="Bootstrap token for gardenlet rebootstrap of seed ${SEED_NAME}" \
+    --from-literal=description="$description" \
     --from-literal=token-id="$BOOTSTRAP_TOKEN_ID" \
     --from-literal=token-secret="$BOOTSTRAP_TOKEN_SECRET" \
     --from-literal=usage-bootstrap-authentication=true \
@@ -153,7 +220,6 @@ function create_bootstrap_token() {
 function get_garden_cluster_info() {
   log_info "Extracting garden cluster information..."
 
-  # Extract server and CA from garden kubeconfig
   GARDEN_SERVER=$(kubectl --kubeconfig="$GARDEN_KUBECONFIG" config view --minify -o jsonpath='{.clusters[0].cluster.server}')
   GARDEN_CA=$(kubectl --kubeconfig="$GARDEN_KUBECONFIG" config view --minify --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
 
@@ -171,12 +237,10 @@ function get_garden_cluster_info() {
 }
 
 function create_bootstrap_kubeconfig_secret() {
-  log_info "Creating bootstrap kubeconfig secret in seed cluster..."
+  log_info "Creating bootstrap kubeconfig secret in target cluster..."
 
   local bootstrap_token="${BOOTSTRAP_TOKEN_ID}.${BOOTSTRAP_TOKEN_SECRET}"
-  local secret_name="gardenlet-bootstrap-kubeconfig"
 
-  # Create bootstrap kubeconfig
   local bootstrap_kubeconfig=$(cat <<EOF
 apiVersion: v1
 kind: Config
@@ -198,31 +262,27 @@ users:
 EOF
 )
 
-  # Check if secret already exists
-  if kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get secret "$secret_name" &> /dev/null; then
-    log_warn "Bootstrap kubeconfig secret '$secret_name' already exists in seed cluster"
-    kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" delete secret "$secret_name"
+  if kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get secret "$BOOTSTRAP_KUBECONFIG_SECRET_NAME" &> /dev/null; then
+    log_warn "Bootstrap kubeconfig secret '$BOOTSTRAP_KUBECONFIG_SECRET_NAME' already exists in target cluster"
+    kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" delete secret "$BOOTSTRAP_KUBECONFIG_SECRET_NAME"
     log_info "Deleted existing bootstrap kubeconfig secret"
   fi
 
-  # Create secret with bootstrap kubeconfig
-  kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" create secret generic "$secret_name" \
+  kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" create secret generic "$BOOTSTRAP_KUBECONFIG_SECRET_NAME" \
     --from-literal=kubeconfig="$bootstrap_kubeconfig"
 
-  log_info "Bootstrap kubeconfig secret created successfully: $secret_name"
+  log_info "Bootstrap kubeconfig secret created successfully: $BOOTSTRAP_KUBECONFIG_SECRET_NAME"
 }
 
 function update_gardenlet_configuration() {
   log_info "Updating gardenlet configuration..."
 
-  # Get the gardenlet deployment
-  if ! kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get deployment "$GARDENLET_DEPLOYMENT_NAME" &> /dev/null; then
+  if ! kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get deployment "$GARDENLET_DEPLOYMENT_NAME" &> /dev/null; then
     log_error "Gardenlet deployment '$GARDENLET_DEPLOYMENT_NAME' not found in namespace '$GARDENLET_NAMESPACE'"
     exit 1
   fi
 
-  # Find the ConfigMap used by the gardenlet deployment (volume name: gardenlet-config)
-  local configmap_name=$(kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get deployment "$GARDENLET_DEPLOYMENT_NAME" -o jsonpath='{.spec.template.spec.volumes[?(@.name=="gardenlet-config")].configMap.name}')
+  local configmap_name=$(kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get deployment "$GARDENLET_DEPLOYMENT_NAME" -o jsonpath='{.spec.template.spec.volumes[?(@.name=="gardenlet-config")].configMap.name}')
 
   if [[ -z "$configmap_name" ]]; then
     log_error "Could not find ConfigMap referenced by gardenlet deployment volume 'gardenlet-config'"
@@ -232,43 +292,35 @@ function update_gardenlet_configuration() {
 
   log_info "Found ConfigMap: $configmap_name"
 
-  # Get the current ConfigMap content and extract the config.yaml key (this is where the GardenletConfiguration is stored)
   local config_key="config\.yaml"
-  local config_content=$(kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get configmap "$configmap_name" -o jsonpath="{.data['$config_key']}")
+  local config_content=$(kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get configmap "$configmap_name" -o jsonpath="{.data['$config_key']}")
 
   if [[ -z "$config_content" ]]; then
     log_error "Could not find '$config_key' in ConfigMap '$configmap_name'"
     exit 1
   fi
 
-  # Create a temporary file with the current config
   local temp_config=$(mktemp)
   echo "$config_content" > "$temp_config"
 
-  # Update or add bootstrapKubeconfig configuration using yq
   log_info "Updating gardenlet configuration with bootstrap kubeconfig..."
-  yq eval -i ".gardenClientConnection.bootstrapKubeconfig.name = \"gardenlet-bootstrap-kubeconfig\"" "$temp_config"
+  yq eval -i ".gardenClientConnection.bootstrapKubeconfig.name = \"$BOOTSTRAP_KUBECONFIG_SECRET_NAME\"" "$temp_config"
   yq eval -i ".gardenClientConnection.bootstrapKubeconfig.namespace = \"$GARDENLET_NAMESPACE\"" "$temp_config"
 
-  # Generate a new ConfigMap name with timestamp to ensure uniqueness
   local timestamp=$(date +%s)
   local new_configmap_name="${configmap_name}-rebootstrap-${timestamp}"
 
   log_info "Creating new ConfigMap: $new_configmap_name"
 
-  # Create the new ConfigMap with updated configuration
-  kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" create configmap "$new_configmap_name" \
+  kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" create configmap "$new_configmap_name" \
     --from-file="${config_key//\\/}=${temp_config}"
 
-  # Clean up temp file
   rm -f "$temp_config"
 
-  # Update the deployment to use the new ConfigMap
   log_info "Updating gardenlet deployment to use new ConfigMap..."
 
-  # Get all volumes and update the gardenlet-config volume to reference the new ConfigMap
   local volumes_json
-  volumes_json=$(kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get deployment "$GARDENLET_DEPLOYMENT_NAME" \
+  volumes_json=$(kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get deployment "$GARDENLET_DEPLOYMENT_NAME" \
     -o yaml | yq eval '(.spec.template.spec.volumes[] | select(.name == "gardenlet-config") | .configMap.name) = "'"$new_configmap_name"'" | .spec.template.spec.volumes' -o json -)
 
   if [[ -z "$volumes_json" ]] || [[ "$volumes_json" == "null" ]]; then
@@ -276,8 +328,7 @@ function update_gardenlet_configuration() {
     exit 1
   fi
 
-  # Patch the deployment to reference the new ConfigMap
-  kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" patch deployment "$GARDENLET_DEPLOYMENT_NAME" --type=json -p="[
+  kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" patch deployment "$GARDENLET_DEPLOYMENT_NAME" --type=json -p="[
     {
       \"op\": \"replace\",
       \"path\": \"/spec/template/spec/volumes\",
@@ -296,8 +347,8 @@ function delete_expired_kubeconfig() {
 
   local kubeconfig_secret_name="gardenlet-kubeconfig"
 
-  if kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get secret "$kubeconfig_secret_name" &> /dev/null; then
-    kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" delete secret "$kubeconfig_secret_name"
+  if kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get secret "$kubeconfig_secret_name" &> /dev/null; then
+    kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" delete secret "$kubeconfig_secret_name"
     log_info "Deleted expired kubeconfig secret: $kubeconfig_secret_name"
   else
     log_warn "Kubeconfig secret '$kubeconfig_secret_name' not found, skipping deletion"
@@ -307,10 +358,10 @@ function delete_expired_kubeconfig() {
 function wait_for_gardenlet_rollout() {
   log_info "Waiting for gardenlet deployment rollout..."
 
-  if kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get deployment "$GARDENLET_DEPLOYMENT_NAME" &> /dev/null; then
+  if kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get deployment "$GARDENLET_DEPLOYMENT_NAME" &> /dev/null; then
     log_info "The deployment will restart automatically due to the ConfigMap change"
     log_info "Waiting for rollout to complete..."
-    kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" rollout status deployment "$GARDENLET_DEPLOYMENT_NAME" --timeout=5m
+    kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" rollout status deployment "$GARDENLET_DEPLOYMENT_NAME" --timeout=5m
     log_info "Gardenlet deployment rollout completed successfully"
   else
     log_error "Gardenlet deployment '$GARDENLET_DEPLOYMENT_NAME' not found in namespace '$GARDENLET_NAMESPACE'"
@@ -322,23 +373,20 @@ function verify_bootstrap() {
   log_info "Verifying bootstrap success..."
 
   local kubeconfig_secret_name="gardenlet-kubeconfig"
-  local bootstrap_secret_name="gardenlet-bootstrap-kubeconfig"
   local max_wait=300
   local elapsed=0
   local interval=10
 
-  # Wait for new kubeconfig secret to be created
   log_info "Waiting for new kubeconfig secret to be created..."
   while [[ $elapsed -lt $max_wait ]]; do
-    if kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get secret "$kubeconfig_secret_name" &> /dev/null; then
+    if kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get secret "$kubeconfig_secret_name" &> /dev/null; then
       log_info "✓ New kubeconfig secret created"
       break
     fi
     sleep $interval
     elapsed=$((elapsed + interval))
 
-    # Check if bootstrap secret was deleted
-    if kubectl --kubeconfig="$SEED_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get secret "$bootstrap_secret_name" &> /dev/null; then
+    if kubectl --kubeconfig="$TARGET_KUBECONFIG" -n "$GARDENLET_NAMESPACE" get secret "$BOOTSTRAP_KUBECONFIG_SECRET_NAME" &> /dev/null; then
       log_warn "⚠ Bootstrap secret still exists (it should be deleted automatically)"
     else
       log_info "✓ Bootstrap secret was deleted"
@@ -349,46 +397,74 @@ function verify_bootstrap() {
   if [[ $elapsed -ge $max_wait ]]; then
     log_error "Timeout waiting for new kubeconfig secret to be created"
     log_error "Check gardenlet logs for errors:"
-    log_error "  kubectl --kubeconfig=$SEED_KUBECONFIG -n $GARDENLET_NAMESPACE logs deployment/$GARDENLET_DEPLOYMENT_NAME"
+    log_error "  kubectl --kubeconfig=$TARGET_KUBECONFIG -n $GARDENLET_NAMESPACE logs deployment/$GARDENLET_DEPLOYMENT_NAME"
     exit 1
   fi
 
-  # Check seed status in garden cluster with retry logic
-  log_info "Checking seed status in garden cluster..."
-
-  if ! kubectl --kubeconfig="$GARDEN_KUBECONFIG" get seed "$SEED_NAME" &> /dev/null; then
-    log_error "Seed resource '$SEED_NAME' not found in garden cluster"
-    exit 1
-  fi
-
-  # Wait for gardenlet to become ready
-  log_info "Waiting for gardenlet to report ready status..."
-  local seed_max_wait=120  # 2 minutes
+  local seed_max_wait=120
   local seed_elapsed=0
   local seed_interval=5
 
-  while [[ $seed_elapsed -lt $seed_max_wait ]]; do
-    local gardenlet_ready
-    gardenlet_ready=$(kubectl --kubeconfig="$GARDEN_KUBECONFIG" get seed "$SEED_NAME" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}' 2>/dev/null || echo "")
+  if [[ "$MODE" == "seed" ]]; then
+    log_info "Checking seed status in garden cluster..."
 
-    if [[ "$gardenlet_ready" == "True" ]]; then
-      log_info "✓ Seed is healthy and gardenlet is ready"
-      break
+    if ! kubectl --kubeconfig="$GARDEN_KUBECONFIG" get seed "$SEED_NAME" &> /dev/null; then
+      log_error "Seed resource '$SEED_NAME' not found in garden cluster"
+      exit 1
     fi
 
-    sleep $seed_interval
-    seed_elapsed=$((seed_elapsed + seed_interval))
-    echo -n "."
-  done
-  echo
+    log_info "Waiting for gardenlet to report ready status..."
+    while [[ $seed_elapsed -lt $seed_max_wait ]]; do
+      local gardenlet_ready
+      gardenlet_ready=$(kubectl --kubeconfig="$GARDEN_KUBECONFIG" get seed "$SEED_NAME" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}' 2>/dev/null || echo "")
+
+      if [[ "$gardenlet_ready" == "True" ]]; then
+        log_info "✓ Seed is healthy and gardenlet is ready"
+        break
+      fi
+
+      sleep $seed_interval
+      seed_elapsed=$((seed_elapsed + seed_interval))
+      echo -n "."
+    done
+    echo
+  else
+    log_info "Checking shoot status in garden cluster..."
+
+    if ! kubectl --kubeconfig="$GARDEN_KUBECONFIG" -n "$SHOOT_NAMESPACE" get shoot "$SHOOT_NAME" &> /dev/null; then
+      log_error "Shoot resource '$SHOOT_NAMESPACE/$SHOOT_NAME' not found in garden cluster"
+      exit 1
+    fi
+
+    log_info "Waiting for gardenlet to report ready status..."
+    while [[ $seed_elapsed -lt $seed_max_wait ]]; do
+      local gardenlet_ready
+      gardenlet_ready=$(kubectl --kubeconfig="$GARDEN_KUBECONFIG" -n "$SHOOT_NAMESPACE" get shoot "$SHOOT_NAME" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}' 2>/dev/null || echo "")
+
+      if [[ "$gardenlet_ready" == "True" ]]; then
+        log_info "✓ Shoot gardenlet is ready"
+        break
+      fi
+
+      sleep $seed_interval
+      seed_elapsed=$((seed_elapsed + seed_interval))
+      echo -n "."
+    done
+    echo
+  fi
 
   log_info "Deleting bootstrap token secret"
   kubectl --kubeconfig=$GARDEN_KUBECONFIG -n kube-system delete secret bootstrap-token-$BOOTSTRAP_TOKEN_ID --ignore-not-found
 
   if [[ $seed_elapsed -ge $seed_max_wait ]]; then
     log_warn "⚠ Timeout waiting for gardenlet to report ready status"
-    log_warn "  The bootstrap may still be in progress. Check seed status manually:"
-    log_warn "  kubectl --kubeconfig=$GARDEN_KUBECONFIG get seed $SEED_NAME -o yaml | yq eval .status.conditions"
+    if [[ "$MODE" == "seed" ]]; then
+      log_warn "  The bootstrap may still be in progress. Check seed status manually:"
+      log_warn "  kubectl --kubeconfig=$GARDEN_KUBECONFIG get seed $SEED_NAME -o yaml | yq eval .status.conditions"
+    else
+      log_warn "  The bootstrap may still be in progress. Check shoot status manually:"
+      log_warn "  kubectl --kubeconfig=$GARDEN_KUBECONFIG -n $SHOOT_NAMESPACE get shoot $SHOOT_NAME -o yaml | yq eval .status.conditions"
+    fi
   fi
 
   log_info ""
@@ -398,10 +474,15 @@ function verify_bootstrap() {
   log_info ""
   log_info "Next steps:"
   log_info "1. Monitor gardenlet logs:"
-  log_info "   kubectl --kubeconfig=$SEED_KUBECONFIG -n $GARDENLET_NAMESPACE logs -f deployment/$GARDENLET_DEPLOYMENT_NAME"
+  log_info "   kubectl --kubeconfig=$TARGET_KUBECONFIG -n $GARDENLET_NAMESPACE logs -f deployment/$GARDENLET_DEPLOYMENT_NAME"
   log_info ""
-  log_info "2. Check seed conditions:"
-  log_info "   kubectl --kubeconfig=$GARDEN_KUBECONFIG get seed $SEED_NAME -o yaml | yq eval .status.conditions"
+  if [[ "$MODE" == "seed" ]]; then
+    log_info "2. Check seed conditions:"
+    log_info "   kubectl --kubeconfig=$GARDEN_KUBECONFIG get seed $SEED_NAME -o yaml | yq eval .status.conditions"
+  else
+    log_info "2. Check shoot conditions:"
+    log_info "   kubectl --kubeconfig=$GARDEN_KUBECONFIG -n $SHOOT_NAMESPACE get shoot $SHOOT_NAME -o yaml | yq eval .status.conditions"
+  fi
 }
 
 # Parse command line arguments
@@ -417,6 +498,18 @@ while [[ $# -gt 0 ]]; do
       ;;
     --seed-name)
       SEED_NAME="$2"
+      shift 2
+      ;;
+    --shoot-kubeconfig)
+      SHOOT_KUBECONFIG="$2"
+      shift 2
+      ;;
+    --shoot-namespace)
+      SHOOT_NAMESPACE="$2"
+      shift 2
+      ;;
+    --shoot-name)
+      SHOOT_NAME="$2"
       shift 2
       ;;
     --token-id)

--- a/pkg/admissioncontroller/webhook/admission/shootrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/shootrestriction/handler.go
@@ -186,7 +186,8 @@ func (h *Handler) admitSecret(ctx context.Context, gardenletShootInfo types.Name
 		}
 
 		kind, namespace, name := gardenletbootstraputil.MetadataFromDescription(string(secret.Data[bootstraptokenapi.BootstrapTokenDescriptionKey]))
-		if kind == gardenletbootstraputil.KindManagedSeed {
+		switch kind {
+		case gardenletbootstraputil.KindManagedSeed:
 			managedSeed := &seedmanagementv1alpha1.ManagedSeed{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
 			if err := h.Client.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed); err != nil {
 				if apierrors.IsNotFound(err) {
@@ -196,6 +197,10 @@ func (h *Handler) admitSecret(ctx context.Context, gardenletShootInfo types.Name
 			}
 
 			return h.admit(gardenletShootInfo, types.NamespacedName{Name: managedSeed.Spec.Shoot.Name, Namespace: managedSeed.Namespace})
+
+		case gardenletbootstraputil.KindGardenlet:
+			// The Gardenlet resource name carries the `self-hosted-shoot-` prefix; strip it to recover the shoot name.
+			return h.admit(gardenletShootInfo, types.NamespacedName{Name: strings.TrimPrefix(name, gardenletutils.ResourcePrefixSelfHostedShoot), Namespace: namespace})
 		}
 	}
 

--- a/pkg/admissioncontroller/webhook/admission/shootrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/shootrestriction/handler_test.go
@@ -706,6 +706,51 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 							}))
 						})
 					})
+
+					Context("Gardenlet bootstrap token secret", func() {
+						BeforeEach(func() {
+							request.Name = "bootstrap-token-abcdef"
+							request.Namespace = metav1.NamespaceSystem
+						})
+
+						It("should allow because the Gardenlet belongs to gardenlet's shoot", func() {
+							secret := &corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{Name: "bootstrap-token-abcdef", Namespace: metav1.NamespaceSystem},
+								Type:       corev1.SecretTypeBootstrapToken,
+								Data: map[string][]byte{
+									"description": []byte("A bootstrap token for the Gardenlet for seedmanagement.gardener.cloud/v1alpha1.Gardenlet resource " + shootNamespace + "/self-hosted-shoot-" + shootName + "."),
+								},
+							}
+							objData, err := runtime.Encode(encoder, secret)
+							Expect(err).NotTo(HaveOccurred())
+							request.Object.Raw = objData
+
+							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+						})
+
+						It("should forbid because the Gardenlet does not belong to gardenlet's shoot", func() {
+							secret := &corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{Name: "bootstrap-token-abcdef", Namespace: "other-namespace"},
+								Type:       corev1.SecretTypeBootstrapToken,
+								Data: map[string][]byte{
+									"description": []byte("A bootstrap token for the Gardenlet for seedmanagement.gardener.cloud/v1alpha1.Gardenlet resource other-namespace/self-hosted-shoot-other-shoot."),
+								},
+							}
+							objData, err := runtime.Encode(encoder, secret)
+							Expect(err).NotTo(HaveOccurred())
+							request.Object.Raw = objData
+
+							Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+								AdmissionResponse: admissionv1.AdmissionResponse{
+									Allowed: false,
+									Result: &metav1.Status{
+										Code:    int32(http.StatusForbidden),
+										Message: fmt.Sprintf("object does not belong to shoot %s/%s", shootNamespace, shootName),
+									},
+								},
+							}))
+						})
+					})
 				})
 			})
 

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	auth "k8s.io/apiserver/pkg/authorization/authorizer"
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
+	bootstraptokenutil "k8s.io/cluster-bootstrap/token/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/admissioncontroller/gardenletidentity"
@@ -38,6 +39,7 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 	"github.com/gardener/gardener/pkg/utils/graph"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 	authorizerwebhook "github.com/gardener/gardener/pkg/webhook/authorizer"
 )
 
@@ -359,21 +361,38 @@ func (a *authorizer) authorizeServiceAccount(requestAuthorizer *authwebhook.Requ
 }
 
 func (a *authorizer) authorizeSecret(ctx context.Context, requestAuthorizer *authwebhook.RequestAuthorizer, attrs auth.Attributes) (auth.Decision, string, error) {
-	// Allow gardenlet to delete bootstrap tokens for its own shoot or for ManagedSeeds referencing its shoot.
-	if attrs.GetVerb() == "delete" && attrs.GetNamespace() == metav1.NamespaceSystem && strings.HasPrefix(attrs.GetName(), bootstraptokenapi.BootstrapTokenSecretPrefix) {
-		shootMeta, found, err := gardenletutils.ShootMetaFromBootstrapToken(ctx, a.client, attrs.GetName())
-		if err != nil {
-			if !apierrors.IsNotFound(err) {
-				return auth.DecisionNoOpinion, "", err
-			}
-		} else if found {
-			if shootMeta.Namespace == requestAuthorizer.ToNamespace && shootMeta.Name == requestAuthorizer.ToName {
+	if attrs.GetNamespace() == metav1.NamespaceSystem && strings.HasPrefix(attrs.GetName(), bootstraptokenapi.BootstrapTokenSecretPrefix) {
+		switch attrs.GetVerb() {
+		case "get", "list", "watch":
+			// Allow gardenlet to get/list/watch the bootstrap token secret whose name is deterministically derived from
+			// its shoot identity. This is needed for the renew-kubeconfig flow which calls
+			// ComputeGardenletKubeconfigWithBootstrapToken to look up the token. The list/watch verbs are issued by the
+			// SingleObjectCache which primes a watch via a namespaced list with a metadata.name field selector.
+			expectedSecretName := bootstraptokenutil.BootstrapTokenSecretName(bootstraptoken.TokenID(metav1.ObjectMeta{
+				Namespace: requestAuthorizer.ToNamespace,
+				Name:      requestAuthorizer.ToName,
+			}))
+			if attrs.GetName() == expectedSecretName {
 				return auth.DecisionAllow, "", nil
 			}
-			return auth.DecisionNoOpinion, fmt.Sprintf("shoot meta in bootstrap token secret %s does not match with identity of requestor %s/%s", shootMeta, requestAuthorizer.ToNamespace, requestAuthorizer.ToName), nil
+			return auth.DecisionNoOpinion, fmt.Sprintf("bootstrap token secret name %s does not match expected name %s for shoot %s/%s", attrs.GetName(), expectedSecretName, requestAuthorizer.ToNamespace, requestAuthorizer.ToName), nil
+
+		case "delete":
+			// Allow gardenlet to delete bootstrap tokens for its own shoot or for ManagedSeeds referencing its shoot.
+			shootMeta, found, err := gardenletutils.ShootMetaFromBootstrapToken(ctx, a.client, attrs.GetName())
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					return auth.DecisionNoOpinion, "", err
+				}
+			} else if found {
+				if shootMeta.Namespace == requestAuthorizer.ToNamespace && shootMeta.Name == requestAuthorizer.ToName {
+					return auth.DecisionAllow, "", nil
+				}
+				return auth.DecisionNoOpinion, fmt.Sprintf("shoot meta in bootstrap token secret %s does not match with identity of requestor %s/%s", shootMeta, requestAuthorizer.ToNamespace, requestAuthorizer.ToName), nil
+			}
+			// No shoot meta found — fall through to graph-based authorization which handles ManagedSeed bootstrap
+			// tokens via the Secret → ManagedSeed → Shoot edges.
 		}
-		// No shoot meta found — fall through to graph-based authorization which handles ManagedSeed bootstrap
-		// tokens via the Secret → ManagedSeed → Shoot edges.
 	}
 
 	return requestAuthorizer.Check(graph.VertexTypeSecret, attrs,

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apiserver/pkg/authentication/user"
 	auth "k8s.io/apiserver/pkg/authorization/authorizer"
+	bootstraptokenutil "k8s.io/cluster-bootstrap/token/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -34,6 +35,7 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 	graphutils "github.com/gardener/gardener/pkg/utils/graph"
 	mockgraph "github.com/gardener/gardener/pkg/utils/graph/mock"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 	authorizerwebhook "github.com/gardener/gardener/pkg/webhook/authorizer"
 	fakeauthorizerwebhook "github.com/gardener/gardener/pkg/webhook/authorizer/fake"
 )
@@ -2019,6 +2021,48 @@ var _ = Describe("Shoot", func() {
 						ResourceRequest: true,
 						Verb:            "get",
 					}
+				})
+
+				When("get/list/watch of bootstrap token secret is requested", func() {
+					var expectedSecretName string
+
+					BeforeEach(func() {
+						expectedSecretName = bootstraptokenutil.BootstrapTokenSecretName(bootstraptoken.TokenID(metav1.ObjectMeta{
+							Namespace: shootNamespace,
+							Name:      shootName,
+						}))
+						attrs.Namespace = metav1.NamespaceSystem
+						attrs.Name = expectedSecretName
+					})
+
+					DescribeTable("should allow for the deterministically derived secret name",
+						func(verb string) {
+							attrs.Verb = verb
+
+							decision, reason, err := authorizer.Authorize(ctx, attrs)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						},
+						Entry("get", "get"),
+						Entry("list", "list"),
+						Entry("watch", "watch"),
+					)
+
+					DescribeTable("should not have an opinion for a different bootstrap token secret name",
+						func(verb string) {
+							attrs.Verb = verb
+							attrs.Name = "bootstrap-token-abcdef"
+
+							decision, reason, err := authorizer.Authorize(ctx, attrs)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("does not match expected name"))
+						},
+						Entry("get", "get"),
+						Entry("list", "list"),
+						Entry("watch", "watch"),
+					)
 				})
 
 				When("deletion of bootstrap token secret is requested", func() {

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -920,8 +921,11 @@ func createBootstrapKubeconfig(
 				return "", fmt.Errorf("unknown bootstrap kind for object of type %T", obj)
 			}
 
+			// For self-hosted shoot Gardenlet resources the object name carries the `self-hosted-shoot-` prefix,
+			// but the authorizer computes the expected token name from the shoot name (without prefix).
+			// Strip the prefix so both sides derive the same deterministic token ID.
 			var (
-				tokenID          = bootstraptoken.TokenID(metav1.ObjectMeta{Name: obj.GetName(), Namespace: obj.GetNamespace()})
+				tokenID          = bootstraptoken.TokenID(metav1.ObjectMeta{Name: strings.TrimPrefix(obj.GetName(), gardenletutils.ResourcePrefixSelfHostedShoot), Namespace: obj.GetNamespace()})
 				tokenDescription = gardenletbootstraputil.Description(kind, obj.GetNamespace(), obj.GetName())
 				tokenValidity    = 24 * time.Hour
 			)

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -508,7 +508,7 @@ func (r *Reconciler) reconcile(
 		// gardenlets will succeed to execute the requested operation.
 		// Therefore the 30s timeout is not sufficient in some cases and longer timeout is needed.
 		renewGardenAccessSecretsInAllSeeds = g.Add(flow.Task{
-			Name: "Annotate seeds to trigger renewal of their garden access secrets",
+			Name: "Annotate Seed resources to trigger renewal of their garden access secrets",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.RenewGardenSecretsInAllSeeds(ctx, log.WithValues(secretsTypeKey, secretsTypeGardenAccess), virtualClusterClient, v1beta1constants.SeedOperationRenewGardenAccessSecrets)
 			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
@@ -524,7 +524,7 @@ func (r *Reconciler) reconcile(
 			Dependencies: flow.NewTaskIDs(renewGardenAccessSecretsInAllSeeds),
 		})
 		renewWorkloadIdentityTokensInAllSeeds = g.Add(flow.Task{
-			Name: "Annotate seeds to trigger renewal of workload identity tokens",
+			Name: "Annotate Seed resources to trigger renewal of workload identity tokens",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.RenewGardenSecretsInAllSeeds(ctx, log.WithValues(secretsTypeKey, secretsTypeWorkloadIdentity), virtualClusterClient, v1beta1constants.SeedOperationRenewWorkloadIdentityTokens)
 			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
@@ -539,29 +539,45 @@ func (r *Reconciler) reconcile(
 			SkipIf:       helper.GetWorkloadIdentityKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
 			Dependencies: flow.NewTaskIDs(renewWorkloadIdentityTokensInAllSeeds),
 		})
-		renewGardenletKubeconfigInAllSeeds = g.Add(flow.Task{
-			Name: "Annotate seeds to trigger renewal of their gardenlet kubeconfig",
+		renewKubeconfigsOfSeedGardenlets = g.Add(flow.Task{
+			Name: "Annotate Seed resources to trigger renewal of their gardenlet kubeconfig",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.RenewGardenSecretsInAllSeeds(ctx, log.WithValues(secretsTypeKey, secretsTypeGardenletKubeconfig), virtualClusterClient, v1beta1constants.GardenerOperationRenewKubeconfig)
 			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
 			SkipIf:       helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
 			Dependencies: flow.NewTaskIDs(checkIfWorkloadIdentityTokensRenewalCompletedInAllSeeds),
 		})
-		checkIfGardenletKubeconfigRenewalCompletedInAllSeeds = g.Add(flow.Task{
-			Name: "Check if all seeds finished the renewal of their gardenlet kubeconfig",
+		checkIfSeedGardenletKubeconfigRenewalsCompleted = g.Add(flow.Task{
+			Name: "Check if all seed gardenlets finished the renewal of their kubeconfig",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.CheckIfGardenSecretsRenewalCompletedInAllSeeds(ctx, virtualClusterClient, v1beta1constants.GardenerOperationRenewKubeconfig, secretsTypeGardenletKubeconfig)
 			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
 			SkipIf:       helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
-			Dependencies: flow.NewTaskIDs(renewGardenletKubeconfigInAllSeeds),
+			Dependencies: flow.NewTaskIDs(renewKubeconfigsOfSeedGardenlets),
+		})
+		renewKubeconfigsOfShootGardenlets = g.Add(flow.Task{
+			Name: "Annotate Gardenlet resources of self-hosted shoots to trigger renewal of their kubeconfig",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return secretsrotation.RenewKubeconfigInAllShootGardenlets(ctx, log.WithValues(secretsTypeKey, secretsTypeGardenletKubeconfig), virtualClusterClient)
+			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
+			SkipIf:       helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
+			Dependencies: flow.NewTaskIDs(initializeVirtualClusterClient),
 		})
 		_ = g.Add(flow.Task{
-			Name: "Annotate seeds to trigger reconciliation after observability credentials rotation",
+			Name: "Check if all shoot gardenlets finished the renewal of their kubeconfig",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return secretsrotation.CheckIfKubeconfigRenewalCompletedInAllShootGardenlets(ctx, virtualClusterClient)
+			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
+			SkipIf:       helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
+			Dependencies: flow.NewTaskIDs(renewKubeconfigsOfShootGardenlets),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Annotate Seed resources to trigger reconciliation after observability credentials rotation",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.RenewGardenSecretsInAllSeeds(ctx, log, virtualClusterClient, v1beta1constants.GardenerOperationReconcile)
 			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
 			SkipIf:       !helper.IsObservabilityRotationInitiationTimeAfterLastCompletionTime(garden.Status.Credentials),
-			Dependencies: flow.NewTaskIDs(generateAndReplicateGlobalObservabilityIngressPassword, checkIfGardenletKubeconfigRenewalCompletedInAllSeeds),
+			Dependencies: flow.NewTaskIDs(generateAndReplicateGlobalObservabilityIngressPassword, checkIfSeedGardenletKubeconfigRenewalsCompleted),
 		})
 
 		rewriteResourcesAddLabel = g.Add(flow.Task{

--- a/pkg/utils/gardener/gardenlet/gardenlet.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet.go
@@ -22,6 +22,7 @@ import (
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
+	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
@@ -101,19 +102,26 @@ func ShootMetaFromBootstrapToken(ctx context.Context, reader client.Reader, boot
 
 func extractShootMetaFromBootstrapToken(bootstrapTokenSecret *corev1.Secret) (types.NamespacedName, bool, error) {
 	description := string(bootstrapTokenSecret.Data[bootstraptokenapi.BootstrapTokenDescriptionKey])
-	if !strings.HasPrefix(description, bootstraptoken.SelfHostedShootBootstrapTokenSecretDescriptionPrefix) {
-		return types.NamespacedName{}, false, nil
+
+	if strings.HasPrefix(description, bootstraptoken.SelfHostedShootBootstrapTokenSecretDescriptionPrefix) {
+		parts := strings.Fields(strings.TrimPrefix(description, bootstraptoken.SelfHostedShootBootstrapTokenSecretDescriptionPrefix))
+		if len(parts) == 0 {
+			return types.NamespacedName{}, false, fmt.Errorf("could not extract shoot meta from bootstrap token description: %s", description)
+		}
+
+		split := strings.Split(parts[0], "/")
+		if len(split) != 2 {
+			return types.NamespacedName{}, false, fmt.Errorf("could not extract shoot namespace and name from bootstrap token description: %s", description)
+		}
+
+		return types.NamespacedName{Namespace: split[0], Name: split[1]}, true, nil
 	}
 
-	parts := strings.Fields(strings.TrimPrefix(description, bootstraptoken.SelfHostedShootBootstrapTokenSecretDescriptionPrefix))
-	if len(parts) == 0 {
-		return types.NamespacedName{}, false, fmt.Errorf("could not extract shoot meta from bootstrap token description: %s", description)
+	// Bootstrap tokens for self-hosted shoot Gardenlets created via the deployer use the standard gardenlet
+	// description format. Extract the shoot namespace and name by stripping the `self-hosted-shoot-` prefix.
+	if kind, namespace, name := gardenletbootstraputil.MetadataFromDescription(description); kind == gardenletbootstraputil.KindGardenlet {
+		return types.NamespacedName{Namespace: namespace, Name: strings.TrimPrefix(name, ResourcePrefixSelfHostedShoot)}, true, nil
 	}
 
-	split := strings.Split(parts[0], "/")
-	if len(split) != 2 {
-		return types.NamespacedName{}, false, fmt.Errorf("could not extract shoot namespace and name from bootstrap token description: %s", description)
-	}
-
-	return types.NamespacedName{Namespace: split[0], Name: split[1]}, true, nil
+	return types.NamespacedName{}, false, nil
 }

--- a/pkg/utils/gardener/gardenlet/gardenlet_test.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet_test.go
@@ -385,5 +385,24 @@ var _ = Describe("Gardenlet", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeFalse())
 		})
+
+		It("should successfully extract shoot meta from a Gardenlet bootstrap token (deployer format)", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bootstrapTokenSecretName,
+					Namespace: "kube-system",
+				},
+				Data: map[string][]byte{
+					"description": []byte("A bootstrap token for the Gardenlet for seedmanagement.gardener.cloud/v1alpha1.Gardenlet resource " + expectedShootNamespace + "/self-hosted-shoot-" + expectedShootName + "."),
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+			result, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(result).To(Equal(expectedNamespacedName))
+		})
 	})
 })

--- a/pkg/utils/gardener/secretsrotation/gardenaccess.go
+++ b/pkg/utils/gardener/secretsrotation/gardenaccess.go
@@ -7,6 +7,8 @@ package secretsrotation
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,7 +16,9 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/flow"
+	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
@@ -38,7 +42,6 @@ func RenewGardenSecretsInAllSeeds(ctx context.Context, log logr.Logger, c client
 			return fmt.Errorf("error annotating seed %s: already annotated with \"%s: %s\"", seed.Name, v1beta1constants.GardenerOperation, seed.Annotations[v1beta1constants.GardenerOperation])
 		}
 
-		seed := seed
 		tasks = append(tasks, func(ctx context.Context) error {
 			log := log.WithValues("seed", seed.Name)
 
@@ -67,6 +70,70 @@ func CheckIfGardenSecretsRenewalCompletedInAllSeeds(ctx context.Context, c clien
 	for _, seed := range seedList.Items {
 		if seed.Annotations[v1beta1constants.GardenerOperation] == operationAnnotation {
 			return fmt.Errorf("renewing %q secrets for seed %q is not yet completed", secretType, seed.Name)
+		}
+	}
+
+	return nil
+}
+
+// RenewKubeconfigInAllShootGardenlets annotates all Gardenlet objects for self-hosted shoots to trigger renewal of
+// their garden cluster kubeconfig.
+func RenewKubeconfigInAllShootGardenlets(ctx context.Context, log logr.Logger, c client.Client) error {
+	gardenletList := &metav1.PartialObjectMetadataList{}
+	gardenletList.SetGroupVersionKind(seedmanagementv1alpha1.SchemeGroupVersion.WithKind("GardenletList"))
+	if err := c.List(ctx, gardenletList, client.InNamespace(v1beta1constants.GardenNamespace)); err != nil {
+		return err
+	}
+
+	gardenletList.Items = slices.DeleteFunc(gardenletList.Items, func(objectMeta metav1.PartialObjectMetadata) bool {
+		return !strings.HasPrefix(objectMeta.Name, gardenletutils.ResourcePrefixSelfHostedShoot)
+	})
+
+	log.Info("Gardenlets requiring renewal of their kubeconfig", "number", len(gardenletList.Items))
+
+	var tasks []flow.TaskFn
+	for _, gardenlet := range gardenletList.Items {
+		if gardenlet.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRenewKubeconfig {
+			continue
+		}
+
+		if gardenlet.Annotations[v1beta1constants.GardenerOperation] != "" {
+			return fmt.Errorf("error annotating gardenlet %s: already annotated with \"%s: %s\"", client.ObjectKeyFromObject(&gardenlet), v1beta1constants.GardenerOperation, gardenlet.Annotations[v1beta1constants.GardenerOperation])
+		}
+
+		tasks = append(tasks, func(ctx context.Context) error {
+			log := log.WithValues("gardenlet", client.ObjectKeyFromObject(&gardenlet))
+
+			gardenlet.SetGroupVersionKind(seedmanagementv1alpha1.SchemeGroupVersion.WithKind("Gardenlet"))
+			patch := client.MergeFrom(gardenlet.DeepCopy())
+			kubernetesutils.SetMetaDataAnnotation(&gardenlet.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRenewKubeconfig)
+			if err := c.Patch(ctx, &gardenlet, patch); err != nil {
+				return fmt.Errorf("error annotating Gardenlet %s: %w", client.ObjectKeyFromObject(&gardenlet), err)
+			}
+			log.Info("Successfully annotated gardenlet to renew its kubeconfig")
+			return nil
+		})
+	}
+
+	return flow.ParallelN(5, tasks...)(ctx)
+}
+
+// CheckIfKubeconfigRenewalCompletedInAllShootGardenlets checks if renewal of the garden cluster kubeconfig is
+// completed for all Gardenlet objects for self-hosted shoots.
+func CheckIfKubeconfigRenewalCompletedInAllShootGardenlets(ctx context.Context, c client.Client) error {
+	gardenletList := &metav1.PartialObjectMetadataList{}
+	gardenletList.SetGroupVersionKind(seedmanagementv1alpha1.SchemeGroupVersion.WithKind("GardenletList"))
+	if err := c.List(ctx, gardenletList, client.InNamespace(v1beta1constants.GardenNamespace)); err != nil {
+		return err
+	}
+
+	gardenletList.Items = slices.DeleteFunc(gardenletList.Items, func(objectMeta metav1.PartialObjectMetadata) bool {
+		return !strings.HasPrefix(objectMeta.Name, gardenletutils.ResourcePrefixSelfHostedShoot)
+	})
+
+	for _, gardenlet := range gardenletList.Items {
+		if gardenlet.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRenewKubeconfig {
+			return fmt.Errorf("renewing kubeconfig for Gardenlet %s is not yet completed", client.ObjectKeyFromObject(&gardenlet))
 		}
 	}
 

--- a/pkg/utils/gardener/secretsrotation/gardenaccess_test.go
+++ b/pkg/utils/gardener/secretsrotation/gardenaccess_test.go
@@ -15,6 +15,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
 )
@@ -149,6 +150,123 @@ var _ = Describe("RenewGardenAccess", func() {
 			Expect(createSeeds()).To(Succeed())
 
 			Expect(RenewGardenSecretsInAllSeeds(ctx, logger.WithValues(secretType, gardenAccess), gardenClient, renewGardenAccessSecrets)).To(MatchError(ContainSubstring("error annotating seed seed1: already annotated with \"gardener.cloud/operation: reconcile\"")))
+		})
+	})
+
+	Context("#RenewKubeconfigInAllShootGardenlets", func() {
+		var gardenlets []seedmanagementv1alpha1.Gardenlet
+
+		BeforeEach(func() {
+			gardenlets = []seedmanagementv1alpha1.Gardenlet{
+				{ObjectMeta: metav1.ObjectMeta{Name: "self-hosted-shoot-g1", Namespace: "garden"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "self-hosted-shoot-g2", Namespace: "garden"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "self-hosted-shoot-g3", Namespace: "garden"}},
+			}
+		})
+
+		createGardenlets := func() error {
+			for _, gardenlet := range gardenlets {
+				if err := gardenClient.Create(ctx, &gardenlet); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		It("should succeed and annotate all self-hosted-shoot gardenlets", func() {
+			Expect(createGardenlets()).To(Succeed())
+
+			Expect(RenewKubeconfigInAllShootGardenlets(ctx, logger.WithValues(secretType, gardenletKubeconfig), gardenClient)).To(Succeed())
+
+			gardenletList := seedmanagementv1alpha1.GardenletList{}
+			Expect(gardenClient.List(ctx, &gardenletList)).To(Succeed())
+			for _, gardenlet := range gardenletList.Items {
+				Expect(gardenlet.Annotations["gardener.cloud/operation"]).To(Equal(renewKubeconfig))
+			}
+		})
+
+		It("should succeed if some gardenlets are already annotated with `renew-kubeconfig`", func() {
+			gardenlets[0].SetAnnotations(map[string]string{"gardener.cloud/operation": renewKubeconfig})
+			Expect(createGardenlets()).To(Succeed())
+
+			Expect(RenewKubeconfigInAllShootGardenlets(ctx, logger.WithValues(secretType, gardenletKubeconfig), gardenClient)).To(Succeed())
+
+			gardenletList := seedmanagementv1alpha1.GardenletList{}
+			Expect(gardenClient.List(ctx, &gardenletList)).To(Succeed())
+			for _, gardenlet := range gardenletList.Items {
+				Expect(gardenlet.Annotations["gardener.cloud/operation"]).To(Equal(renewKubeconfig))
+			}
+		})
+
+		It("should fail if some gardenlets have a different `gardener.cloud/operation` annotation", func() {
+			gardenlets[0].SetAnnotations(map[string]string{"gardener.cloud/operation": "reconcile"})
+			Expect(createGardenlets()).To(Succeed())
+
+			Expect(RenewKubeconfigInAllShootGardenlets(ctx, logger.WithValues(secretType, gardenletKubeconfig), gardenClient)).To(MatchError(ContainSubstring("error annotating gardenlet garden/self-hosted-shoot-g1: already annotated with \"gardener.cloud/operation: reconcile\"")))
+		})
+
+		It("should skip gardenlets not related to self-hosted shoots", func() {
+			nonSelfHosted := seedmanagementv1alpha1.Gardenlet{ObjectMeta: metav1.ObjectMeta{Name: "managed-seed-gardenlet", Namespace: "garden"}}
+			Expect(gardenClient.Create(ctx, &nonSelfHosted)).To(Succeed())
+			Expect(createGardenlets()).To(Succeed())
+
+			Expect(RenewKubeconfigInAllShootGardenlets(ctx, logger.WithValues(secretType, gardenletKubeconfig), gardenClient)).To(Succeed())
+
+			updated := &seedmanagementv1alpha1.Gardenlet{}
+			Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(&nonSelfHosted), updated)).To(Succeed())
+			Expect(updated.Annotations["gardener.cloud/operation"]).To(BeEmpty())
+		})
+	})
+
+	Context("#CheckIfKubeconfigRenewalCompletedInAllShootGardenlets", func() {
+		var gardenlets []seedmanagementv1alpha1.Gardenlet
+
+		BeforeEach(func() {
+			gardenlets = []seedmanagementv1alpha1.Gardenlet{
+				{ObjectMeta: metav1.ObjectMeta{Name: "self-hosted-shoot-g1", Namespace: "garden"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "self-hosted-shoot-g2", Namespace: "garden"}},
+			}
+		})
+
+		createGardenlets := func() error {
+			for _, gardenlet := range gardenlets {
+				if err := gardenClient.Create(ctx, &gardenlet); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		It("should succeed if no gardenlet is annotated anymore", func() {
+			Expect(createGardenlets()).To(Succeed())
+
+			Expect(CheckIfKubeconfigRenewalCompletedInAllShootGardenlets(ctx, gardenClient)).To(Succeed())
+		})
+
+		It("should succeed if some gardenlets have a different `gardener.cloud/operation` annotation", func() {
+			gardenlets[0].SetAnnotations(map[string]string{"gardener.cloud/operation": "reconcile"})
+			Expect(createGardenlets()).To(Succeed())
+
+			Expect(CheckIfKubeconfigRenewalCompletedInAllShootGardenlets(ctx, gardenClient)).To(Succeed())
+		})
+
+		It("should fail if some gardenlets are still annotated with `renew-kubeconfig`", func() {
+			gardenlets[1].SetAnnotations(map[string]string{"gardener.cloud/operation": renewKubeconfig})
+			Expect(createGardenlets()).To(Succeed())
+
+			Expect(CheckIfKubeconfigRenewalCompletedInAllShootGardenlets(ctx, gardenClient)).To(MatchError(ContainSubstring("renewing kubeconfig for Gardenlet garden/self-hosted-shoot-g2 is not yet completed")))
+		})
+
+		It("should succeed if only non-self-hosted-shoot gardenlets are still annotated with `renew-kubeconfig`", func() {
+			nonSelfHosted := seedmanagementv1alpha1.Gardenlet{ObjectMeta: metav1.ObjectMeta{
+				Name:        "managed-seed-gardenlet",
+				Namespace:   "garden",
+				Annotations: map[string]string{"gardener.cloud/operation": renewKubeconfig},
+			}}
+			Expect(gardenClient.Create(ctx, &nonSelfHosted)).To(Succeed())
+			Expect(createGardenlets()).To(Succeed())
+
+			Expect(CheckIfKubeconfigRenewalCompletedInAllShootGardenlets(ctx, gardenClient)).To(Succeed())
 		})
 	})
 })

--- a/pkg/utils/graph/eventhandler_gardenlet.go
+++ b/pkg/utils/graph/eventhandler_gardenlet.go
@@ -164,7 +164,4 @@ func (g *graph) handleGardenletCreateOrUpdateForShoots(gardenlet *seedmanagement
 	)
 
 	g.addEdge(gardenletVertex, shootVertex)
-
-	// TODO(rfranzke): Check if we need to support the 'allowBootstrap' logic for self-hosted shoots as well (see
-	//  handling for seeds).
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/area security
/kind enhancement

**What this PR does / why we need it**:

Self-hosted shoot `gardenlet`s (managed via `gardenadm connect`) were failing to bootstrap because of a `TokenID` mismatch between what the `Gardenlet` deployer computed (from the full `Gardenlet` object name, e.g. `self-hosted-shoot-root`) and what the shoot authorizer expected (from the shoot name, e.g. `root`). The shoot-restriction admission webhook also rejected the bootstrap token secret, and the CSR auto-approver didn't recognise the standard `gardenletbootstraputil` description format used by the deployer.

This PR fixes all three layers, extends `rebootstrap-gardenlet.sh` to cover shoot gardenlets, and wires the gardener-operator CA rotation flow to also annotate shoot `Gardenlet` objects with `gardener.cloud/operation=renew-kubeconfig`.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
Three independent fixup layers in commit 2 — each touches a different component (`actuator.go`, shoot-restriction webhook, CSR approver) but they're all part of the same end-to-end bootstrap flow.

**Release note**:
```other operator
NONE
```