### PR TITLE
[release-v1.148] Automated cherry pick of #15437: Ensure global observability secret is synced during rotation before triggering seed reconciliation

### DIFF
--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -388,6 +388,7 @@ build:
             - pkg/utils/managedresources/builder
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/structuredmap
             - pkg/utils/validation
@@ -509,6 +510,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/admissionplugins

--- a/dev-setup/skaffold-operator.yaml
+++ b/dev-setup/skaffold-operator.yaml
@@ -359,6 +359,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
@@ -532,6 +533,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
@@ -709,6 +711,7 @@ build:
             - pkg/utils/managedresources/builder
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
@@ -789,6 +792,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/cidr
@@ -889,6 +893,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/kubernetesversion

--- a/dev-setup/skaffold-seed.yaml
+++ b/dev-setup/skaffold-seed.yaml
@@ -452,6 +452,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
@@ -577,6 +578,7 @@ build:
             - pkg/utils/managedresources/builder
             - pkg/utils/retry
             - pkg/utils/secrets
+            - pkg/utils/secrets/manager
             - pkg/utils/signals
             - pkg/utils/structuredmap
             - pkg/utils/validation

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -174,6 +175,8 @@ func (r *Reconciler) reconcile(
 		// This is validated by a webhook, so we can read from either apiserver config.
 		encryptionProviderToUse = v1beta1helper.GetEncryptionProviderType(garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig)
 		encryptionProvider      = helper.GetEncryptionProviderTypeInStatus(garden.Status)
+
+		globalObservabilitySecretLastRotationInitiationTimestamp int64
 
 		g                              = flow.NewGraph("Garden reconciliation")
 		generateGenericTokenKubeconfig = g.Add(flow.Task{
@@ -475,6 +478,15 @@ func (r *Reconciler) reconcile(
 					return fmt.Errorf("failed to generate global observability ingress secret: %w", err)
 				}
 
+				// accept missing and empty last-rotation-initiation-time label values for human-generated or
+				// brand new generated secrets, but fail for any other content that cannot be parsed as an integer.
+				if lastRotationInitiationTime := secret.Labels[secretsmanager.LabelKeyLastRotationInitiationTime]; lastRotationInitiationTime != "" {
+					globalObservabilitySecretLastRotationInitiationTimestamp, err = strconv.ParseInt(lastRotationInitiationTime, 10, 64)
+					if err != nil {
+						return fmt.Errorf("error parsing last rotation initiation time of global observability secret in namespace %q: %w", r.GardenNamespace, err)
+					}
+				}
+
 				_, err = gardenerutils.ReplicateGlobalMonitoringSecret(ctx, virtualClusterClient, secret, r.GardenNamespace, func(name string) string {
 					return strings.TrimPrefix(name, "global-")
 				})
@@ -547,13 +559,21 @@ func (r *Reconciler) reconcile(
 			SkipIf:       helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
 			Dependencies: flow.NewTaskIDs(renewGardenletKubeconfigInAllSeeds),
 		})
+		waitUntilGlobalObservabilitySecretPropagatedToAllSeeds = g.Add(flow.Task{
+			Name: "Wait until global observability secret is propagated to all seed namespaces",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return secretsrotation.CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, virtualClusterClient, globalObservabilitySecretLastRotationInitiationTimestamp)
+			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
+			SkipIf:       !helper.IsObservabilityRotationInitiationTimeAfterLastCompletionTime(garden.Status.Credentials),
+			Dependencies: flow.NewTaskIDs(generateAndReplicateGlobalObservabilityIngressPassword),
+		})
 		_ = g.Add(flow.Task{
 			Name: "Annotate seeds to trigger reconciliation after observability credentials rotation",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.RenewGardenSecretsInAllSeeds(ctx, log, virtualClusterClient, v1beta1constants.GardenerOperationReconcile)
 			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
 			SkipIf:       !helper.IsObservabilityRotationInitiationTimeAfterLastCompletionTime(garden.Status.Credentials),
-			Dependencies: flow.NewTaskIDs(generateAndReplicateGlobalObservabilityIngressPassword, checkIfGardenletKubeconfigRenewalCompletedInAllSeeds),
+			Dependencies: flow.NewTaskIDs(waitUntilGlobalObservabilitySecretPropagatedToAllSeeds, checkIfGardenletKubeconfigRenewalCompletedInAllSeeds),
 		})
 
 		rewriteResourcesAddLabel = g.Add(flow.Task{

--- a/pkg/utils/gardener/secrets.go
+++ b/pkg/utils/gardener/secrets.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
 var (
@@ -67,6 +68,10 @@ func ReplicateGlobalMonitoringSecret(ctx context.Context, c client.Client, globa
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c, globalMonitoringSecretReplica, func() error {
 		metav1.SetMetaDataLabel(&globalMonitoringSecretReplica.ObjectMeta, v1beta1constants.GardenRole, v1beta1constants.GardenRoleGlobalMonitoring)
 		metav1.SetMetaDataLabel(&globalMonitoringSecretReplica.ObjectMeta, v1beta1constants.GardenerPurpose, LabelPurposeGlobalMonitoringSecret)
+
+		if rotationInitiationTime, ok := globalMonitoringSecret.Labels[secretsmanager.LabelKeyLastRotationInitiationTime]; ok {
+			metav1.SetMetaDataLabel(&globalMonitoringSecretReplica.ObjectMeta, secretsmanager.LabelKeyLastRotationInitiationTime, rotationInitiationTime)
+		}
 
 		globalMonitoringSecretReplica.Type = globalMonitoringSecret.Type
 		globalMonitoringSecretReplica.Data = globalMonitoringSecret.Data

--- a/pkg/utils/gardener/secrets_test.go
+++ b/pkg/utils/gardener/secrets_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Secrets", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "global-monitoring-secret",
 					Namespace:   "foo",
-					Labels:      map[string]string{"bar": "baz"},
+					Labels:      map[string]string{"bar": "baz", "last-rotation-initiation-time": "1700000000"},
 					Annotations: map[string]string{"baz": "foo"},
 				},
 				Type:      corev1.SecretTypeOpaque,
@@ -104,6 +104,8 @@ var _ = Describe("Secrets", func() {
 			assertions := func(secret *corev1.Secret) {
 				Expect(secret.Labels).To(HaveKeyWithValue("gardener.cloud/role", "global-monitoring"))
 				Expect(secret.Labels).To(HaveKeyWithValue("gardener.cloud/purpose", "global-monitoring-secret-replica"))
+				Expect(secret.Labels).To(HaveKeyWithValue("last-rotation-initiation-time", "1700000000"))
+				Expect(secret.Labels).NotTo(HaveKey("bar"))
 				Expect(secret.Type).To(Equal(globalMonitoringSecret.Type))
 				Expect(secret.Immutable).To(Equal(globalMonitoringSecret.Immutable))
 				for k, v := range globalMonitoringSecret.Data {

--- a/pkg/utils/gardener/secretsrotation/observability.go
+++ b/pkg/utils/gardener/secretsrotation/observability.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secretsrotation
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+// CheckIfGlobalObservabilitySecretPropagatedToAllSeeds waits until the global observability secret has been synced by the
+// gardener-controller-manager from the garden namespace into every seed namespace of the virtual cluster.
+func CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx context.Context, c client.Client, lastRotationInitiationTimestamp int64) error {
+	seedList := &metav1.PartialObjectMetadataList{}
+	seedList.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("SeedList"))
+	if err := c.List(ctx, seedList); err != nil {
+		return fmt.Errorf("failed to list seeds: %w", err)
+	}
+
+	for _, seed := range seedList.Items {
+		seedNamespace := gardenerutils.ComputeGardenNamespace(seed.Name)
+
+		secretList := &metav1.PartialObjectMetadataList{}
+		secretList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("SecretList"))
+		secretSelector := client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleGlobalMonitoring}
+		if err := c.List(ctx, secretList, client.InNamespace(seedNamespace), secretSelector); err != nil {
+			return fmt.Errorf("failed to list global observability secrets in namespace %q of seed %q: %w", seedNamespace, seed.Name, err)
+		}
+
+		for _, secret := range secretList.Items {
+			secretLastRotationInitiationTime, ok := secret.Labels[secretsmanager.LabelKeyLastRotationInitiationTime]
+
+			// accept missing last-rotation-initiation-time label values, e.g., human-managed secrets.
+			if !ok {
+				continue
+			}
+
+			// fail empty last-rotation-initiation-time label values, e.g., the secret is being rotated for the first time.
+			if secretLastRotationInitiationTime == "" {
+				return fmt.Errorf("global observability secret in namespace %q of seed %q does not yet carry a last rotation initiation time", seedNamespace, seed.Name)
+			}
+
+			secretLastRotationInitiationTimestamp, err := strconv.ParseInt(secretLastRotationInitiationTime, 10, 64)
+			if err != nil {
+				return fmt.Errorf("error parsing last rotation initiation time of global observability secret in namespace %q of seed %q: %w", seedNamespace, seed.Name, err)
+			}
+			if secretLastRotationInitiationTimestamp < lastRotationInitiationTimestamp {
+				return fmt.Errorf("global observability secret is not yet propagated to namespace %q of seed %q", seedNamespace, seed.Name)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/gardener/secretsrotation/observability_test.go
+++ b/pkg/utils/gardener/secretsrotation/observability_test.go
@@ -46,15 +46,19 @@ var _ = Describe("Observability", func() {
 			}
 		})
 
-		createGlobalMonitoringSecret := func(seedName string, timestamp int) {
+		createGlobalMonitoringSecretWithRawTimestamp := func(seedName, timestamp string) {
 			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 				Name:      "observability-ingress",
 				Namespace: gardenerutils.ComputeGardenNamespace(seedName),
 				Labels: map[string]string{
 					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
-					secretsmanager.LabelKeyLastRotationInitiationTime: strconv.Itoa(timestamp),
+					secretsmanager.LabelKeyLastRotationInitiationTime: timestamp,
 				},
 			}})).To(Succeed())
+		}
+
+		createGlobalMonitoringSecret := func(seedName string, timestamp int) {
+			createGlobalMonitoringSecretWithRawTimestamp(seedName, strconv.Itoa(timestamp))
 		}
 
 		createGlobalMonitoringSecretWithoutTimestamp := func(seedName string) {
@@ -95,28 +99,14 @@ var _ = Describe("Observability", func() {
 
 		It("should fail when a secret carries an empty rotation initiation time label", func() {
 			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
-			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name:      "observability-ingress",
-				Namespace: gardenerutils.ComputeGardenNamespace("seed2"),
-				Labels: map[string]string{
-					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
-					secretsmanager.LabelKeyLastRotationInitiationTime: "",
-				},
-			}})).To(Succeed())
+			createGlobalMonitoringSecretWithRawTimestamp("seed2", "")
 
 			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(MatchError(ContainSubstring("does not yet carry a last rotation initiation time")))
 		})
 
 		It("should fail when a secret carries a non-numeric rotation initiation time label", func() {
 			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
-			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name:      "observability-ingress",
-				Namespace: gardenerutils.ComputeGardenNamespace("seed2"),
-				Labels: map[string]string{
-					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
-					secretsmanager.LabelKeyLastRotationInitiationTime: "not-a-number",
-				},
-			}})).To(Succeed())
+			createGlobalMonitoringSecretWithRawTimestamp("seed2", "not-a-number")
 
 			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(MatchError(ContainSubstring("error parsing last rotation initiation time")))
 		})

