### PR TITLE
[GEP-28] Introduce `gardenadm restore` command

### DIFF
--- a/cmd/gardenadm/app/app.go
+++ b/cmd/gardenadm/app/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenadm/cmd/discover"
 	initcmd "github.com/gardener/gardener/pkg/gardenadm/cmd/init"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd/join"
+	"github.com/gardener/gardener/pkg/gardenadm/cmd/restore"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd/token"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd/version"
 )
@@ -69,6 +70,7 @@ func prepareClusterBootstrapGroup(cmd *cobra.Command, opts *cmd.Options) {
 		join.NewCommand(opts),
 		bootstrap.NewCommand(opts),
 		token.NewCommand(opts),
+		restore.NewCommand(opts),
 	} {
 		subcommand.GroupID = group.ID
 		cmd.AddCommand(subcommand)

--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -187,6 +187,7 @@ build:
             - pkg/gardenadm/cmd/discover/new
             - pkg/gardenadm/cmd/init
             - pkg/gardenadm/cmd/join
+            - pkg/gardenadm/cmd/restore
             - pkg/gardenadm/cmd/token
             - pkg/gardenadm/cmd/token/create
             - pkg/gardenadm/cmd/token/delete

--- a/docs/cli-reference/gardenadm/gardenadm.md
+++ b/docs/cli-reference/gardenadm/gardenadm.md
@@ -17,6 +17,7 @@ gardenadm bootstraps and manages self-hosted shoot clusters in the Gardener proj
 * [gardenadm discover](gardenadm_discover.md)	 - Conveniently download Gardener configuration resources from an existing garden cluster
 * [gardenadm init](gardenadm_init.md)	 - Bootstrap the first control plane node
 * [gardenadm join](gardenadm_join.md)	 - Bootstrap control plane or worker nodes and join them to the cluster
+* [gardenadm restore](gardenadm_restore.md)	 - Restore a control plane node from an etcd backup and manifest files
 * [gardenadm token](gardenadm_token.md)	 - Manage bootstrap and discovery tokens for gardenadm join
 * [gardenadm version](gardenadm_version.md)	 - Print the client version information
 

--- a/docs/cli-reference/gardenadm/gardenadm_restore.md
+++ b/docs/cli-reference/gardenadm/gardenadm_restore.md
@@ -1,0 +1,42 @@
+## gardenadm restore
+
+Restore a control plane node from an etcd backup and manifest files
+
+### Synopsis
+
+Restore a control plane node from an etcd backup and manifest files. Use this command to recover the
+self-hosted shoot cluster's control plane node after a disaster (e.g., the control plane node is lost)
+onto a new or existing node.
+
+```
+gardenadm restore [flags]
+```
+
+### Examples
+
+```
+# Restore a control plane node from an etcd backup
+gardenadm restore --config-dir /path/to/manifests --backup-data-path /path/to/etcd-main/v2 --prior-node-name <name>
+```
+
+### Options
+
+```
+      --backup-data-path string   Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
+  -d, --config-dir string         Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
+  -h, --help                      help for restore
+      --prior-node-name string    The name of the prior control plane node. Required in order to cleanup stale resources.
+  -z, --zone string               Availability zone of the new machine where the prior node is being restored to. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.
+```
+
+### Options inherited from parent commands
+
+```
+      --log-format string   The format for the logs. Must be one of [json text] (default "text")
+      --log-level string    The level/severity for the logs. Must be one of [debug info error] (default "info")
+```
+
+### SEE ALSO
+
+* [gardenadm](gardenadm.md)	 - gardenadm bootstraps and manages self-hosted shoot clusters in the Gardener project.
+

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -49,6 +49,8 @@ func NewCommand(globalOpts *cmd.Options) *cobra.Command {
 		Example: `# Bootstrap the infrastructure
 gardenadm bootstrap --config-dir /path/to/manifests`,
 
+		Args: cobra.NoArgs,
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.ParseArgs(args); err != nil {
 				return err

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap_test.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap_test.go
@@ -74,4 +74,14 @@ var _ = Describe("Bootstrap", func() {
 			})
 		})
 	})
