### PR TITLE
test(api): convert helper test() funcs to DescribeTable

### DIFF
--- a/pkg/api/core/helper/seed_test.go
+++ b/pkg/api/core/helper/seed_test.go
@@ -156,51 +156,39 @@ var _ = Describe("Helper", func() {
 			specSeedName, statusSeedName string
 		}
 
-		test := func(shoots []shootCase, expectedUsage map[string]int) {
-			var shootList []*core.Shoot
+		DescribeTable("should calculate the seed usage",
+			func(shoots []shootCase, expectedUsage map[string]int) {
+				var shootList []*core.Shoot
 
-			for i, shoot := range shoots {
-				s := &core.Shoot{}
-				s.Name = fmt.Sprintf("shoot-%d", i)
-				if shoot.specSeedName != "" {
-					s.Spec.SeedName = new(shoot.specSeedName)
+				for i, shoot := range shoots {
+					s := &core.Shoot{}
+					s.Name = fmt.Sprintf("shoot-%d", i)
+					if shoot.specSeedName != "" {
+						s.Spec.SeedName = new(shoot.specSeedName)
+					}
+					if shoot.statusSeedName != "" {
+						s.Status.SeedName = new(shoot.statusSeedName)
+					}
+					shootList = append(shootList, s)
 				}
-				if shoot.statusSeedName != "" {
-					s.Status.SeedName = new(shoot.statusSeedName)
-				}
-				shootList = append(shootList, s)
-			}
 
-			ExpectWithOffset(1, CalculateSeedUsage(shootList)).To(Equal(expectedUsage))
-		}
+				Expect(CalculateSeedUsage(shootList)).To(Equal(expectedUsage))
+			},
 
-		It("no shoots", func() {
-			test([]shootCase{}, map[string]int{})
-		})
-		It("shoot with both fields unset", func() {
-			test([]shootCase{{}}, map[string]int{})
-		})
-		It("shoot with only spec set", func() {
-			test([]shootCase{{specSeedName: "seed"}}, map[string]int{"seed": 1})
-		})
-		It("shoot with only status set", func() {
-			test([]shootCase{{statusSeedName: "seed"}}, map[string]int{"seed": 1})
-		})
-		It("shoot with both fields set to same seed", func() {
-			test([]shootCase{{specSeedName: "seed", statusSeedName: "seed"}}, map[string]int{"seed": 1})
-		})
-		It("shoot with fields set to different seeds", func() {
-			test([]shootCase{{specSeedName: "seed", statusSeedName: "seed2"}}, map[string]int{"seed": 1, "seed2": 1})
-		})
-		It("multiple shoots", func() {
-			test([]shootCase{
+			Entry("no shoots", []shootCase{}, map[string]int{}),
+			Entry("shoot with both fields unset", []shootCase{{}}, map[string]int{}),
+			Entry("shoot with only spec set", []shootCase{{specSeedName: "seed"}}, map[string]int{"seed": 1}),
+			Entry("shoot with only status set", []shootCase{{statusSeedName: "seed"}}, map[string]int{"seed": 1}),
+			Entry("shoot with both fields set to same seed", []shootCase{{specSeedName: "seed", statusSeedName: "seed"}}, map[string]int{"seed": 1}),
+			Entry("shoot with fields set to different seeds", []shootCase{{specSeedName: "seed", statusSeedName: "seed2"}}, map[string]int{"seed": 1, "seed2": 1}),
+			Entry("multiple shoots", []shootCase{
 				{},
 				{specSeedName: "seed", statusSeedName: "seed2"},
 				{specSeedName: "seed2", statusSeedName: "seed2"},
 				{specSeedName: "seed3", statusSeedName: "seed2"},
 				{specSeedName: "seed3", statusSeedName: "seed4"},
-			}, map[string]int{"seed": 1, "seed2": 3, "seed3": 2, "seed4": 1})
-		})
+			}, map[string]int{"seed": 1, "seed2": 3, "seed3": 2, "seed4": 1}),
+		)
 	})
 
 	Describe("#ConvertSeed", func() {

--- a/pkg/api/core/helper/shoot_test.go
+++ b/pkg/api/core/helper/shoot_test.go
@@ -292,57 +292,53 @@ var _ = Describe("Helper", func() {
 		})
 	})
 
