### PR TITLE
Configure Renovate to combine minor and patch updates of Victoria Metrics dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -223,6 +223,7 @@
         '/.*VictoriaMetrics/operator$/',
         '/github\\.com/VictoriaMetrics/operator/api$/',
       ],
+      separateMinorPatch: false,
     },
     {
       // Group Prometheus updates in one PR.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Configures the Renovate `packageRule` for Victoria Metrics dependencies to combine minor and patch updates into a single PR.

**Which issue(s) this PR fixes**:

The following Renovate PRs are being separated:
* https://github.com/gardener/gardener/pull/15439
* https://github.com/gardener/gardener/pull/15440

**Special notes for your reviewer**:

/cc @ialidzhikov @rrhubenov @plkokanov @oliver-goetz 

See the documentation for [separateMinorPatch](https://docs.renovatebot.com/configuration-options/#separateminorpatch) and our configuration line for enabling it by default:
https://github.com/gardener/gardener/blob/2da1c2a035a0531ab65c24a57ecf2638427b9407/.github/renovate.json5#L87

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