--- a/pkg/utils/gardener/secretsrotation/observability_test.go
+++ b/pkg/utils/gardener/secretsrotation/observability_test.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secretsrotation_test
+
+import (
+	"context"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	. "github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+var _ = Describe("Observability", func() {
+	Context("#CheckIfGlobalObservabilitySecretPropagatedToAllSeeds", func() {
+		const lastRotationInitiationTimestamp = 1700000000
+
+		var (
+			ctx          context.Context
+			gardenClient client.Client
+			seeds        []gardencorev1beta1.Seed
+		)
+
+		BeforeEach(func() {
+			ctx = context.TODO()
+			gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+
+			seeds = []gardencorev1beta1.Seed{
+				{ObjectMeta: metav1.ObjectMeta{Name: "seed1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "seed2"}},
+			}
+			for _, seed := range seeds {
+				Expect(gardenClient.Create(ctx, &seed)).To(Succeed())
+			}
+		})
+
+		createGlobalMonitoringSecret := func(seedName string, timestamp int) {
+			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      "observability-ingress",
+				Namespace: gardenerutils.ComputeGardenNamespace(seedName),
+				Labels: map[string]string{
+					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
+					secretsmanager.LabelKeyLastRotationInitiationTime: strconv.Itoa(timestamp),
+				},
+			}})).To(Succeed())
+		}
+
+		createGlobalMonitoringSecretWithoutTimestamp := func(seedName string) {
+			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      "observability-ingress",
+				Namespace: gardenerutils.ComputeGardenNamespace(seedName),
+				Labels:    map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleGlobalMonitoring},
+			}})).To(Succeed())
+		}
+
+		It("should succeed when the secret propagated to all seeds with the expected timestamp", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			createGlobalMonitoringSecret("seed2", lastRotationInitiationTimestamp)
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(Succeed())
+		})
+
+		It("should succeed when a seed carries a newer timestamp than expected", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			createGlobalMonitoringSecret("seed2", lastRotationInitiationTimestamp+1)
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(Succeed())
+		})
+
+		It("should fail when a seed still carries an older timestamp", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			createGlobalMonitoringSecret("seed2", lastRotationInitiationTimestamp-1)
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(MatchError(ContainSubstring("not yet propagated to namespace \"seed-seed2\" of seed \"seed2\"")))
+		})
+
+		It("should ignore a secret without the rotation initiation time label", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			createGlobalMonitoringSecretWithoutTimestamp("seed2")
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(Succeed())
+		})
+
+		It("should fail when a secret carries an empty rotation initiation time label", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      "observability-ingress",
+				Namespace: gardenerutils.ComputeGardenNamespace("seed2"),
+				Labels: map[string]string{
+					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
+					secretsmanager.LabelKeyLastRotationInitiationTime: "",
+				},
+			}})).To(Succeed())
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(MatchError(ContainSubstring("does not yet carry a last rotation initiation time")))
+		})
+
+		It("should fail when a secret carries a non-numeric rotation initiation time label", func() {
+			createGlobalMonitoringSecret("seed1", lastRotationInitiationTimestamp)
+			Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      "observability-ingress",
+				Namespace: gardenerutils.ComputeGardenNamespace("seed2"),
+				Labels: map[string]string{
+					v1beta1constants.GardenRole:                       v1beta1constants.GardenRoleGlobalMonitoring,
+					secretsmanager.LabelKeyLastRotationInitiationTime: "not-a-number",
+				},
+			}})).To(Succeed())
+
+			Expect(CheckIfGlobalObservabilitySecretPropagatedToAllSeeds(ctx, gardenClient, lastRotationInitiationTimestamp)).To(MatchError(ContainSubstring("error parsing last rotation initiation time")))
+		})
+	})
+})


### PR DESCRIPTION
/kind bug
/area monitoring

Cherry pick of #15437 on release-v1.148.

#15437: Ensure global observability secret is synced during rotation before triggering seed reconciliation

**Release Notes:**
```bugfix operator
A race condition during the global observability ingress secret rotation has been fixed.
```