-	Describe("GetShootAuditPolicyConfigMapName", func() {
-		test := func(description string, config *core.KubeAPIServerConfig, expectedName string) {
-			It(description, Offset(1), func() {
-				Expect(GetShootAuditPolicyConfigMapName(config)).To(Equal(expectedName))
-			})
-		}
+	DescribeTable("#GetShootAuditPolicyConfigMapName",
+		func(config *core.KubeAPIServerConfig, expectedName string) {
+			Expect(GetShootAuditPolicyConfigMapName(config)).To(Equal(expectedName))
+		},
 
-		test("KubeAPIServerConfig = nil", nil, "")
-		test("AuditConfig = nil", &core.KubeAPIServerConfig{}, "")
-		test("AuditPolicy = nil", &core.KubeAPIServerConfig{
+		Entry("KubeAPIServerConfig = nil", nil, ""),
+		Entry("AuditConfig = nil", &core.KubeAPIServerConfig{}, ""),
+		Entry("AuditPolicy = nil", &core.KubeAPIServerConfig{
 			AuditConfig: &core.AuditConfig{},
-		}, "")
-		test("ConfigMapRef = nil", &core.KubeAPIServerConfig{
+		}, ""),
+		Entry("ConfigMapRef = nil", &core.KubeAPIServerConfig{
 			AuditConfig: &core.AuditConfig{
 				AuditPolicy: &core.AuditPolicy{},
 			},
-		}, "")
-		test("ConfigMapRef set", &core.KubeAPIServerConfig{
+		}, ""),
+		Entry("ConfigMapRef set", &core.KubeAPIServerConfig{
 			AuditConfig: &core.AuditConfig{
 				AuditPolicy: &core.AuditPolicy{
 					ConfigMapRef: &corev1.ObjectReference{Name: "foo"},
 				},
 			},
-		}, "foo")
-	})
+		}, "foo"),
+	)
 
