### PR TITLE
gardenlet: wait for `vpn-shoot` to be ready before checking tunnel connection

### DIFF
--- a/pkg/component/networking/vpn/shoot/shoot.go
+++ b/pkg/component/networking/vpn/shoot/shoot.go
@@ -354,7 +354,7 @@ func (v *vpnShoot) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilHealthy(timeoutCtx, v.client, v.namespace, managedResourceName)
+	return managedresources.WaitUntilHealthyAndNotProgressing(timeoutCtx, v.client, v.namespace, managedResourceName)
 }
 
 func (v *vpnShoot) WaitCleanup(ctx context.Context) error {

--- a/pkg/component/networking/vpn/shoot/shoot_test.go
+++ b/pkg/component/networking/vpn/shoot/shoot_test.go
@@ -1165,6 +1165,10 @@ var _ = Describe("VPNShoot", func() {
 								Type:   resourcesv1alpha1.ResourcesHealthy,
 								Status: gardencorev1beta1.ConditionTrue,
 							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
 						},
 					},
 				})).To(Succeed())

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -761,6 +761,12 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, deployGardenerResourceManager, deployKubeScheduler, deployVPNSeedServer, waitUntilShootNamespacesReady),
 		})
+		waitUntilVPNShootReady = g.Add(flow.Task{
+			Name:         "Waiting until vpn-shoot system component is ready",
+			Fn:           b.Shoot.Components.SystemComponents.VPNShoot.Wait,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			Dependencies: flow.NewTaskIDs(deployVPNShoot),
+		})
 		deployNodeProblemDetector = g.Add(flow.Task{
 			Name: "Deploying node-problem-detector system component",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
@@ -845,7 +851,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 			deployNodeExporter,
 			deployNodeLocalDNS,
 			deployMetricsServer,
-			deployVPNShoot,
+			waitUntilVPNShootReady,
 			deployNodeProblemDetector,
 			deployKubeProxy,
 			deployBlackboxExporter,

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -762,8 +762,10 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 				waitUntilGardenerResourceManagerReady, deployGardenerResourceManager, deployKubeScheduler, deployVPNSeedServer, waitUntilShootNamespacesReady),
 		})
 		waitUntilVPNShootReady = g.Add(flow.Task{
-			Name:         "Waiting until vpn-shoot system component is ready",
-			Fn:           b.Shoot.Components.SystemComponents.VPNShoot.Wait,
+			Name: "Waiting until vpn-shoot system component is ready",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return b.Shoot.Components.SystemComponents.VPNShoot.Wait(ctx)
+			}),
 			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployVPNShoot),
 		})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind flake

**What this PR does / why we need it**:

During control-plane migration, the gardenlet gets stuck in `WaitUntilTunnelConnectionExists`. [gardenlet logs](https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/pr-logs/pull/gardener_gardener/15438/pull-gardener-e2e-kind-migration/2084669780081512448/artifacts/gardener-local2/gardener-local2-control-plane/containers/gardenlet-8656b9458c-vdjr5_garden_gardenlet-c4752accc36e40be0e823bd3cc9bc03d15d0ee5382bdb15aa2132f6fda86f5ce.log) 

The destination seed generates a new `vpn-seed-server-tlsauth` HMAC key; the vpn-seed-server starts with it immediately, but the flow did not wait for the `vpn-shoot` pod to roll out with the matching key before beginning the tunnel check. The old pod connects with the stale key and every attempt fails with : `TLS Error: incoming packet authentication failed`. See [vpn-seed-server logs](https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/pr-logs/pull/gardener_gardener/15438/pull-gardener-e2e-kind-migration/2084669780081512448/artifacts/gardener-local2/gardener-local2-control-plane/containers/vpn-seed-server-666d7d857-qxwm7_shoot--local--e2e-migrate_vpn-seed-server-c6a30ff83e2ae43eddbef888d4602c3d756152d8b01f845731519588ee3a5495.log).

VPA concurrently evicted the vpn-shoot pod to resize resources, adding a second restart with the wrong key and further extending the recovery time. [Shoot events](https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/pr-logs/pull/gardener_gardener/15438/pull-gardener-e2e-kind-migration/2084669780081512448/artifacts/shoot--local--e2e-migrate/events/kube-system.log)

This PR tries to mitigate this by adding a `waitUntilVPNShootReady` task (calls managedresources.WaitUntilHealthy on shoot-core-vpn-shoot) between `deployVPNShoot` and `syncPointAllSystemComponentsDeployed`. `waitUntilTunnelConnectionExists` only starts once the Deployment rollout is complete and the pod is running with the correct TLS auth key.
The wait is skipped if `skipReadiness` is set to true.

**Which issue(s) this PR fixes**:

https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15437/pull-gardener-e2e-kind-migration/2084648136281690112
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15417/pull-gardener-e2e-kind-migration/2084654055245746176
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15384/pull-gardener-e2e-kind-migration/2084659837496463360
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15438/pull-gardener-e2e-kind-migration/2084669780081512448
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15287/pull-gardener-e2e-kind-migration/2084691907883044864
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15437/pull-gardener-e2e-kind-migration/2084694075943948288

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