+
+	Describe("#Args", func() {
+		It("should accept no arguments", func() {
+			Expect(command.Args(command, nil)).To(Succeed())
+		})
+
+		It("should reject any positional arguments", func() {
+			Expect(command.Args(command, []string{"foo"})).To(HaveOccurred())
+		})
+	})
 })

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -53,6 +53,8 @@ func NewCommand(globalOpts *cmd.Options) *cobra.Command {
 		Example: `# Deploy a gardenlet
 gardenadm connect`,
 
+		Args: cobra.MaximumNArgs(1),
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.ParseArgs(args); err != nil {
 				return err

--- a/pkg/gardenadm/cmd/connect/connect_test.go
+++ b/pkg/gardenadm/cmd/connect/connect_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package token_test
+package connect_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -10,11 +10,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
-	. "github.com/gardener/gardener/pkg/gardenadm/cmd/token"
+	. "github.com/gardener/gardener/pkg/gardenadm/cmd/connect"
 	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
-var _ = Describe("Token", func() {
+var _ = Describe("Connect", func() {
 	var (
 		globalOpts *cmd.Options
 		command    *cobra.Command
@@ -26,19 +26,17 @@ var _ = Describe("Token", func() {
 		command = NewCommand(globalOpts)
 	})
 
-	Describe("#RunE", func() {
-		It("should not have a Run function", func() {
-			Expect(command.RunE).To(BeNil())
-		})
-	})
-
 	Describe("#Args", func() {
 		It("should accept no arguments", func() {
 			Expect(command.Args(command, nil)).To(Succeed())
 		})
 
-		It("should reject any positional arguments", func() {
-			Expect(command.Args(command, []string{"foo"})).To(HaveOccurred())
+		It("should accept a single positional argument", func() {
+			Expect(command.Args(command, []string{"foo"})).To(Succeed())
+		})
+
+		It("should reject more than one positional argument", func() {
+			Expect(command.Args(command, []string{"foo", "bar"})).To(HaveOccurred())
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/discover/discover.go
+++ b/pkg/gardenadm/cmd/discover/discover.go
@@ -18,6 +18,7 @@ func NewCommand(globalOpts *cmd.Options) *cobra.Command {
 		Use:   "discover",
 		Short: "Conveniently download Gardener configuration resources from an existing garden cluster",
 		Long:  "Conveniently download Gardener configuration resources from an existing garden cluster (CloudProfile, ControllerRegistrations, ControllerDeployments, etc.)",
+		Args:  cobra.NoArgs,
 	}
 
 	cmd.AddCommand(dnew.NewCommand(globalOpts))

--- a/pkg/gardenadm/cmd/discover/discover_test.go
+++ b/pkg/gardenadm/cmd/discover/discover_test.go
@@ -26,4 +26,16 @@ var _ = Describe("Discover", func() {
 			Expect(subs).To(HaveKey("existing"))
 		})
 	})
+
+	Describe("#Args", func() {
+		It("should accept no arguments", func() {
+			command := NewCommand(&cmd.Options{})
+			Expect(command.Args(command, nil)).To(Succeed())
+		})
+
+		It("should reject any positional arguments", func() {
+			command := NewCommand(&cmd.Options{})
+			Expect(command.Args(command, []string{"foo"})).To(HaveOccurred())
+		})
+	})
 })

--- a/pkg/gardenadm/cmd/discover/existing/existing_test.go
+++ b/pkg/gardenadm/cmd/discover/existing/existing_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Existing", func() {
 		backupBucketGeneratedSecret *corev1.Secret
 		backupBucket                *gardencorev1beta1.BackupBucket
 		backupEntry                 *gardencorev1beta1.BackupEntry
+		shootState                  *gardencorev1beta1.ShootState
 	)
 
 	BeforeEach(func() {
@@ -135,6 +136,12 @@ var _ = Describe("Existing", func() {
 				},
 			},
 		}
+		shootState = &gardencorev1beta1.ShootState{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-shoot",
+				Namespace: resources.Shoot.Namespace,
+			},
+		}
 	})
 
 	Describe("#RunE", func() {
@@ -159,6 +166,7 @@ var _ = Describe("Existing", func() {
 			}
 			Expect(fakeClient.Status().Patch(ctx, backupBucket, patch)).To(Succeed())
 			Expect(fakeClient.Create(ctx, backupEntry)).To(Succeed())
+			Expect(fakeClient.Create(ctx, shootState)).To(Succeed())
 
 			Expect(command.Flags().Set("name", resources.Shoot.Name)).To(Succeed())
 			Expect(command.Flags().Set("namespace", resources.Shoot.Namespace)).To(Succeed())
@@ -186,6 +194,8 @@ var _ = Describe("Existing", func() {
 				ContainSubstring("Exported Secret/"+backupBucketGeneratedSecret.Name),
 				ContainSubstring("Exported BackupBucket/"+backupBucket.Name),
 				ContainSubstring("Exported BackupEntry/"+backupEntry.Name),
+				ContainSubstring("Exported Shoot/"+resources.Shoot.Name),
+				ContainSubstring("Exported ShootState/"+shootState.Name),
 			))
 
 			for _, path := range []string{
@@ -205,6 +215,8 @@ var _ = Describe("Existing", func() {
 				fmt.Sprintf("secret-%s.yaml", backupBucketGeneratedSecret.Name),
 				fmt.Sprintf("backupbucket-%s.yaml", backupBucket.Name),
 				fmt.Sprintf("backupentry-%s.yaml", backupEntry.Name),
+				fmt.Sprintf("shoot-%s.yaml", resources.Shoot.Name),
+				fmt.Sprintf("shootstate-%s.yaml", shootState.Name),
 			} {
 				exists, err := fs.Exists(path)
 				Expect(err).NotTo(HaveOccurred(), "for path "+path)

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -37,6 +37,8 @@ gardenadm init --config-dir /path/to/manifests
 # Bootstrap the first control plane node in a specific zone (required when multiple zones are configured in the ` + "`Shoot`" + ` resource)
 gardenadm init --config-dir /path/to/manifests --zone zone-a`,
 
+		Args: cobra.NoArgs,
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.ParseArgs(args); err != nil {
 				return err

--- a/pkg/gardenadm/cmd/init/init_test.go
+++ b/pkg/gardenadm/cmd/init/init_test.go
@@ -2,43 +2,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package generate_test
+package init_test
 
 import (
-	"strings"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
-	. "github.com/gardener/gardener/pkg/gardenadm/cmd/token/generate"
-	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
+	. "github.com/gardener/gardener/pkg/gardenadm/cmd/init"
 	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
-var _ = Describe("Generate", func() {
+var _ = Describe("Init", func() {
 	var (
 		globalOpts *cmd.Options
-		stdOut     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, stdOut, _ = clitest.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, _ = clitest.NewTestIOStreams()
 		command = NewCommand(globalOpts)
-	})
-
-	Describe("#RunE", func() {
-		It("should compute a random bootstrap token and print it", func() {
-			Expect(command.RunE(command, nil)).To(Succeed())
-
-			Eventually(func() string {
-				return strings.TrimSpace(string(stdOut.Contents()))
-			}).Should(MatchRegexp(bootstraptoken.ValidBootstrapTokenRegex.String()))
-		})
 	})
 
 	Describe("#Args", func() {

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -38,7 +38,7 @@ type Options struct {
 	// When set, the bootstrap etcd will be initialized from this path using the Local storage provider.
 	// The path is expected to have the structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2.
 	//
-	// TODO(Kostov6): Support specifying the backup root path after backup resource manifests are imported.
+	// TODO(ialidzhikov): Remove this option in favor of the same BackupDataPath option in the `gardenadm restore` command.
 	BackupDataPath string
 }
 
@@ -78,6 +78,6 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.UseHostNetwork, "use-host-network", false, "If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.")
 	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
 	fs.BoolVar(&o.Force, "force", false, "If set, the init command will be executed even if the control plane is already initialized.")
-	// TODO(Kostov6): Support specifying the backup root path after backup resource manifests are imported.
+	// TODO(ialidzhikov): Remove this flag in favor of the same `--backup-data-path` flag in the `gardenadm restore` command.
 	fs.StringVar(&o.BackupDataPath, "backup-data-path", "", "Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2")
 }

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/pflag"
 
-	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/gardenadm"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 )
@@ -55,32 +53,17 @@ func (o *Options) Validate() error {
 		return err
 	}
 
-	return o.validateZone()
-}
-
-// validateZone validates the zone configuration against the shoot specification.
-func (o *Options) validateZone() error {
 	resources, err := gardenadm.ReadManifests(o.Log, os.DirFS(o.ConfigDir))
 	if err != nil {
 		return fmt.Errorf("failed loading resources for zone validation: %w", err)
 	}
 
-	if resources.Shoot == nil {
-		return fmt.Errorf("zone validation failed shoot resource is missing in the manifests")
-	}
-
-	// init command is only for control plane node, therefore we look for the control plane pool
-	var controlPlanePool *gardencorev1beta1.Worker
-	if controlPlanePool = v1beta1helper.ControlPlaneWorkerPoolForShoot(resources.Shoot.Spec.Provider.Workers); controlPlanePool == nil {
-		return fmt.Errorf("zone validation failed, shoot doesn't have a control plane worker pool configured")
-	}
-
-	effectiveZone, err := cmd.DetermineZone(*controlPlanePool, o.Zone)
+	effectiveZone, err := cmd.ValidateAndDetermineControlPlaneZone(resources.Shoot, o.Zone)
 	if err != nil {
-		return fmt.Errorf("failed determining zone for control plane worker pool %q: %w", controlPlanePool.Name, err)
+		return err
 	}
-
 	o.Zone = effectiveZone
+
 	return nil
 }
 

--- a/pkg/gardenadm/cmd/init/options_test.go
+++ b/pkg/gardenadm/cmd/init/options_test.go
@@ -112,94 +112,17 @@ spec:`)
 			Expect(options.Validate()).To(MatchError(ContainSubstring("failed loading resources for zone validation")))
 		})
 
-		It("should fail when control plane worker pool is not found", func() {
+		It("should determine the zone against the control plane worker pool", func() {
+			createShootManifest("", []string{"zone-1"}, true)
+
+			Expect(options.Validate()).To(Succeed())
+			Expect(options.Zone).To(Equal("zone-1"))
+		})
+
+		It("should surface zone validation errors from the shared helper", func() {
 			createShootManifest("", nil, false)
 
 			Expect(options.Validate()).To(MatchError(ContainSubstring("shoot doesn't have a control plane worker pool configured")))
-		})
-
-		When("zone validation with managed infrastructure", func() {
-			BeforeEach(func() {
-				createShootManifest("test-credentials", []string{"us-east-1a"}, true)
-			})
-
-			It("should allow zone when provided for managed infrastructure", func() {
-				options.Zone = "us-east-1a"
-
-				Expect(options.Validate()).To(Succeed())
-			})
-		})
-
-		When("zone validation with unmanaged infrastructure", func() {
-			When("worker with no zones configured", func() {
-				BeforeEach(func() {
-					createShootManifest("", nil, true)
-				})
-
-				It("should reject zone when worker has no zones configured", func() {
-					options.Zone = "custom-zone"
-
-					Expect(options.Validate()).To(MatchError(ContainSubstring(`worker "control-plane" has no zones configured, but zone "custom-zone" was provided`)))
-				})
-
-				It("should allow empty zone when worker has no zones", func() {
-					options.Zone = ""
-
-					Expect(options.Validate()).To(Succeed())
-					Expect(options.Zone).To(BeEmpty())
-				})
-			})
-
-			When("worker with single zone configured", func() {
-				BeforeEach(func() {
-					createShootManifest("", []string{"zone-1"}, true)
-				})
-
-				It("should auto-apply the single zone when not provided", func() {
-					options.Zone = ""
-
-					Expect(options.Validate()).To(Succeed())
-					Expect(options.Zone).To(Equal("zone-1"))
-				})
-
-				It("should accept matching zone when provided", func() {
-					options.Zone = "zone-1"
-
-					Expect(options.Validate()).To(Succeed())
-					Expect(options.Zone).To(Equal("zone-1"))
-				})
-
-				It("should reject non-matching zone when provided", func() {
-					options.Zone = "zone-2"
-
-					Expect(options.Validate()).To(MatchError(ContainSubstring(`provided zone "zone-2" does not match the configured zones [zone-1] for worker "control-plane"`)))
-				})
-			})
-
-			When("worker with multiple zones configured", func() {
-				BeforeEach(func() {
-					createShootManifest("", []string{"zone-1", "zone-2", "zone-3"}, true)
-				})
-
-				It("should require zone flag when not provided", func() {
-					options.Zone = ""
-
-					Expect(options.Validate()).To(MatchError(ContainSubstring(`worker "control-plane" has multiple zones configured [zone-1 zone-2 zone-3], --zone flag is required`)))
-				})
-
-				It("should accept valid zone when provided", func() {
-					options.Zone = "zone-2"
-
-					Expect(options.Validate()).To(Succeed())
-					Expect(options.Zone).To(Equal("zone-2"))
-				})
-
-				It("should reject invalid zone when provided", func() {
-					options.Zone = "zone-4"
-
-					Expect(options.Validate()).To(MatchError(ContainSubstring(`provided zone "zone-4" does not match the configured zones [zone-1 zone-2 zone-3] for worker "control-plane"`)))
-				})
-			})
 		})
 	})
 

--- a/pkg/gardenadm/cmd/restore/options.go
+++ b/pkg/gardenadm/cmd/restore/options.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package restore
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+
+	"github.com/gardener/gardener/pkg/gardenadm"
+	"github.com/gardener/gardener/pkg/gardenadm/cmd"
+)
+
+// Options contains options for this command.
+type Options struct {
+	*cmd.Options
+	cmd.ManifestOptions
+
+	// BackupDataPath is the local path on the node where the etcd backup data is stored.
+	// When set, the bootstrap etcd will be initialized from this path using the Local storage provider.
+	// The path is expected to have the structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2.
+	//
+	// TODO(Kostov6): Support specifying the backup root path after backup resource manifests are imported.
+	BackupDataPath string
+	// PriorNodeName defines the name of the node that is going to be replaced.
+	PriorNodeName string
+	// Zone is the availability zone of the new machine where the prior node is being restored to.
+	// The zone of the new machine can differ from the zone of the prior node.
+	// It is validated against the `.spec.provider.workers[].zones` field of the Shoot manifest.
+	// If the worker pool has multiple zones configured, this flag is required.
+	// If it has exactly one zone configured, that zone is automatically applied and the flag is optional.
+	// If it has no zones configured, this flag must not be set.
+	Zone string
+}
+
+// ParseArgs parses the arguments to the options.
+func (o *Options) ParseArgs(args []string) error {
+	return o.ManifestOptions.ParseArgs(args)
+}
+
+// Validate validates the options.
+func (o *Options) Validate() error {
+	if err := o.ManifestOptions.Validate(); err != nil {
+		return err
+	}
+	if o.BackupDataPath == "" {
+		return fmt.Errorf("must provide --backup-data-path")
+	}
+	if o.PriorNodeName == "" {
+		return fmt.Errorf("must provide --prior-node-name")
+	}
+
+	resources, err := gardenadm.ReadManifests(o.Log, os.DirFS(o.ConfigDir))
+	if err != nil {
+		return fmt.Errorf("failed loading resources for gardenadm restore validation: %w", err)
+	}
+	if resources.ShootState == nil {
+		return fmt.Errorf("gardenadm restore requires a ShootState resource in the config directory, but none was found")
+	}
+	if resources.Shoot == nil || resources.Shoot.Status.UID == "" {
+		// The Shoot .status.uid must match the UID from the original cluster because it determines the
+		// BackupBucket and BackupEntry names and identifies the cluster in the cluster-identity ConfigMap.
+		// If it were empty, a fresh UID would be generated, which would lead to undesired behaviour and inconsistency in the system.
+		return fmt.Errorf("gardenadm restore requires the Shoot manifest in the config directory to have .status.uid set")
+	}
+
+	effectiveZone, err := cmd.ValidateAndDetermineControlPlaneZone(resources.Shoot, o.Zone)
+	if err != nil {
+		return err
+	}
+	o.Zone = effectiveZone
+
+	return nil
+}
+
+// Complete completes the options.
+func (o *Options) Complete() error {
+	return o.ManifestOptions.Complete()
+}
+
+func (o *Options) addFlags(fs *pflag.FlagSet) {
+	o.ManifestOptions.AddFlags(fs)
+	// TODO(Kostov6): Support specifying the backup root path after backup resource manifests are imported.
+	fs.StringVar(&o.BackupDataPath, "backup-data-path", "", "Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2")
+	fs.StringVar(&o.PriorNodeName, "prior-node-name", "", "The name of the prior control plane node. Required in order to cleanup stale resources.")
+	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone of the new machine where the prior node is being restored to. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
+}

--- a/pkg/gardenadm/cmd/restore/options_test.go
+++ b/pkg/gardenadm/cmd/restore/options_test.go
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package restore_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/gardenadm/cmd"
+	. "github.com/gardener/gardener/pkg/gardenadm/cmd/restore"
+)
+
+var _ = Describe("Options", func() {
+	var (
+		options   *Options
+		configDir string
+	)
+
+	BeforeEach(func() {
+		var err error
+		configDir, err = os.MkdirTemp("", "gardenadm-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		options = &Options{
+			Options: &cmd.Options{},
+		}
+		options.ConfigDir = configDir
+
+		cloudProfileManifest := `apiVersion: core.gardener.cloud/v1beta1
+kind: CloudProfile
+metadata:
+  name: local
+spec:
+  type: local
+`
+		Expect(os.WriteFile(filepath.Join(configDir, "cloudprofile.yaml"), []byte(cloudProfileManifest), 0644)).To(Succeed())
+
+		projectManifest := `apiVersion: core.gardener.cloud/v1beta1
+kind: Project
+metadata:
+  name: test-project
+spec:
+  namespace: garden-test
+`
+		Expect(os.WriteFile(filepath.Join(configDir, "project.yaml"), []byte(projectManifest), 0644)).To(Succeed())
+
+		DeferCleanup(func() {
+			if configDir != "" {
+				Expect(os.RemoveAll(configDir)).To(Succeed())
+			}
+		})
+	})
+
+	createShootManifest := func(credentialsBindingName string, zones []string, isControlPlane bool, statusUID string) {
+		var shootManifest strings.Builder
+		shootManifest.WriteString(`apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+metadata:
+  name: test-shoot
+  namespace: garden-test
+spec:`)
+		if credentialsBindingName != "" {
+			shootManifest.WriteString(`
+  credentialsBindingName: ` + credentialsBindingName)
+		}
+		shootManifest.WriteString(`
+  provider:
+    type: local
+    workers:
+    - name: control-plane
+      minimum: 1
+      maximum: 1`)
+		if isControlPlane {
+			shootManifest.WriteString(`
+      controlPlane:
+        highAvailability: {}`)
+		}
+		if len(zones) > 0 {
+			shootManifest.WriteString(`
+      zones:`)
+			for _, zone := range zones {
+				shootManifest.WriteString(`
+      - ` + zone)
+			}
+		}
+		shootManifest.WriteString("\n")
+		if statusUID != "" {
+			shootManifest.WriteString(`status:
+  uid: ` + statusUID + `
+`)
+		}
+
+		Expect(os.WriteFile(filepath.Join(configDir, "shoot.yaml"), []byte(shootManifest.String()), 0644)).To(Succeed())
+	}
+
+	createShootStateManifest := func() {
+		shootStateManifest := `apiVersion: core.gardener.cloud/v1beta1
+kind: ShootState
+metadata:
+  name: test-shoot
+  namespace: garden-test
+spec:
+  gardener:
+  extensions:`
+		Expect(os.WriteFile(filepath.Join(configDir, "shootstate.yaml"), []byte(shootStateManifest), 0644)).To(Succeed())
+	}
+
+	createBackupBucketManifest := func(name string) {
+		manifest := `apiVersion: core.gardener.cloud/v1beta1
+kind: BackupBucket
+metadata:
+  name: ` + name + `
+spec:
+  provider:
+    type: local
+    region: local
+`
+		Expect(os.WriteFile(filepath.Join(configDir, "backupbucket.yaml"), []byte(manifest), 0644)).To(Succeed())
+	}
+
+	createBackupEntryManifest := func(name, bucketName string) {
+		manifest := `apiVersion: core.gardener.cloud/v1beta1
+kind: BackupEntry
+metadata:
+  name: ` + name + `
+  namespace: garden-test
+spec:
+  bucketName: ` + bucketName + `
+`
+		Expect(os.WriteFile(filepath.Join(configDir, "backupentry.yaml"), []byte(manifest), 0644)).To(Succeed())
+	}
+	Describe("#ParseArgs", func() {
+		It("should return nil", func() {
+			Expect(options.ParseArgs(nil)).To(Succeed())
+		})
+	})
+
+	Describe("#Validate", func() {
+		const (
+			statusUID        = "abcd-1234-uid"
+			backupBucketName = statusUID
+			backupEntryName  = "kube-system--" + statusUID
+		)
+
+		BeforeEach(func() {
+			createShootManifest("test-credentials", nil, true, statusUID)
+			createShootStateManifest()
+			createBackupBucketManifest(backupBucketName)
+			createBackupEntryManifest(backupEntryName, backupBucketName)
+
+			options.BackupDataPath = "/some/path/to/backup"
+			options.PriorNodeName = "node-01"
+		})
+
+		It("should pass for valid options", func() {
+			Expect(options.Validate()).To(Succeed())
+		})
+
+		It("should fail when --backup-data-path is not set", func() {
+			options.BackupDataPath = ""
+
+			Expect(options.Validate()).To(MatchError(ContainSubstring("must provide --backup-data-path")))
+		})
+
+		It("should fail when --prior-node-name is not set", func() {
+			options.PriorNodeName = ""
+
+			Expect(options.Validate()).To(MatchError(ContainSubstring("must provide --prior-node-name")))
+		})
+
+		It("should fail when config directory does not exist", func() {
+			options.ConfigDir = "non-existent-directory"
+
+			Expect(options.Validate()).To(MatchError(ContainSubstring("failed loading resources for gardenadm restore validation")))
+		})
+
+		It("should fail when ShootState manifest is missing", func() {
+			Expect(os.Remove(filepath.Join(configDir, "shootstate.yaml"))).To(Succeed())
+
+			Expect(options.Validate()).To(MatchError(ContainSubstring("gardenadm restore requires a ShootState resource in the config directory, but none was found")))
+		})
+
+		It("should fail when Shoot .status.uid is empty", func() {
+			createShootManifest("test-credentials", nil, true, "")
+
+			Expect(options.Validate()).To(MatchError(ContainSubstring("gardenadm restore requires the Shoot manifest in the config directory to have .status.uid set")))
+		})
+
+		It("should determine the zone against the control plane worker pool", func() {
+			createShootManifest("", []string{"zone-1"}, true, statusUID)
+
+			Expect(options.Validate()).To(Succeed())
+			Expect(options.Zone).To(Equal("zone-1"))
+		})
+
+		It("should surface zone validation errors from the shared helper", func() {
+			createShootManifest("test-credentials", nil, false, statusUID)
+
+			Expect(options.Validate()).To(MatchError(ContainSubstring("shoot doesn't have a control plane worker pool configured")))
+		})
+	})
+
+	Describe("#Complete", func() {
+		It("should return nil", func() {
+			Expect(options.Complete()).To(Succeed())
+		})
+	})
+})

--- a/pkg/gardenadm/cmd/restore/restore.go
+++ b/pkg/gardenadm/cmd/restore/restore.go
@@ -27,6 +27,8 @@ onto a new or existing node.`,
 		Example: `# Restore a control plane node from an etcd backup
 gardenadm restore --config-dir /path/to/manifests --backup-data-path /path/to/etcd-main/v2 --prior-node-name <name>`,
 
+		Args: cobra.NoArgs,
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.ParseArgs(args); err != nil {
 				return err

--- a/pkg/gardenadm/cmd/restore/restore.go
+++ b/pkg/gardenadm/cmd/restore/restore.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package restore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gardener/gardener/pkg/gardenadm/cmd"
+)
+
+// NewCommand creates a new cobra.Command.
+func NewCommand(globalOpts *cmd.Options) *cobra.Command {
+	opts := &Options{Options: globalOpts}
+
+	cmd := &cobra.Command{
+		Use:   "restore",
+		Short: "Restore a control plane node from an etcd backup and manifest files",
+		Long: `Restore a control plane node from an etcd backup and manifest files. Use this command to recover the
+self-hosted shoot cluster's control plane node after a disaster (e.g., the control plane node is lost)
+onto a new or existing node.`,
+
+		Example: `# Restore a control plane node from an etcd backup
+gardenadm restore --config-dir /path/to/manifests --backup-data-path /path/to/etcd-main/v2 --prior-node-name <name>`,
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.ParseArgs(args); err != nil {
+				return err
+			}
+
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			if err := opts.Complete(); err != nil {
+				return err
+			}
+
+			return run(cmd.Context(), opts)
+		},
+	}
+
+	opts.addFlags(cmd.Flags())
+
+	return cmd
+}
+
+func run(_ context.Context, _ *Options) error {
+	return fmt.Errorf("the gardenadm restore command is not implemented yet, see https://github.com/gardener/gardener/issues/15279 for more details")
+}

--- a/pkg/gardenadm/cmd/restore/restore_suite_test.go
+++ b/pkg/gardenadm/cmd/restore/restore_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package restore_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRestore(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardenadm Command Restore Suite")
+}

--- a/pkg/gardenadm/cmd/restore/restore_test.go
+++ b/pkg/gardenadm/cmd/restore/restore_test.go
@@ -2,43 +2,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package generate_test
+package restore_test
 
 import (
-	"strings"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
 
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
-	. "github.com/gardener/gardener/pkg/gardenadm/cmd/token/generate"
-	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
+	. "github.com/gardener/gardener/pkg/gardenadm/cmd/restore"
 	clitest "github.com/gardener/gardener/pkg/utils/test/cli"
 )
 
-var _ = Describe("Generate", func() {
+var _ = Describe("Restore", func() {
 	var (
 		globalOpts *cmd.Options
-		stdOut     *Buffer
 		command    *cobra.Command
 	)
 
 	BeforeEach(func() {
 		globalOpts = &cmd.Options{}
-		globalOpts.IOStreams, _, stdOut, _ = clitest.NewTestIOStreams()
+		globalOpts.IOStreams, _, _, _ = clitest.NewTestIOStreams()
 		command = NewCommand(globalOpts)
-	})
-
-	Describe("#RunE", func() {
-		It("should compute a random bootstrap token and print it", func() {
-			Expect(command.RunE(command, nil)).To(Succeed())
-
-			Eventually(func() string {
-				return strings.TrimSpace(string(stdOut.Contents()))
-			}).Should(MatchRegexp(bootstraptoken.ValidBootstrapTokenRegex.String()))
-		})
 	})
 
 	Describe("#Args", func() {

--- a/pkg/gardenadm/cmd/token/generate/generate.go
+++ b/pkg/gardenadm/cmd/token/generate/generate.go
@@ -31,7 +31,7 @@ Read more about it here: https://kubernetes.io/docs/reference/access-authn-authz
 		Example: `# Generate a random bootstrap token for joining a node
 gardenadm token generate`,
 
-		Args: cobra.ExactArgs(0),
+		Args: cobra.NoArgs,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.ParseArgs(args); err != nil {

--- a/pkg/gardenadm/cmd/token/list/list.go
+++ b/pkg/gardenadm/cmd/token/list/list.go
@@ -39,7 +39,7 @@ gardenadm token list
 # To include additional sensitive details such as token secrets:
 gardenadm token list --with-token-secret`,
 
-		Args: cobra.ExactArgs(0),
+		Args: cobra.NoArgs,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.ParseArgs(args); err != nil {

--- a/pkg/gardenadm/cmd/token/list/list_test.go
+++ b/pkg/gardenadm/cmd/token/list/list_test.go
@@ -101,4 +101,14 @@ bootstrap-token-token2\s+token2\s+token2secret5678\s+token2.token2secret5678\s+1
 			})
 		})
 	})
+
+	Describe("#Args", func() {
+		It("should accept no arguments", func() {
+			Expect(command.Args(command, nil)).To(Succeed())
+		})
+
+		It("should reject any positional arguments", func() {
+			Expect(command.Args(command, []string{"foo"})).To(HaveOccurred())
+		})
+	})
 })