-	Describe("GetShootAuditPolicyConfigMapRef", func() {
-		test := func(description string, config *core.KubeAPIServerConfig, expectedRef *corev1.ObjectReference) {
-			It(description, Offset(1), func() {
-				Expect(GetShootAuditPolicyConfigMapRef(config)).To(Equal(expectedRef))
-			})
-		}
+	DescribeTable("#GetShootAuditPolicyConfigMapRef",
+		func(config *core.KubeAPIServerConfig, expectedRef *corev1.ObjectReference) {
+			Expect(GetShootAuditPolicyConfigMapRef(config)).To(Equal(expectedRef))
+		},
 
-		test("KubeAPIServerConfig = nil", nil, nil)
-		test("AuditConfig = nil", &core.KubeAPIServerConfig{}, nil)
-		test("AuditPolicy = nil", &core.KubeAPIServerConfig{
+		Entry("KubeAPIServerConfig = nil", nil, nil),
+		Entry("AuditConfig = nil", &core.KubeAPIServerConfig{}, nil),
+		Entry("AuditPolicy = nil", &core.KubeAPIServerConfig{
 			AuditConfig: &core.AuditConfig{},
-		}, nil)
-		test("ConfigMapRef = nil", &core.KubeAPIServerConfig{
+		}, nil),
+		Entry("ConfigMapRef = nil", &core.KubeAPIServerConfig{
 			AuditConfig: &core.AuditConfig{
 				AuditPolicy: &core.AuditPolicy{},
 			},
-		}, nil)
-		test("ConfigMapRef set", &core.KubeAPIServerConfig{
+		}, nil),
+		Entry("ConfigMapRef set", &core.KubeAPIServerConfig{
 			AuditConfig: &core.AuditConfig{
 				AuditPolicy: &core.AuditPolicy{
 					ConfigMapRef: &corev1.ObjectReference{Name: "foo"},
 				},
 			},
-		}, &corev1.ObjectReference{Name: "foo"})
-	})
+		}, &corev1.ObjectReference{Name: "foo"}),
+	)
 
 	DescribeTable("#GetShootAuthenticationConfigurationConfigMapName",
 		func(kubeAPIServerConfig *core.KubeAPIServerConfig, expectedName string) {

--- a/pkg/api/core/v1beta1/helper/seed_test.go
+++ b/pkg/api/core/v1beta1/helper/seed_test.go
@@ -287,51 +287,39 @@ var _ = Describe("Helper", func() {
 			specSeedName, statusSeedName string
 		}
 
-		test := func(shoots []shootCase, expectedUsage map[string]int) {
-			var shootList []*gardencorev1beta1.Shoot
+		DescribeTable("should calculate the seed usage",
+			func(shoots []shootCase, expectedUsage map[string]int) {
+				var shootList []*gardencorev1beta1.Shoot
 
-			for i, shoot := range shoots {
-				s := &gardencorev1beta1.Shoot{}
-				s.Name = fmt.Sprintf("shoot-%d", i)
-				if shoot.specSeedName != "" {
-					s.Spec.SeedName = new(shoot.specSeedName)
+				for i, shoot := range shoots {
+					s := &gardencorev1beta1.Shoot{}
+					s.Name = fmt.Sprintf("shoot-%d", i)
+					if shoot.specSeedName != "" {
+						s.Spec.SeedName = new(shoot.specSeedName)
+					}
+					if shoot.statusSeedName != "" {
+						s.Status.SeedName = new(shoot.statusSeedName)
+					}
+					shootList = append(shootList, s)
 				}
-				if shoot.statusSeedName != "" {
-					s.Status.SeedName = new(shoot.statusSeedName)
-				}
-				shootList = append(shootList, s)
-			}
 
-			ExpectWithOffset(1, CalculateSeedUsage(shootList)).To(Equal(expectedUsage))
-		}
+				Expect(CalculateSeedUsage(shootList)).To(Equal(expectedUsage))
+			},
 
-		It("no shoots", func() {
-			test([]shootCase{}, map[string]int{})
-		})
-		It("shoot with both fields unset", func() {
-			test([]shootCase{{}}, map[string]int{})
-		})
-		It("shoot with only spec set", func() {
-			test([]shootCase{{specSeedName: "seed"}}, map[string]int{"seed": 1})
-		})
-		It("shoot with only status set", func() {
-			test([]shootCase{{statusSeedName: "seed"}}, map[string]int{"seed": 1})
-		})
-		It("shoot with both fields set to same seed", func() {
-			test([]shootCase{{specSeedName: "seed", statusSeedName: "seed"}}, map[string]int{"seed": 1})
-		})
-		It("shoot with fields set to different seeds", func() {
-			test([]shootCase{{specSeedName: "seed", statusSeedName: "seed2"}}, map[string]int{"seed": 1, "seed2": 1})
-		})
-		It("multiple shoots", func() {
-			test([]shootCase{
+			Entry("no shoots", []shootCase{}, map[string]int{}),
+			Entry("shoot with both fields unset", []shootCase{{}}, map[string]int{}),
+			Entry("shoot with only spec set", []shootCase{{specSeedName: "seed"}}, map[string]int{"seed": 1}),
+			Entry("shoot with only status set", []shootCase{{statusSeedName: "seed"}}, map[string]int{"seed": 1}),
+			Entry("shoot with both fields set to same seed", []shootCase{{specSeedName: "seed", statusSeedName: "seed"}}, map[string]int{"seed": 1}),
+			Entry("shoot with fields set to different seeds", []shootCase{{specSeedName: "seed", statusSeedName: "seed2"}}, map[string]int{"seed": 1, "seed2": 1}),
+			Entry("multiple shoots", []shootCase{
 				{},
 				{specSeedName: "seed", statusSeedName: "seed2"},
 				{specSeedName: "seed2", statusSeedName: "seed2"},
 				{specSeedName: "seed3", statusSeedName: "seed2"},
 				{specSeedName: "seed3", statusSeedName: "seed4"},
-			}, map[string]int{"seed": 1, "seed2": 3, "seed3": 2, "seed4": 1})
-		})
+			}, map[string]int{"seed": 1, "seed2": 3, "seed3": 2, "seed4": 1}),
+		)
 	})
 
 	DescribeTable("#DNSProviderCredentialsRefEqual",

--- a/pkg/api/core/v1beta1/helper/shoot_test.go
+++ b/pkg/api/core/v1beta1/helper/shoot_test.go
@@ -924,57 +924,53 @@ var _ = Describe("Helper", func() {
 		})
 	})
 
-	Describe("GetShootAuditPolicyConfigMapName", func() {
-		test := func(description string, config *gardencorev1beta1.KubeAPIServerConfig, expectedName string) {
-			It(description, Offset(1), func() {
-				Expect(GetShootAuditPolicyConfigMapName(config)).To(Equal(expectedName))
-			})
-		}
+	DescribeTable("#GetShootAuditPolicyConfigMapName",
+		func(config *gardencorev1beta1.KubeAPIServerConfig, expectedName string) {
+			Expect(GetShootAuditPolicyConfigMapName(config)).To(Equal(expectedName))
+		},
 
-		test("KubeAPIServerConfig = nil", nil, "")
-		test("AuditConfig = nil", &gardencorev1beta1.KubeAPIServerConfig{}, "")
-		test("AuditPolicy = nil", &gardencorev1beta1.KubeAPIServerConfig{
+		Entry("KubeAPIServerConfig = nil", nil, ""),
+		Entry("AuditConfig = nil", &gardencorev1beta1.KubeAPIServerConfig{}, ""),
+		Entry("AuditPolicy = nil", &gardencorev1beta1.KubeAPIServerConfig{
 			AuditConfig: &gardencorev1beta1.AuditConfig{},
-		}, "")
-		test("ConfigMapRef = nil", &gardencorev1beta1.KubeAPIServerConfig{
+		}, ""),
+		Entry("ConfigMapRef = nil", &gardencorev1beta1.KubeAPIServerConfig{
 			AuditConfig: &gardencorev1beta1.AuditConfig{
 				AuditPolicy: &gardencorev1beta1.AuditPolicy{},
 			},
-		}, "")
-		test("ConfigMapRef set", &gardencorev1beta1.KubeAPIServerConfig{
+		}, ""),
+		Entry("ConfigMapRef set", &gardencorev1beta1.KubeAPIServerConfig{
 			AuditConfig: &gardencorev1beta1.AuditConfig{
 				AuditPolicy: &gardencorev1beta1.AuditPolicy{
 					ConfigMapRef: &corev1.ObjectReference{Name: "foo"},
 				},
 			},
-		}, "foo")
-	})
+		}, "foo"),
+	)
 
-	Describe("GetShootAuditPolicyConfigMapRef", func() {
-		test := func(description string, config *gardencorev1beta1.KubeAPIServerConfig, expectedRef *corev1.ObjectReference) {
-			It(description, Offset(1), func() {
-				Expect(GetShootAuditPolicyConfigMapRef(config)).To(Equal(expectedRef))
-			})
-		}
+	DescribeTable("#GetShootAuditPolicyConfigMapRef",
+		func(config *gardencorev1beta1.KubeAPIServerConfig, expectedRef *corev1.ObjectReference) {
+			Expect(GetShootAuditPolicyConfigMapRef(config)).To(Equal(expectedRef))
+		},
 
-		test("KubeAPIServerConfig = nil", nil, nil)
-		test("AuditConfig = nil", &gardencorev1beta1.KubeAPIServerConfig{}, nil)
-		test("AuditPolicy = nil", &gardencorev1beta1.KubeAPIServerConfig{
+		Entry("KubeAPIServerConfig = nil", nil, nil),
+		Entry("AuditConfig = nil", &gardencorev1beta1.KubeAPIServerConfig{}, nil),
+		Entry("AuditPolicy = nil", &gardencorev1beta1.KubeAPIServerConfig{
 			AuditConfig: &gardencorev1beta1.AuditConfig{},
-		}, nil)
-		test("ConfigMapRef = nil", &gardencorev1beta1.KubeAPIServerConfig{
+		}, nil),
+		Entry("ConfigMapRef = nil", &gardencorev1beta1.KubeAPIServerConfig{
 			AuditConfig: &gardencorev1beta1.AuditConfig{
 				AuditPolicy: &gardencorev1beta1.AuditPolicy{},
 			},
-		}, nil)
-		test("ConfigMapRef set", &gardencorev1beta1.KubeAPIServerConfig{
+		}, nil),
+		Entry("ConfigMapRef set", &gardencorev1beta1.KubeAPIServerConfig{
 			AuditConfig: &gardencorev1beta1.AuditConfig{
 				AuditPolicy: &gardencorev1beta1.AuditPolicy{
 					ConfigMapRef: &corev1.ObjectReference{Name: "foo"},
 				},
 			},
-		}, &corev1.ObjectReference{Name: "foo"})
-	})
+		}, &corev1.ObjectReference{Name: "foo"}),
+	)
 
 	DescribeTable("#GetShootAuthenticationConfigurationConfigMapName",
 		func(kubeAPIServerConfig *gardencorev1beta1.KubeAPIServerConfig, expectedName string) {


### PR DESCRIPTION
<!-- /area dev-productivity -->
<!-- /kind cleanup -->

**What this PR does / why we need it**:

Refs #13890. Converts the remaining manual `test()` helpers listed in the issue body into idiomatic Ginkgo `DescribeTable`s:

- `pkg/api/core/helper/shoot_test.go` — `GetShootAuditPolicyConfigMapName`, `GetShootAuditPolicyConfigMapRef`
- `pkg/api/core/v1beta1/helper/shoot_test.go` — same two functions
- `pkg/api/core/helper/seed_test.go` — `CalculateSeedUsage`
- `pkg/api/core/v1beta1/helper/seed_test.go` — same function

#14750 noted that the `pkg/apis/core/helper/` examples from the issue body could not be found because the package no longer exists. It was renamed to `pkg/api/core/helper/`, so the `shoot_test.go` and `seed_test.go` examples the issue points at are still there — this PR picks them up, plus their `v1beta1` counterparts so the two API versions stay in sync.

For the two `GetShootAuditPolicyConfigMap*` cases the enclosing `Describe` contained nothing but the helper, so it is replaced outright by a top-level `DescribeTable`, matching the `DescribeTable("#GetShootAuthenticationConfigurationConfigMapName", ...)` immediately below it in the same file. For `CalculateSeedUsage` the `Describe` is kept because it declares the local `shootCase` type, and the `DescribeTable` nests inside it.

Since each case is now an `Entry` rather than an `It` created from inside a helper, the `Offset(1)` / `ExpectWithOffset(1)` indirection is no longer needed and is dropped — Ginkgo already reports the failing `Entry` location.

Behaviour is unchanged; this is test-only and touches no production code.

**Which issue(s) this PR fixes**:
Part of #13890

**Special notes for your reviewer**:

- Spec counts are identical before and after, so no case was dropped in the conversion: `pkg/api/core/helper` 253 of 253, `pkg/api/core/v1beta1/helper` 741 of 741 (`go test -v`, on `master` and on this branch).
- `gofmt`, `go vet` and `ginkgolinter` are clean on both packages.
- @timebertt — I noted your type-safety/LSP-navigation caveat in the issue thread. The four blocks converted here are plain value-in/value-out helpers, which is the case where the trade seems most favourable; happy to drop any of them if you'd rather keep the helper style.
- @Sujeev-Uthayakumar asked about taking this issue in January but the issue is still unassigned and no PR followed — apologies if I've cut across anything in progress, happy to step back.

**Release note**:
```other
NONE
```
