### PR TITLE
Ensure global observability secret is synced during rotation before triggering seed reconciliation

### DIFF
--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -389,6 +389,7 @@ build:
             - pkg/utils/managedresources/builder
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/structuredmap
             - pkg/utils/validation
@@ -510,6 +511,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/admissionplugins

--- a/dev-setup/skaffold-operator.yaml
+++ b/dev-setup/skaffold-operator.yaml
@@ -359,6 +359,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
@@ -532,6 +533,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
@@ -711,6 +713,7 @@ build:
             - pkg/utils/managedresources/builder
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
@@ -791,6 +794,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/cidr
@@ -891,6 +895,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/kubernetesversion

--- a/dev-setup/skaffold-seed.yaml
+++ b/dev-setup/skaffold-seed.yaml
@@ -454,6 +454,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
@@ -579,6 +580,7 @@ build:
             - pkg/utils/managedresources/builder
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/structuredmap
             - pkg/utils/validation

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -174,6 +175,8 @@ func (r *Reconciler) reconcile(
 		// This is validated by a webhook, so we can read from either apiserver config.
 		encryptionProviderToUse = v1beta1helper.GetEncryptionProviderType(garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig)
 		encryptionProvider      = helper.GetEncryptionProviderTypeInStatus(garden.Status)
+
+		globalObservabilitySecretLastRotationInitiationTimestamp int64
 
 		g                              = flow.NewGraph("Garden reconciliation")
 		generateGenericTokenKubeconfig = g.Add(flow.Task{
@@ -483,6 +486,15 @@ func (r *Reconciler) reconcile(
 					return fmt.Errorf("failed to generate global observability ingress secret: %w", err)
 				}
 
+				// accept missing and empty last-rotation-initiation-time label values for human-generated or
+				// brand new generated secrets, but fail for any other content that cannot be parsed as an integer.
+				if lastRotationInitiationTime := secret.Labels[secretsmanager.LabelKeyLastRotationInitiationTime]; lastRotationInitiationTime != "" {
+					globalObservabilitySecretLastRotationInitiationTimestamp, err = strconv.ParseInt(lastRotationInitiationTime, 10, 64)
+					if err != nil {
+						return fmt.Errorf("error parsing last rotation initiation time of global observability secret in namespace %q: %w", r.GardenNamespace, err)
+					}
+				}
+
 				_, err = gardenerutils.ReplicateGlobalMonitoringSecret(ctx, virtualClusterClient, secret, r.GardenNamespace, func(name string) string {
 					return strings.TrimPrefix(name, "global-")
 				})
@@ -563,6 +575,14 @@ func (r *Reconciler) reconcile(
 			SkipIf:       helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
 			Dependencies: flow.NewTaskIDs(initializeVirtualClusterClient),
 		})
+		waitUntilGlobalObservabilitySecretPropagatedToAllSeeds = g.Add(flow.Task{
+			Name: "Wait until global observability secret is propagated to all seed namespaces",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return secretsrotation.CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, virtualClusterClient, globalObservabilitySecretLastRotationInitiationTimestamp)
+			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
+			SkipIf:       !helper.IsObservabilityRotationInitiationTimeAfterLastCompletionTime(garden.Status.Credentials),
+			Dependencies: flow.NewTaskIDs(generateAndReplicateGlobalObservabilityIngressPassword),
+		})
 		_ = g.Add(flow.Task{
 			Name: "Check if all shoot gardenlets finished the renewal of their kubeconfig",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
@@ -577,7 +597,7 @@ func (r *Reconciler) reconcile(
 				return secretsrotation.RenewGardenSecretsInAllSeeds(ctx, log, virtualClusterClient, v1beta1constants.GardenerOperationReconcile)
 			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
 			SkipIf:       !helper.IsObservabilityRotationInitiationTimeAfterLastCompletionTime(garden.Status.Credentials),
-			Dependencies: flow.NewTaskIDs(generateAndReplicateGlobalObservabilityIngressPassword, checkIfSeedGardenletKubeconfigRenewalsCompleted),
+			Dependencies: flow.NewTaskIDs(waitUntilGlobalObservabilitySecretPropagatedToAllSeeds, checkIfSeedGardenletKubeconfigRenewalsCompleted),
 		})
 
 		rewriteResourcesAddLabel = g.Add(flow.Task{

--- a/pkg/utils/gardener/secrets.go
+++ b/pkg/utils/gardener/secrets.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
 var (
@@ -67,6 +68,10 @@ func ReplicateGlobalMonitoringSecret(ctx context.Context, c client.Client, globa
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c, globalMonitoringSecretReplica, func() error {
 		metav1.SetMetaDataLabel(&globalMonitoringSecretReplica.ObjectMeta, v1beta1constants.GardenRole, v1beta1constants.GardenRoleGlobalMonitoring)
 		metav1.SetMetaDataLabel(&globalMonitoringSecretReplica.ObjectMeta, v1beta1constants.GardenerPurpose, LabelPurposeGlobalMonitoringSecret)
+
+		if rotationInitiationTime, ok := globalMonitoringSecret.Labels[secretsmanager.LabelKeyLastRotationInitiationTime]; ok {
+			metav1.SetMetaDataLabel(&globalMonitoringSecretReplica.ObjectMeta, secretsmanager.LabelKeyLastRotationInitiationTime, rotationInitiationTime)
+		}
 
 		globalMonitoringSecretReplica.Type = globalMonitoringSecret.Type
 		globalMonitoringSecretReplica.Data = globalMonitoringSecret.Data

--- a/pkg/utils/gardener/secrets_test.go
+++ b/pkg/utils/gardener/secrets_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Secrets", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "global-monitoring-secret",
 					Namespace:   "foo",
-					Labels:      map[string]string{"bar": "baz"},
+					Labels:      map[string]string{"bar": "baz", "last-rotation-initiation-time": "1700000000"},
 					Annotations: map[string]string{"baz": "foo"},
 				},
 				Type:      corev1.SecretTypeOpaque,
@@ -104,6 +104,8 @@ var _ = Describe("Secrets", func() {
 			assertions := func(secret *corev1.Secret) {
 				Expect(secret.Labels).To(HaveKeyWithValue("gardener.cloud/role", "global-monitoring"))
 				Expect(secret.Labels).To(HaveKeyWithValue("gardener.cloud/purpose", "global-monitoring-secret-replica"))
+				Expect(secret.Labels).To(HaveKeyWithValue("last-rotation-initiation-time", "1700000000"))
+				Expect(secret.Labels).NotTo(HaveKey("bar"))
 				Expect(secret.Type).To(Equal(globalMonitoringSecret.Type))
 				Expect(secret.Immutable).To(Equal(globalMonitoringSecret.Immutable))
 				for k, v := range globalMonitoringSecret.Data {

--- a/pkg/utils/gardener/secretsrotation/observability.go
+++ b/pkg/utils/gardener/secretsrotation/observability.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secretsrotation
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+// CheckIfGlobalObservabilitySecretPropagatedToAllSeeds waits until the global observability secret has been synced by the
+// gardener-controller-manager from the garden namespace into every seed namespace of the virtual cluster.
+func CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx context.Context, c client.Client, lastRotationInitiationTimestamp int64) error {
+	seedList := &metav1.PartialObjectMetadataList{}
+	seedList.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("SeedList"))
+	if err := c.List(ctx, seedList); err != nil {
+		return fmt.Errorf("failed to list seeds: %w", err)
+	}
+
+	for _, seed := range seedList.Items {
+		seedNamespace := gardenerutils.ComputeGardenNamespace(seed.Name)
+
+		secretList := &metav1.PartialObjectMetadataList{}
+		secretList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("SecretList"))
+		secretSelector := client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleGlobalMonitoring}
+		if err := c.List(ctx, secretList, client.InNamespace(seedNamespace), secretSelector); err != nil {
+			return fmt.Errorf("failed to list global observability secrets in namespace %q of seed %q: %w", seedNamespace, seed.Name, err)
+		}
+
+		for _, secret := range secretList.Items {
+			secretLastRotationInitiationTime, ok := secret.Labels[secretsmanager.LabelKeyLastRotationInitiationTime]
+
+			// accept missing last-rotation-initiation-time label values, e.g., human-managed secrets.
+			if !ok {
+				continue
+			}
+
+			// fail empty last-rotation-initiation-time label values, e.g., the secret is being rotated for the first time.
+			if secretLastRotationInitiationTime == "" {
+				return fmt.Errorf("global observability secret in namespace %q of seed %q does not yet carry a last rotation initiation time", seedNamespace, seed.Name)
+			}
+
+			secretLastRotationInitiationTimestamp, err := strconv.ParseInt(secretLastRotationInitiationTime, 10, 64)
+			if err != nil {
+				return fmt.Errorf("error parsing last rotation initiation time of global observability secret in namespace %q of seed %q: %w", seedNamespace, seed.Name, err)
+			}
+			if secretLastRotationInitiationTimestamp < lastRotationInitiationTimestamp {
+				return fmt.Errorf("global observability secret is not yet propagated to namespace %q of seed %q", seedNamespace, seed.Name)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/gardener/secretsrotation/observability_test.go
+++ b/pkg/utils/gardener/secretsrotation/observability_test.go
@@ -46,15 +46,19 @@ var _ = Describe("Observability", func() {
 			}
 		})
 
-		createGlobalMonitoringSecret := func(seedName string, timestamp int) {
+		createGlobalMonitoringSecretWithRawTimestamp := func(seedName, timestamp string) {
 			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 				Name:      "observability-ingress",
 				Namespace: gardenerutils.ComputeGardenNamespace(seedName),
 				Labels: map[string]string{
 					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
-					secretsmanager.LabelKeyLastRotationInitiationTime: strconv.Itoa(timestamp),
+					secretsmanager.LabelKeyLastRotationInitiationTime: timestamp,
 				},
 			}})).To(Succeed())
+		}
+
+		createGlobalMonitoringSecret := func(seedName string, timestamp int) {
+			createGlobalMonitoringSecretWithRawTimestamp(seedName, strconv.Itoa(timestamp))
 		}
 
 		createGlobalMonitoringSecretWithoutTimestamp := func(seedName string) {
@@ -95,28 +99,14 @@ var _ = Describe("Observability", func() {
 
 		It("should fail when a secret carries an empty rotation initiation time label", func() {
 			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
-			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name:      "observability-ingress",
-				Namespace: gardenerutils.ComputeGardenNamespace("seed2"),
-				Labels: map[string]string{
-					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
-					secretsmanager.LabelKeyLastRotationInitiationTime: "",
-				},
-			}})).To(Succeed())
+			createGlobalMonitoringSecretWithRawTimestamp("seed2", "")
 
 			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(MatchError(ContainSubstring("does not yet carry a last rotation initiation time")))
 		})
 
 		It("should fail when a secret carries a non-numeric rotation initiation time label", func() {
 			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
-			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name:      "observability-ingress",
-				Namespace: gardenerutils.ComputeGardenNamespace("seed2"),
-				Labels: map[string]string{
-					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
-					secretsmanager.LabelKeyLastRotationInitiationTime: "not-a-number",
-				},
-			}})).To(Succeed())
+			createGlobalMonitoringSecretWithRawTimestamp("seed2", "not-a-number")
 
 			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(MatchError(ContainSubstring("error parsing last rotation initiation time")))
 		})

--- a/pkg/utils/gardener/secretsrotation/observability_test.go
+++ b/pkg/utils/gardener/secretsrotation/observability_test.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secretsrotation_test
+
+import (
+	"context"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	. "github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+var _ = Describe("Observability", func() {
+	Context("#CheckIfGlobalObservabilitySecretPropagatedToAllSeeds", func() {
+		const lastRotationInitiationTimestamp = 1700000000
+
+		var (
+			ctx          context.Context
+			gardenClient client.Client
+			seeds        []gardencorev1beta1.Seed
+		)
+
+		BeforeEach(func() {
+			ctx = context.TODO()
+			gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+
+			seeds = []gardencorev1beta1.Seed{
+				{ObjectMeta: metav1.ObjectMeta{Name: "seed1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "seed2"}},
+			}
+			for _, seed := range seeds {
+				Expect(gardenClient.Create(ctx, &seed)).To(Succeed())
+			}
+		})
+
+		createGlobalMonitoringSecret := func(seedName string, timestamp int) {
+			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      "observability-ingress",
+				Namespace: gardenerutils.ComputeGardenNamespace(seedName),
+				Labels: map[string]string{
+					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
+					secretsmanager.LabelKeyLastRotationInitiationTime: strconv.Itoa(timestamp),
+				},
+			}})).To(Succeed())
+		}
+
+		createGlobalMonitoringSecretWithoutTimestamp := func(seedName string) {
+			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      "observability-ingress",
+				Namespace: gardenerutils.ComputeGardenNamespace(seedName),
+				Labels:    map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleGlobalMonitoring},
+			}})).To(Succeed())
+		}
+
+		It("should succeed when the secret propagated to all seeds with the expected timestamp", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			createGlobalMonitoringSecret("seed2", lastRotationInitiationTimestamp)
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(Succeed())
+		})
+
+		It("should succeed when a seed carries a newer timestamp than expected", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			createGlobalMonitoringSecret("seed2", lastRotationInitiationTimestamp+1)
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(Succeed())
+		})
+
+		It("should fail when a seed still carries an older timestamp", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			createGlobalMonitoringSecret("seed2", lastRotationInitiationTimestamp-1)
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(MatchError(ContainSubstring("not yet propagated to namespace \"seed-seed2\" of seed \"seed2\"")))
+		})
+
+		It("should ignore a secret without the rotation initiation time label", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			createGlobalMonitoringSecretWithoutTimestamp("seed2")
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(Succeed())
+		})
+
+		It("should fail when a secret carries an empty rotation initiation time label", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      "observability-ingress",
+				Namespace: gardenerutils.ComputeGardenNamespace("seed2"),
+				Labels: map[string]string{
+					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
+					secretsmanager.LabelKeyLastRotationInitiationTime: "",
+				},
+			}})).To(Succeed())
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(MatchError(ContainSubstring("does not yet carry a last rotation initiation time")))
+		})
+
+		It("should fail when a secret carries a non-numeric rotation initiation time label", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      "observability-ingress",
+				Namespace: gardenerutils.ComputeGardenNamespace("seed2"),
+				Labels: map[string]string{
+					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
+					secretsmanager.LabelKeyLastRotationInitiationTime: "not-a-number",
+				},
+			}})).To(Succeed())
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(MatchError(ContainSubstring("error parsing last rotation initiation time")))
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind bug

