### PR TITLE
test(gardenlet): add unit tests for kubeapiserverexposure

### DIFF
--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
@@ -21,8 +22,10 @@ import (
 	"github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	gardenpkg "github.com/gardener/gardener/pkg/gardenlet/operation/garden"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 )
 
@@ -127,5 +130,79 @@ var _ = Describe("KubeAPIServerExposure", func() {
 			// We call Deploy to trigger the valuesFunc and ensure it doesn't panic.
 			Expect(botanist.Shoot.Components.ControlPlane.KubeAPIServerSNI.Deploy(context.TODO())).To(Succeed())
 		})
+
+		DescribeTable("should map the cluster IP of the kube-apiserver service",
+			func(ipFamilies []gardencorev1beta1.IPFamily, clusterIPs []string, expectedClusterIP string) {
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Networking: &gardencorev1beta1.Networking{
+							IPFamilies: ipFamilies,
+						},
+					},
+				})
+
+				service := &corev1.Service{}
+				Expect(botanist.SeedClientSet.Client().Get(context.TODO(), client.ObjectKey{
+					Name:      v1beta1constants.DeploymentNameKubeAPIServer,
+					Namespace: botanist.Shoot.ControlPlaneNamespace,
+				}, service)).To(Succeed())
+				service.Spec.ClusterIPs = clusterIPs
+				Expect(botanist.SeedClientSet.Client().Update(context.TODO(), service)).To(Succeed())
+
+				Expect(botanist.DefaultKubeAPIServerService().Deploy(context.TODO())).To(Succeed())
+
+				Expect(botanist.APIServerClusterIP).To(Equal(expectedClusterIP))
+			},
+
+			// The real cluster IP must not leak into the shoot, so IPv4 addresses are mapped into
+			// the reserved 240.0.0.0/8 range with the last three octets preserved.
+			Entry("IPv4 single-stack", []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+				[]string{"10.0.0.1"}, "240.0.0.1"),
+			Entry("IPv4 single-stack, all octets preserved", []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+				[]string{"192.168.102.23"}, "240.168.102.23"),
+			Entry("IPv6-first shoot with IPv4 cluster IP is prefixed for address translation",
+				[]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6, gardencorev1beta1.IPFamilyIPv4},
+				[]string{"10.0.0.1"}, "64:ff9b:1::10.0.0.1"),
+			Entry("IPv4 single-stack falls back to the second cluster IP if the first one is not IPv4",
+				[]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+				[]string{"fd00::1", "10.0.0.1"}, "240.0.0.1"),
+			Entry("IPv6 shoot with IPv6 cluster IP is used as is",
+				[]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6},
+				[]string{"fd00::1"}, "fd00::1"),
+		)
+	})
+
+	Describe("#ShootUsesDNS", func() {
+		DescribeTable("should return whether the shoot uses both internal and external DNS",
+			func(needsInternalDNS, needsExternalDNS, expected bool) {
+				botanist.Garden = nil
+				botanist.Shoot.ExternalClusterDomain = nil
+				botanist.Shoot.ExternalDomain = nil
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
+
+				if needsInternalDNS {
+					botanist.Garden = &gardenpkg.Garden{
+						InternalDomain: &gardenerutils.Domain{Provider: "some-provider"},
+					}
+				}
+
+				if needsExternalDNS {
+					botanist.Shoot.ExternalClusterDomain = new("external.foo.bar")
+					botanist.Shoot.ExternalDomain = &gardenerutils.Domain{Provider: "some-provider"}
+					botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+						Spec: gardencorev1beta1.ShootSpec{
+							DNS: &gardencorev1beta1.DNS{Domain: new("external.foo.bar")},
+						},
+					})
+				}
+
+				Expect(botanist.ShootUsesDNS()).To(Equal(expected))
+			},
+
+			Entry("internal and external DNS are needed", true, true, true),
+			Entry("only internal DNS is needed", true, false, false),
+			Entry("only external DNS is needed", false, true, false),
+			Entry("neither internal nor external DNS is needed", false, false, false),
+		)
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #13161, which asks for unit tests covering the non-trivial logic in `pkg/gardenlet/operation/botanist/kubeapiserverexposure.go`, motivated by #13158 ("We had issues in the past that could have been avoided with unit tests").

This adds coverage for the two pieces of that file that had none:

**`setAPIServerServiceClusterIPs`** — the cluster-IP mapping, which is the part that actually carries risk, since a mistake here leaks a real seed cluster IP into the shoot. It is unexported, so the test drives it through the exported path the existing tests already use (`DefaultKubeAPIServerService().Deploy(ctx)` invokes `clusterIPsFunc`) and then asserts on `b.APIServerClusterIP`. Cases:

| shoot IP families | service cluster IPs | expected |
| --- | --- | --- |
| IPv4 | `10.0.0.1` | `240.0.0.1` |
| IPv4 | `192.168.102.23` | `240.168.102.23` |
| IPv6, IPv4 | `10.0.0.1` | `64:ff9b:1::10.0.0.1` |
| IPv4 | `fd00::1`, `10.0.0.1` | `240.0.0.1` |
| IPv6 | `fd00::1` | `fd00::1` |

The third and fourth rows are the ones I'd expect to regress silently: the IPv6-first prefix branch, and the fallback that picks the *second* cluster IP when the first one isn't IPv4.

**`ShootUsesDNS`** — the full 2×2 truth table over `NeedsInternalDNS`/`NeedsExternalDNS`.

I did not add coverage for `ShootUsesIstioTLSTermination`; it needs the `IstioTLSTermination` feature gate toggled, and I didn't want to guess at the repo's preferred helper for that in a first contribution. Happy to add it in a follow-up if you point me at the pattern you'd like used.

**Which issue(s) this PR fixes**:
Part of #13161

**Special notes for your reviewer**:

- Test-only; no production code is touched.
- 9 new specs, all passing (`go test ./pkg/gardenlet/operation/botanist/`). `gofmt` and `go vet` clean.
- Per the testing guide's "make sure that your test is actually asserting the right thing and it doesn't pass if the exact bug is introduced that you want to prevent", I mutation-checked both blocks against the current source:
  - changing `mapToReservedKubeApiServerRange` to emit the wrong octet (`net.IPv4(prefix[0], ip[0], ip[2], ip[3])`) fails the cluster-IP entries;
  - changing `ShootUsesDNS` from `&&` to `||` fails two of the four truth-table entries.
  Both were reverted; the diff contains only the test file.
- Expected values were each derived from `ReservedKubeApiServerMappingRange` (`240.0.0.0/8`) rather than copied from current behaviour.

**Release note**:
```other
NONE
```
