### PR TITLE
Increase timeout to 10m for `VerifyInPlaceUpdateCompletion`

### DIFF
--- a/test/utils/shoots/update/inplace/shoot.go
+++ b/test/utils/shoots/update/inplace/shoot.go
@@ -62,7 +62,7 @@ func ItShouldVerifyInPlaceUpdateCompletion(s *ShootContext) {
 
 	It("Verify in-place update completion", func(ctx SpecContext) {
 		VerifyInPlaceUpdateCompletion(ctx, s.Log, s.GardenClient, s.Shoot)
-	}, SpecTimeout(5*time.Minute))
+	}, SpecTimeout(10*time.Minute))
 }
 
 // VerifyInPlaceUpdateCompletion verifies that the in-place update was completed successfully by checking the


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind flake

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/15400#issuecomment-5141061483 for details.
This is an attempt to deflake the test.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/15400

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
