### PR TITLE
Run `make generate` for `perses-operator` update PRs opened by `renovate`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -158,6 +158,7 @@
         '/.*gardener/pvc-autoscaler$/',
         '/.*open-telemetry/opentelemetry-operator/apis$/',
         '/.*VictoriaMetrics/operator/api$/',
+        '/.*perses/perses-operator$/',
         '/sigs\\.k8s\\.io/controller-tools/',
       ],
     },


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

`perses-operator` was missing from the `postUpgradeTasks` allow-list, so its bumps did not run `make generate` and left the Perses CRDs stale (e.g. #15435). This adds it so future bumps regenerate the CRDs automatically.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Suggested in https://github.com/gardener/gardener/pull/15438#issuecomment-5205437630.

**Release note**:
```other dependency
NONE
```
