### PR TITLE
Fix `UpdateInfo`/`UpdateInfoStatus` to preserve `b.Shoot.GetInfo()` across reconciliation flow

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -202,7 +202,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	if _, ok := b.Shoot.GetInfo().Annotations[v1beta1constants.AnnotationShootSkipReadiness]; ok {
 		b.Logger.Info("Removing skip-readiness annotation")
 
-		if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
+		if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
 			delete(shoot.Annotations, v1beta1constants.AnnotationShootSkipReadiness)
 			return nil
 		}); err != nil {
@@ -934,7 +934,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 				// If there are no pending workers rollouts for in-place updates, we can remove the force in-place update annotation.
 				if (b.Shoot.GetInfo().Status.InPlaceUpdates == nil || b.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates == nil) &&
 					kubernetesutils.HasMetaDataAnnotation(b.Shoot.GetInfo(), v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationForceInPlaceUpdate) {
-					return b.Shoot.UpdateInfo(ctx, b.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
+					return b.Shoot.UpdateInfo(ctx, b.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
 						delete(shoot.Annotations, v1beta1constants.GardenerOperation)
 						return nil
 					})
@@ -1172,7 +1172,7 @@ func removeTaskAnnotation(ctx context.Context, b *botanistpkg.Botanist, tasksToR
 		return nil
 	}
 
-	return b.Shoot.UpdateInfo(ctx, b.GardenClient, false, false, func(shoot *gardencorev1beta1.Shoot) error {
+	return b.Shoot.UpdateInfo(ctx, b.GardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
 		controllerutils.RemoveTasks(shoot.Annotations, tasksToRemove...)
 		return nil
 	})

--- a/pkg/gardenlet/operation/botanist/botanist_test.go
+++ b/pkg/gardenlet/operation/botanist/botanist_test.go
@@ -252,7 +252,7 @@ var _ = Describe("Botanist", func() {
 			Expect(botanist.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).To(Equal([]string{"pool-1", "pool-3", "pool-4"}))
 			Expect(botanist.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).To(Equal([]string{"pool-2", "pool-5", "pool-6"}))
 
-			Expect(botanist.Shoot.UpdateInfo(ctx, gardenClient, false, true, func(shoot *gardencorev1beta1.Shoot) error {
+			Expect(botanist.Shoot.UpdateInfo(ctx, gardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
 				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
 					{
 						Name:           "pool-1",
@@ -288,7 +288,7 @@ var _ = Describe("Botanist", func() {
 			Expect(botanist.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).To(Equal([]string{"pool-1", "pool-3", "pool-4"}))
 			Expect(botanist.Shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).To(Equal([]string{"pool-2", "pool-5", "pool-6"}))
 
-			Expect(botanist.Shoot.UpdateInfo(ctx, gardenClient, false, true, func(shoot *gardencorev1beta1.Shoot) error {
+			Expect(botanist.Shoot.UpdateInfo(ctx, gardenClient, false, func(shoot *gardencorev1beta1.Shoot) error {
 				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
 					{
 						Name:           "pool-1",

--- a/pkg/gardenlet/operation/botanist/infrastructure.go
+++ b/pkg/gardenlet/operation/botanist/infrastructure.go
@@ -70,7 +70,7 @@ func (b *Botanist) WaitForInfrastructure(ctx context.Context) error {
 	if nodesCIDRs := b.Shoot.Components.Extensions.Infrastructure.NodesCIDRs(); len(nodesCIDRs) > 0 {
 		// Only update node CIDR if it's not already set.
 		if b.Shoot.GetInfo().Spec.Networking.Nodes == nil {
-			if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
+			if err := b.Shoot.UpdateInfo(ctx, b.GardenClient, true, func(shoot *gardencorev1beta1.Shoot) error {
 				shoot.Spec.Networking.Nodes = &nodesCIDRs[0]
 				return nil
 			}); err != nil {

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -415,10 +415,13 @@ func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMer
 	if err := f(shoot); err != nil {
 		return err
 	}
+	shootWithMutations := shoot.DeepCopy()
 	if err := c.Patch(ctx, shoot, patch); err != nil {
 		return err
 	}
-	s.info.Store(shoot)
+	// Carry the server-assigned ResourceVersion back so subsequent optimistic-lock patches don't conflict.
+	shootWithMutations.ResourceVersion = shoot.ResourceVersion
+	s.info.Store(shootWithMutations)
 	return nil
 }
 
@@ -448,10 +451,13 @@ func (s *Shoot) UpdateInfoStatus(ctx context.Context, c client.Client, useStrate
 	if err := f(shoot); err != nil {
 		return err
 	}
+	shootWithMutations := shoot.DeepCopy()
 	if err := c.Status().Patch(ctx, shoot, patch); err != nil {
 		return err
 	}
-	s.info.Store(shoot)
+	// Carry the server-assigned ResourceVersion back so subsequent optimistic-lock patches don't conflict.
+	shootWithMutations.ResourceVersion = shoot.ResourceVersion
+	s.info.Store(shootWithMutations)
 	return nil
 }
 

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -395,7 +395,10 @@ func (s *Shoot) SetShootState(shootState *gardencorev1beta1.ShootState) {
 // using either client.MergeFrom or client.StrategicMergeFrom depending on useStrategicMerge.
 // This method is protected by a mutex, so only a single UpdateInfo or UpdateInfoStatus operation can be
 // executed at any point in time.
-func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMerge, mergeWithOptimisticLock bool, f func(*gardencorev1beta1.Shoot) error) error {
+// The stored object preserves .metadata and .spec as mutated by f, but adopts .status and .metadata.resourceVersion
+// from the server response. This keeps the in-memory generation stable across reconciliation while letting
+// subsequent status patches compute correct diffs against the current server state.
+func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMerge bool, f func(*gardencorev1beta1.Shoot) error) error {
 	s.infoMutex.Lock()
 	defer s.infoMutex.Unlock()
 
@@ -403,14 +406,8 @@ func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMer
 	var patch client.Patch
 	if useStrategicMerge {
 		patch = client.StrategicMergeFrom(shoot.DeepCopy())
-		if mergeWithOptimisticLock {
-			patch = client.StrategicMergeFrom(shoot.DeepCopy(), client.MergeFromWithOptimisticLock{})
-		}
 	} else {
 		patch = client.MergeFrom(shoot.DeepCopy())
-		if mergeWithOptimisticLock {
-			patch = client.MergeFromWithOptions(shoot.DeepCopy(), client.MergeFromWithOptimisticLock{})
-		}
 	}
 	if err := f(shoot); err != nil {
 		return err
@@ -419,8 +416,12 @@ func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMer
 	if err := c.Patch(ctx, shoot, patch); err != nil {
 		return err
 	}
-	// Carry the server-assigned ResourceVersion back so subsequent optimistic-lock patches don't conflict.
+	// Carry .resourceVersion and .status from the server response: .resourceVersion keeps subsequent patches
+	// conflict-free; .status reflects any concurrent status writes so that the next UpdateInfoStatus call
+	// computes a correct diff. .metadata (except .resourceVersion) and .spec are kept from shootWithMutations
+	// so that a concurrent generation bump by another actor does not bleed into our in-memory view.
 	shootWithMutations.ResourceVersion = shoot.ResourceVersion
+	shootWithMutations.Status = shoot.Status
 	s.info.Store(shootWithMutations)
 	return nil
 }
@@ -431,6 +432,8 @@ func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMer
 // using either client.MergeFrom or client.StrategicMergeFrom depending on useStrategicMerge.
 // This method is protected by a mutex, so only a single UpdateInfo or UpdateInfoStatus operation can be
 // executed at any point in time.
+// The stored object preserves .metadata and .spec from the pre-patch state, but adopts .status and .metadata.resourceVersion
+// from the server response. This ensures subsequent status patches compute correct diffs against the current server state.
 func (s *Shoot) UpdateInfoStatus(ctx context.Context, c client.Client, useStrategicMerge, mergeWithOptimisticLock bool, f func(*gardencorev1beta1.Shoot) error) error {
 	s.infoMutex.Lock()
 	defer s.infoMutex.Unlock()
@@ -455,8 +458,12 @@ func (s *Shoot) UpdateInfoStatus(ctx context.Context, c client.Client, useStrate
 	if err := c.Status().Patch(ctx, shoot, patch); err != nil {
 		return err
 	}
-	// Carry the server-assigned ResourceVersion back so subsequent optimistic-lock patches don't conflict.
+	// Carry .resourceVersion and .status from the server response: .resourceVersion keeps subsequent patches
+	// conflict-free; .status reflects the full server state so the next UpdateInfoStatus call computes a
+	// correct diff even if a concurrent status writer (e.g. the status reconciler) wrote in between.
+	// .metadata (except .resourceVersion) and .spec are kept from shootWithMutations.
 	shootWithMutations.ResourceVersion = shoot.ResourceVersion
+	shootWithMutations.Status = shoot.Status
 	s.info.Store(shootWithMutations)
 	return nil
 }

--- a/pkg/gardenlet/operation/shoot/shoot_test.go
+++ b/pkg/gardenlet/operation/shoot/shoot_test.go
@@ -454,7 +454,7 @@ var _ = Describe("shoot", func() {
 		})
 
 		Describe("#UpdateInfo", func() {
-			It("should apply the mutation and carry the server ResourceVersion, but not other server-side fields", func() {
+			It("should apply the mutation, carry .resourceVersion and .status from server, but not other server-side fields", func() {
 				shootObj := &gardencorev1beta1.Shoot{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "foo",
@@ -466,7 +466,8 @@ var _ = Describe("shoot", func() {
 				s := &Shoot{}
 				s.SetInfo(shootObj)
 
-				// Simulate a server that bumps ResourceVersion (normal) and Generation (concurrent spec change we didn't make).
+				// Simulate a server that bumps ResourceVersion (normal), Generation (concurrent spec change we didn't
+				// make), and writes a .status field concurrently.
 				c := fake.NewClientBuilder().
 					WithScheme(kubernetes.GardenScheme).
 					WithObjects(shootObj).
@@ -477,27 +478,30 @@ var _ = Describe("shoot", func() {
 							}
 							obj.(*gardencorev1beta1.Shoot).ResourceVersion = "2"
 							obj.(*gardencorev1beta1.Shoot).Generation = 2
+							obj.(*gardencorev1beta1.Shoot).Status.ObservedGeneration = 42
 							return nil
 						},
 					}).
 					Build()
 
-				Expect(s.UpdateInfo(context.Background(), c, false, false, func(shoot *gardencorev1beta1.Shoot) error {
+				Expect(s.UpdateInfo(context.Background(), c, false, func(shoot *gardencorev1beta1.Shoot) error {
 					shoot.Labels = map[string]string{"foo": "bar"}
 					return nil
 				})).To(Succeed())
 
 				info := s.GetInfo()
 				Expect(info.Labels).To(Equal(map[string]string{"foo": "bar"}))
-				// ResourceVersion must be carried back so the next optimistic-lock patch doesn't conflict.
+				// .resourceVersion must be carried back so the next patch doesn't conflict.
 				Expect(info.ResourceVersion).To(Equal("2"))
 				// Generation bump from a concurrent spec change must not bleed into our in-memory view.
 				Expect(info.Generation).To(Equal(int64(1)))
+				// .status must be synced from the server so that subsequent UpdateInfoStatus calls compute correct diffs.
+				Expect(info.Status.ObservedGeneration).To(Equal(int64(42)))
 			})
 		})
 
 		Describe("#UpdateInfoStatus", func() {
-			It("should apply the mutation and carry the server ResourceVersion, but not other server-side fields", func() {
+			It("should apply the mutation, carry .resourceVersion and full .status from server", func() {
 				shootObj := &gardencorev1beta1.Shoot{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "foo",
@@ -509,7 +513,8 @@ var _ = Describe("shoot", func() {
 				s := &Shoot{}
 				s.SetInfo(shootObj)
 
-				// Simulate a server that bumps ResourceVersion on status patch (as a real API server would).
+				// Simulate a server that bumps ResourceVersion and writes an additional .status field
+				// (e.g. a concurrent status reconciler), beyond what f sets.
 				c := fake.NewClientBuilder().
 					WithScheme(kubernetes.GardenScheme).
 					WithObjects(shootObj).
@@ -520,6 +525,7 @@ var _ = Describe("shoot", func() {
 								return err
 							}
 							obj.(*gardencorev1beta1.Shoot).ResourceVersion = "2"
+							obj.(*gardencorev1beta1.Shoot).Status.TechnicalID = "concurrent-write"
 							return nil
 						},
 					}).
@@ -532,8 +538,10 @@ var _ = Describe("shoot", func() {
 
 				info := s.GetInfo()
 				Expect(info.Status.ObservedGeneration).To(Equal(int64(1)))
-				// ResourceVersion must be carried back so the next optimistic-lock patch doesn't conflict.
+				// .resourceVersion must be carried back so the next patch doesn't conflict.
 				Expect(info.ResourceVersion).To(Equal("2"))
+				// .status from a concurrent server write must be reflected so subsequent diffs are correct.
+				Expect(info.Status.TechnicalID).To(Equal("concurrent-write"))
 			})
 		})
 	})

--- a/pkg/gardenlet/operation/shoot/shoot_test.go
+++ b/pkg/gardenlet/operation/shoot/shoot_test.go
@@ -15,9 +15,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/gardener"
@@ -448,6 +450,90 @@ var _ = Describe("shoot", func() {
 				Expect(shoot.GetInfo().Spec.DNS).To(Equal(&gardencorev1beta1.DNS{
 					Domain: new("shoot.example.com"),
 				}))
+			})
+		})
+
+		Describe("#UpdateInfo", func() {
+			It("should apply the mutation and carry the server ResourceVersion, but not other server-side fields", func() {
+				shootObj := &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "foo",
+						Namespace:       "garden-bar",
+						Generation:      1,
+						ResourceVersion: "1",
+					},
+				}
+				s := &Shoot{}
+				s.SetInfo(shootObj)
+
+				// Simulate a server that bumps ResourceVersion (normal) and Generation (concurrent spec change we didn't make).
+				c := fake.NewClientBuilder().
+					WithScheme(kubernetes.GardenScheme).
+					WithObjects(shootObj).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+							if err := c.Patch(ctx, obj, patch, opts...); err != nil {
+								return err
+							}
+							obj.(*gardencorev1beta1.Shoot).ResourceVersion = "2"
+							obj.(*gardencorev1beta1.Shoot).Generation = 2
+							return nil
+						},
+					}).
+					Build()
+
+				Expect(s.UpdateInfo(context.Background(), c, false, false, func(shoot *gardencorev1beta1.Shoot) error {
+					shoot.Labels = map[string]string{"foo": "bar"}
+					return nil
+				})).To(Succeed())
+
+				info := s.GetInfo()
+				Expect(info.Labels).To(Equal(map[string]string{"foo": "bar"}))
+				// ResourceVersion must be carried back so the next optimistic-lock patch doesn't conflict.
+				Expect(info.ResourceVersion).To(Equal("2"))
+				// Generation bump from a concurrent spec change must not bleed into our in-memory view.
+				Expect(info.Generation).To(Equal(int64(1)))
+			})
+		})
+
+		Describe("#UpdateInfoStatus", func() {
+			It("should apply the mutation and carry the server ResourceVersion, but not other server-side fields", func() {
+				shootObj := &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "foo",
+						Namespace:       "garden-bar",
+						Generation:      1,
+						ResourceVersion: "1",
+					},
+				}
+				s := &Shoot{}
+				s.SetInfo(shootObj)
+
+				// Simulate a server that bumps ResourceVersion on status patch (as a real API server would).
+				c := fake.NewClientBuilder().
+					WithScheme(kubernetes.GardenScheme).
+					WithObjects(shootObj).
+					WithStatusSubresource(shootObj).
+					WithInterceptorFuncs(interceptor.Funcs{
+						SubResourcePatch: func(ctx context.Context, c client.Client, _ string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+							if err := c.Status().Patch(ctx, obj, patch, opts...); err != nil {
+								return err
+							}
+							obj.(*gardencorev1beta1.Shoot).ResourceVersion = "2"
+							return nil
+						},
+					}).
+					Build()
+
+				Expect(s.UpdateInfoStatus(context.Background(), c, false, false, func(shoot *gardencorev1beta1.Shoot) error {
+					shoot.Status.ObservedGeneration = 1
+					return nil
+				})).To(Succeed())
+
+				info := s.GetInfo()
+				Expect(info.Status.ObservedGeneration).To(Equal(int64(1)))
+				// ResourceVersion must be carried back so the next optimistic-lock patch doesn't conflict.
+				Expect(info.ResourceVersion).To(Equal("2"))
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
`UpdateInfo` and `UpdateInfoStatus` stored the full server response back into `b.Shoot.GetInfo()`, causing it to pick up server-side field changes (e.g. a generation bump from an external actor patching the Shoot mid-reconciliation) that the current flow was not initialized for. This broke the mid-air generation check in [`removeTaskAnnotation`](https://github.com/gardener/gardener/blob/315d8f38b211ad0538f28d89011f0d89ac8d1f98/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go#L1163-L1179) in the `Shoot` controller: `WaitForInfrastructure` calls `UpdateInfoStatus` just before `removeTaskAnnotation` runs, the server response carries the bumped generation, and both sides of the check become equal — so the `deployInfrastructure` task annotation is incorrectly removed even though the Infrastructure extension never reconciled the new generation. Fix by deep-copying the post-mutation object before `c.Patch` overwrites it in-place with the server response. `b.Shoot.GetInfo()` now reflects exactly the caller's mutations, without externally-bumped fields.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Regressed in #15316, which removed the explicit `generation int64` parameter from `removeTaskAnnotation` (captured once at flow start and threaded through all callers — a bit of a hack, admittedly) in favour of `b.Shoot.GetInfo().Generation`, unaware that `UpdateInfoStatus` would silently update it mid-flow. Even before the regression, passing `generation` explicitly was never the right fix — the proper solution is to ensure `b.Shoot.GetInfo()` stays stable across a reconciliation flow, which is what this PR does.

**Release note**:
```bugfix user
Fixed a bug where the `deployInfrastructure` task annotation on a `Shoot` was incorrectly removed when the `Shoot` spec was changed by an external actor while the infrastructure was being reconciled, causing the Infrastructure extension to never pick up the new generation.
```