**What this PR does / why we need it**:

PR https://github.com/gardener/gardener/pull/15284 added rotation for the global observability ingress secret. However, it introduced a race condition that the local setup did not surface.

The rotation assumes the following order:

- `t0`: The secrets manager generates a new global observability ingress secret in the runtime cluster and the gardener-operator copies it to the `garden` namespace in the virtual cluster.
- `t1`: The gardener-controller-manager (GCM) sees the new secret in the `garden` namespace and propagates it to each seed namespace in the virtual cluster.
- `t2`: The gardener-operator annotates the seeds for reconciliation.
- `t3`: The gardenlet picks up and deploys the new global observability ingress secret in the seed.

This path works, but `t1` and `t2` can swap if the gardener-operator triggers seed reconciliation before the GCM copies the new secret to the corresponding seed namespaces. In consequence, seed reconciliation is triggered too early, missing the recently rotated secret.

This PR addresses this issue by forcing the credential rotation flow to wait until the new secret is copied into every seed namespace in the virtual cluster before triggering seed reconciliation. To do so, the `last-rotation-initiation-time` label is now propagated to the global observability ingress secret replicas. The rotation blocks for as long as there is a secret replica with `last-rotation-initiation-time` label value older than the current rotation timestamp.

<details>
<summary>How to reproduce the race and test the fix in the local setup</summary>

