### PR TITLE
Use `memberNamePrefix` only when etcd-druid `UpgradeEtcdVersion` feature gate is enabled

### DIFF
--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -43,7 +43,10 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 
 	// Prefix etcd member names with the seed name so that members can be distinguished across
 	// control plane migrations between seeds. Self-hosted shoots have no Seed object.
-	if !b.Shoot.IsSelfHosted() {
+	// spec.memberNamePrefix requires etcd-druid v0.37+, only available when UpgradeEtcdVersion is enabled.
+	// TODO: Remove this once UpgradeEtcdVersion is enabled by default and the feature gate is removed.
+	if !b.Shoot.IsSelfHosted() &&
+		b.Config != nil && b.Config.ETCDConfig != nil && b.Config.ETCDConfig.FeatureGates["UpgradeEtcdVersion"] {
 		values.MemberNamePrefix = b.Seed.GetInfo().Name
 	}
 

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -44,7 +44,9 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 	// Prefix etcd member names with the seed name so that members can be distinguished across
 	// control plane migrations between seeds. Self-hosted shoots have no Seed object.
 	// spec.memberNamePrefix requires etcd-druid v0.37+, only available when UpgradeEtcdVersion is enabled.
-	// TODO: Remove this once UpgradeEtcdVersion is enabled by default and the feature gate is removed.
+	//
+	// TODO(acumino): Remove this `UpgradeEtcdVersion` feature gate check once the feature gate is permanently enabled and the feature gate is removed.
+	// TODO(acumino): Rework this feature gate condition once `UpgradeEtcdVersion` is enabled by default.
 	if !b.Shoot.IsSelfHosted() &&
 		b.Config != nil && b.Config.ETCDConfig != nil && b.Config.ETCDConfig.FeatureGates["UpgradeEtcdVersion"] {
 		values.MemberNamePrefix = b.Seed.GetInfo().Name

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -87,6 +87,11 @@ var _ = Describe("Etcd", func() {
 			botanist.Shoot = &shootpkg.Shoot{
 				ControlPlaneNamespace: namespace,
 			}
+			botanist.Config = &gardenletconfigv1alpha1.GardenletConfiguration{
+				ETCDConfig: &gardenletconfigv1alpha1.ETCDConfig{
+					FeatureGates: map[string]bool{"UpgradeEtcdVersion": true},
+				},
+			}
 			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: "test-seed"}})
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
@@ -216,6 +221,23 @@ var _ = Describe("Etcd", func() {
 			})
 
 			It("should not set MemberNamePrefix for self-hosted shoots", func() {
+				oldNewEtcd := NewEtcd
+				defer func() { NewEtcd = oldNewEtcd }()
+				NewEtcd = validator.NewEtcd
+
+				etcd, err := botanist.DefaultEtcd(role, class)
+				Expect(etcd).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("UpgradeEtcdVersion feature gate disabled", func() {
+			BeforeEach(func() {
+				botanist.Config.ETCDConfig.FeatureGates["UpgradeEtcdVersion"] = false
+				validator.expectedMemberNamePrefix = Equal("")
+			})
+
+			It("should not set MemberNamePrefix when UpgradeEtcdVersion is disabled", func() {
 				oldNewEtcd := NewEtcd
 				defer func() { NewEtcd = oldNewEtcd }()
 				NewEtcd = validator.NewEtcd

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -248,6 +248,23 @@ var _ = Describe("Etcd", func() {
 			})
 		})
 
+		Context("UpgradeEtcdVersion feature gate not specified", func() {
+			BeforeEach(func() {
+				botanist.Config.ETCDConfig.FeatureGates = nil
+				validator.expectedMemberNamePrefix = Equal("")
+			})
+
+			It("should not set MemberNamePrefix when FeatureGates is nil", func() {
+				oldNewEtcd := NewEtcd
+				defer func() { NewEtcd = oldNewEtcd }()
+				NewEtcd = validator.NewEtcd
+
+				etcd, err := botanist.DefaultEtcd(role, class)
+				Expect(etcd).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
 		It("should return an error because the maintenance time window cannot be parsed", func() {
 			botanist.Shoot.GetInfo().Spec.Maintenance.TimeWindow = &gardencorev1beta1.MaintenanceTimeWindow{
 				Begin: "foobar",


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The PR sets `memberNamePrefix` only when etcd-druid `UpgradeEtcdVersion` feature gate is enabled. See motivation in https://github.com/gardener/gardener/issues/15444

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/15444

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug preventing Shoot creation when the etcd-druid's `UpgradeEtcdVersion` feature gate is disabled (not explicitly enabled) has been fixed.
```