--- a/pkg/gardenadm/cmd/token/token.go
+++ b/pkg/gardenadm/cmd/token/token.go
@@ -22,6 +22,7 @@ func NewCommand(globalOpts *cmd.Options) *cobra.Command {
 		Use:   "token",
 		Short: "Manage bootstrap and discovery tokens for gardenadm join",
 		Long:  "Manage bootstrap and discovery tokens for gardenadm join",
+		Args:  cobra.NoArgs,
 	}
 
 	opts.addFlags(cmd.Flags())

--- a/pkg/gardenadm/cmd/version/version.go
+++ b/pkg/gardenadm/cmd/version/version.go
@@ -20,6 +20,8 @@ func NewCommand(opts *cmd.Options) *cobra.Command {
 		Short: "Print the client version information",
 		Long:  "Print the client version information",
 
+		Args: cobra.NoArgs,
+
 		Run: func(_ *cobra.Command, _ []string) {
 			fmt.Fprintf(opts.Out, "gardenadm version %s\n", version.Get())
 		},

--- a/pkg/gardenadm/cmd/version/version_test.go
+++ b/pkg/gardenadm/cmd/version/version_test.go
@@ -37,4 +37,14 @@ var _ = Describe("Version", func() {
 			Eventually(stdOut).Should(Say(regexp.QuoteMeta("gardenadm version v0.0.0-master+$Format:%H$")))
 		})
 	})