The local setup does not surface this race because the GCM copies the secret into the seed namespaces before the gardener-operator annotates the seeds. To force the `t2`-before-`t1` ordering, we can apply the patch below, which delays the GCM copy into the seed namespace by 2 minutes.
  
```bash
git am << 'PATCH'
From 40b82ad25ad6852da1542e5dab57d793eeb358c3 Mon Sep 17 00:00:00 2001
From: Victor Herrero Otal <victor.herrero.otal@sap.com>
Date: Mon, 3 Aug 2026 21:55:59 +0200
Subject: [PATCH] Slow down GCM

---
 .../controller/seed/secrets/reconciler.go     | 19 +++++++++++++++++++
 1 file changed, 19 insertions(+)

diff --git a/pkg/controllermanager/controller/seed/secrets/reconciler.go b/pkg/controllermanager/controller/seed/secrets/reconciler.go
index 2039af0b708c..f46c16df8970 100644
--- a/pkg/controllermanager/controller/seed/secrets/reconciler.go
+++ b/pkg/controllermanager/controller/seed/secrets/reconciler.go
@@ -7,6 +7,7 @@ package secrets
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -78,6 +79,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 	}
 
+	// TEMP repro of observability rotation race: delay copying secrets into the seed namespace so the
+	// gardener-operator annotates the seed before the new global monitoring secret is propagated.
+	gmList := &corev1.SecretList{}
+	if err := r.Client.List(ctx, gmList, client.InNamespace(r.GardenNamespace),
+		client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleGlobalMonitoring}); err == nil && len(gmList.Items) > 0 {
+		const reproAnnotation = "repro-delayed-until"
+		gm := &gmList.Items[0]
+		if gm.Annotations[reproAnnotation] == "" {
+			patch := client.MergeFrom(gm.DeepCopy())
+			metav1.SetMetaDataAnnotation(&gm.ObjectMeta, reproAnnotation, time.Now().Add(2*time.Minute).Format(time.RFC3339))
+			_ = r.Client.Patch(ctx, gm, patch)
+			return reconcile.Result{RequeueAfter: 2 * time.Minute}, nil
+		}
+		if t, parseErr := time.Parse(time.RFC3339, gm.Annotations[reproAnnotation]); parseErr == nil && time.Now().Before(t) {
+			return reconcile.Result{RequeueAfter: time.Until(t)}, nil
+		}
+	}
+
 	syncedSecrets, err := r.syncGardenSecrets(ctx, namespace)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to sync garden secrets: %v", err)
-- 
2.54.0
PATCH
```

  </details>


**Special notes for your reviewer**:

/cc @rfranzke @istvanballok 

**Release note**:

```bugfix operator
A race condition during the global observability ingress secret rotation has been fixed.
```
