### PR TITLE
Fix `make seed-dev` command

### DIFF
--- a/dev-setup/seed.sh
+++ b/dev-setup/seed.sh
@@ -14,7 +14,7 @@ detect_scenario
 skaffold_profile "$SCENARIO"
 
 COMMAND="${1:-up}"
-VALID_COMMANDS=("up dev debug down")
+VALID_COMMANDS=("up" "dev" "debug" "down")
 
 skaffold_command="run"
 if [[ "$COMMAND" == "dev" ]]; then
@@ -39,7 +39,7 @@ fi
 SYSTEM_ARCH=$(kubectl get nodes -o yaml | yq '.items[0].status.nodeInfo.architecture')
 
 case "$COMMAND" in
-  up)
+  up | dev | debug)
     skaffold run \
       -m garden-config \
       ${BUILD_CONCURRENCY:+--build-concurrency "$BUILD_CONCURRENCY"} \


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Currently running `make seed-dev` returns:
```
❯ make seed-dev
./dev-setup/seed.sh dev
Detected scenario: single-node
Using skaffold profile: single-node
Error: Invalid command 'dev'. Valid options are: up dev debug down.
make: *** [seed-dev] Error 1
```

This PR fixes this issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