+
+	Describe("#Args", func() {
+		It("should accept no arguments", func() {
+			Expect(command.Args(command, nil)).To(Succeed())
+		})
+
+		It("should reject any positional arguments", func() {
+			Expect(command.Args(command, []string{"foo"})).To(HaveOccurred())
+		})
+	})
 })

--- a/pkg/gardenadm/cmd/zone.go
+++ b/pkg/gardenadm/cmd/zone.go
@@ -8,8 +8,30 @@ import (
 	"fmt"
 	"slices"
 
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
+
+// ValidateAndDetermineControlPlaneZone validates the provided zone against the Shoot's control plane worker pool and returns the
+// effective zone. The zone is validated and auto-applied via DetermineZone.
+func ValidateAndDetermineControlPlaneZone(shoot *gardencorev1beta1.Shoot, providedZone string) (string, error) {
+	if shoot == nil {
+		return "", fmt.Errorf("zone validation failed, shoot resource is missing in the manifests")
+	}
+
+	// This command is only for control plane nodes, therefore we look for the control plane pool.
+	controlPlanePool := v1beta1helper.ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers)
+	if controlPlanePool == nil {
+		return "", fmt.Errorf("zone validation failed, shoot doesn't have a control plane worker pool configured")
+	}
+
+	effectiveZone, err := DetermineZone(*controlPlanePool, providedZone)
+	if err != nil {
+		return "", fmt.Errorf("failed determining zone for control plane worker pool %q: %w", controlPlanePool.Name, err)
+	}
+
+	return effectiveZone, nil
+}
 
 // DetermineZone determines the effective zone for the node based on the shoot specification.
 func DetermineZone(worker gardencorev1beta1.Worker, providedZone string) (string, error) {

--- a/pkg/gardenadm/cmd/zone_test.go
+++ b/pkg/gardenadm/cmd/zone_test.go
@@ -12,81 +12,153 @@ import (
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 )
 
-var _ = Describe("DetermineZone", func() {
-	var worker gardencorev1beta1.Worker
-
-	When("worker has no zones configured", func() {
-		BeforeEach(func() {
-			worker = gardencorev1beta1.Worker{
-				Name:  "test-worker",
-				Zones: []string{},
+var _ = Describe("Zone", func() {
+	Describe("#ValidateAndDetermineControlPlaneZone", func() {
+		unmanagedShoot := func(zones []string) *gardencorev1beta1.Shoot {
+			return &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Provider: gardencorev1beta1.Provider{
+						Workers: []gardencorev1beta1.Worker{{
+							Name:         "control-plane",
+							Zones:        zones,
+							ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+						}},
+					},
+				},
 			}
+		}
+
+		When("the shoot has managed infrastructure", func() {
+			managedShoot := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Provider: gardencorev1beta1.Provider{
+						Workers: []gardencorev1beta1.Worker{
+							{
+								Name:         "control-plane",
+								Zones:        []string{"us-east-1a"},
+								ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+							},
+						},
+					},
+					CredentialsBindingName: new("test-credentials"),
+				},
+			}
+
+			It("should allow a provided zone", func() {
+				zone, err := cmd.ValidateAndDetermineControlPlaneZone(managedShoot, "us-east-1a")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(zone).To(Equal("us-east-1a"))
+			})
 		})
 
-		It("should return error when zone is provided", func() {
-			zone, err := cmd.DetermineZone(worker, "custom-zone")
-			Expect(err).To(MatchError(ContainSubstring(`worker "test-worker" has no zones configured, but zone "custom-zone" was provided`)))
+		It("should fail when the shoot is nil", func() {
+			zone, err := cmd.ValidateAndDetermineControlPlaneZone(nil, "")
+			Expect(err).To(MatchError(ContainSubstring("shoot resource is missing in the manifests")))
 			Expect(zone).To(BeEmpty())
 		})
 
-		It("should return empty zone when no zone is provided", func() {
-			zone, err := cmd.DetermineZone(worker, "")
-			Expect(err).ToNot(HaveOccurred())
+		It("should fail when the shoot has no control plane worker pool", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Provider: gardencorev1beta1.Provider{
+						Workers: []gardencorev1beta1.Worker{{Name: "worker"}},
+					},
+				},
+			}
+			zone, err := cmd.ValidateAndDetermineControlPlaneZone(shoot, "")
+			Expect(err).To(MatchError(ContainSubstring("shoot doesn't have a control plane worker pool configured")))
 			Expect(zone).To(BeEmpty())
 		})
-	})
 
-	When("worker has a single zone configured", func() {
-		BeforeEach(func() {
-			worker = gardencorev1beta1.Worker{
-				Name:  "test-worker",
-				Zones: []string{"zone-1"},
-			}
-		})
-
-		It("should auto-apply the configured zone when no zone provided", func() {
-			zone, err := cmd.DetermineZone(worker, "")
+		It("should determine the zone against the control plane worker pool", func() {
+			zone, err := cmd.ValidateAndDetermineControlPlaneZone(unmanagedShoot([]string{"zone-1"}), "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(zone).To(Equal("zone-1"))
 		})
 
-		It("should accept the correct zone when provided", func() {
-			zone, err := cmd.DetermineZone(worker, "zone-1")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(zone).To(Equal("zone-1"))
-		})
-
-		It("should reject an incorrect zone when provided", func() {
-			zone, err := cmd.DetermineZone(worker, "zone-2")
-			Expect(err).To(MatchError(ContainSubstring(`provided zone "zone-2" does not match the configured zones [zone-1] for worker "test-worker"`)))
+		It("should surface DetermineZone errors for the control plane worker pool", func() {
+			zone, err := cmd.ValidateAndDetermineControlPlaneZone(unmanagedShoot([]string{"zone-1", "zone-2"}), "")
+			Expect(err).To(MatchError(ContainSubstring(`worker "control-plane" has multiple zones configured [zone-1 zone-2], --zone flag is required`)))
 			Expect(zone).To(BeEmpty())
 		})
 	})
 
-	When("worker has multiple zones configured", func() {
-		BeforeEach(func() {
-			worker = gardencorev1beta1.Worker{
-				Name:  "test-worker",
-				Zones: []string{"zone-1", "zone-2", "zone-3"},
-			}
+	Describe("#DetermineZone", func() {
+		var worker gardencorev1beta1.Worker
+
+		When("worker has no zones configured", func() {
+			BeforeEach(func() {
+				worker = gardencorev1beta1.Worker{
+					Name:  "test-worker",
+					Zones: []string{},
+				}
+			})
+
+			It("should return error when zone is provided", func() {
+				zone, err := cmd.DetermineZone(worker, "custom-zone")
+				Expect(err).To(MatchError(ContainSubstring(`worker "test-worker" has no zones configured, but zone "custom-zone" was provided`)))
+				Expect(zone).To(BeEmpty())
+			})
+
+			It("should return empty zone when no zone is provided", func() {
+				zone, err := cmd.DetermineZone(worker, "")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(zone).To(BeEmpty())
+			})
 		})
 
-		It("should require zone flag when no zone provided", func() {
-			zone, err := cmd.DetermineZone(worker, "")
-			Expect(err).To(MatchError(ContainSubstring(`worker "test-worker" has multiple zones configured [zone-1 zone-2 zone-3], --zone flag is required`)))
-			Expect(zone).To(BeEmpty())
+		When("worker has a single zone configured", func() {
+			BeforeEach(func() {
+				worker = gardencorev1beta1.Worker{
+					Name:  "test-worker",
+					Zones: []string{"zone-1"},
+				}
+			})
+
+			It("should auto-apply the configured zone when no zone provided", func() {
+				zone, err := cmd.DetermineZone(worker, "")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(zone).To(Equal("zone-1"))
+			})
+
+			It("should accept the correct zone when provided", func() {
+				zone, err := cmd.DetermineZone(worker, "zone-1")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(zone).To(Equal("zone-1"))
+			})
+
+			It("should reject an incorrect zone when provided", func() {
+				zone, err := cmd.DetermineZone(worker, "zone-2")
+				Expect(err).To(MatchError(ContainSubstring(`provided zone "zone-2" does not match the configured zones [zone-1] for worker "test-worker"`)))
+				Expect(zone).To(BeEmpty())
+			})
 		})
 
-		It("should accept a valid zone when provided", func() {
-			zone, err := cmd.DetermineZone(worker, "zone-2")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(zone).To(Equal("zone-2"))
-		})
+		When("worker has multiple zones configured", func() {
+			BeforeEach(func() {
+				worker = gardencorev1beta1.Worker{
+					Name:  "test-worker",
+					Zones: []string{"zone-1", "zone-2", "zone-3"},
+				}
+			})
 
-		It("should reject an invalid zone when provided", func() {
-			zone, err := cmd.DetermineZone(worker, "zone-4")
-			Expect(err).To(MatchError(ContainSubstring(`provided zone "zone-4" does not match the configured zones [zone-1 zone-2 zone-3] for worker "test-worker"`)))
-			Expect(zone).To(BeEmpty())
+			It("should require zone flag when no zone provided", func() {
+				zone, err := cmd.DetermineZone(worker, "")
+				Expect(err).To(MatchError(ContainSubstring(`worker "test-worker" has multiple zones configured [zone-1 zone-2 zone-3], --zone flag is required`)))
+				Expect(zone).To(BeEmpty())
+			})
+
+			It("should accept a valid zone when provided", func() {
+				zone, err := cmd.DetermineZone(worker, "zone-2")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(zone).To(Equal("zone-2"))
+			})
+
+			It("should reject an invalid zone when provided", func() {
+				zone, err := cmd.DetermineZone(worker, "zone-4")
+				Expect(err).To(MatchError(ContainSubstring(`provided zone "zone-4" does not match the configured zones [zone-1 zone-2 zone-3] for worker "test-worker"`)))
+				Expect(zone).To(BeEmpty())
+			})
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area disaster-recovery control-plane ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR introduces the scaffolding for a new `gardenadm restore` command.
The command is intended to recover a self-hosted shoot cluster's control plane node from an etcd backup and manifest files after a disaster (e.g., the control plane node is lost), onto a new or existing node.

The command adds the following flags:
- `--backup-data-path`: local path on the node where the etcd backup data is stored.
- `--prior-node-name`: name of the prior control plane node, used to clean up stale resources.
- `--zone`: availability zone of the new machine the prior node is being restored to.

Option validation is included:
- Requires a ShootState resource in the config directory. The ShootState is used to restore the Secrets from.
- Requires the Shoot manifest to have `.status.uid` set (it determines the BackupBucket/BackupEntry names and identifies the cluster in the cluster-identity `ConfigMap`; a fresh UID would lead to undesired behaviour and inconsistency in the system).
- Reuses the control plane zone validation.

To avoid duplicating logic between `gardenadm init` and `gardenadm restore`, the zone validation was extracted into a reusable `ValidateAndDetermineControlPlaneZone` helper in `pkg/gardenadm/cmd`, and `gardenadm init` was refactored to use it.

The actual restore logic is not implemented yet — `run` currently returns a "not implemented" error.
It will be implemented as part of https://github.com/gardener/gardener/issues/15279.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/15279

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A new `gardenadm restore` command has been introduced to recover a self-hosted shoot cluster's control plane Node from an etcd backup and manifest files. The restore logic itself is not yet implemented and will be contributed step by step in the future releases.
```
