### PR TITLE
[GEP-28] Allow self-hosted shoot gardenlet to read `shoot-service-account-issuer` secret

### DIFF
--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -242,7 +242,7 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 			)
 
 		case secretResource:
-			return a.authorizeSecret(ctx, requestAuthorizer, attrs)
+			return a.authorizeSecret(ctx, requestAuthorizer, userType, attrs)
 
 		case seedResource:
 			// The self-hosted shoot gardenlet needs read access for the Seed whose name matches its shoot name.
@@ -360,7 +360,19 @@ func (a *authorizer) authorizeServiceAccount(requestAuthorizer *authwebhook.Requ
 	)
 }
 
-func (a *authorizer) authorizeSecret(ctx context.Context, requestAuthorizer *authwebhook.RequestAuthorizer, attrs auth.Attributes) (auth.Decision, string, error) {
+func (a *authorizer) authorizeSecret(ctx context.Context, requestAuthorizer *authwebhook.RequestAuthorizer, userType gardenletidentity.UserType, attrs auth.Attributes) (auth.Decision, string, error) {
+	// Allow the gardenlet (not extension service accounts) to list/watch secrets labeled
+	// gardener.cloud/role=shoot-service-account-issuer from the garden namespace.
+	if userType == gardenletidentity.UserTypeGardenlet &&
+		slices.Contains([]string{"list", "watch"}, attrs.GetVerb()) &&
+		attrs.GetNamespace() == v1beta1constants.GardenNamespace {
+		return requestAuthorizer.Check(graph.VertexTypeSecret, attrs,
+			authwebhook.WithAllowedVerbs("list", "watch"),
+			authwebhook.WithAllowedNamespaces(v1beta1constants.GardenNamespace),
+			authwebhook.WithLabelSelectors(map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShootServiceAccountIssuer}),
+		)
+	}
+
 	if attrs.GetNamespace() == metav1.NamespaceSystem && strings.HasPrefix(attrs.GetName(), bootstraptokenapi.BootstrapTokenSecretPrefix) {
 		switch attrs.GetVerb() {
 		case "get", "list", "watch":

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -18,6 +18,7 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authentication/user"
 	auth "k8s.io/apiserver/pkg/authorization/authorizer"
 	bootstraptokenutil "k8s.io/cluster-bootstrap/token/util"
@@ -27,6 +28,7 @@ import (
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhook/auth/shoot"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
@@ -2118,6 +2120,89 @@ var _ = Describe("Shoot", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionAllow))
 						Expect(reason).To(BeEmpty())
+					})
+				})
+
+				When("list/watch of shoot-service-account-issuer secret from garden namespace is requested", func() {
+					var issuerLabelRequirements labels.Requirements
+
+					BeforeEach(func() {
+						selector, err := labels.Parse(v1beta1constants.GardenRole + "=" + v1beta1constants.GardenRoleShootServiceAccountIssuer)
+						Expect(err).NotTo(HaveOccurred())
+						var selectable bool
+						issuerLabelRequirements, selectable = selector.Requirements()
+						Expect(selectable).To(BeTrue())
+
+						attrs.Namespace = v1beta1constants.GardenNamespace
+						attrs.Name = ""
+						attrs.LabelSelectorRequirements = issuerLabelRequirements
+					})
+
+					DescribeTable("should allow for gardenlet user type with correct label selector",
+						func(verb string) {
+							attrs.Verb = verb
+
+							decision, reason, err := authorizer.Authorize(ctx, attrs)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						},
+						Entry("list", "list"),
+						Entry("watch", "watch"),
+					)
+
+					DescribeTable("should not allow for gardenlet user type without label selector",
+						func(verb string) {
+							attrs.Verb = verb
+							attrs.LabelSelectorRequirements = nil
+
+							decision, reason, err := authorizer.Authorize(ctx, attrs)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("must specify field or label selector"))
+						},
+						Entry("list", "list"),
+						Entry("watch", "watch"),
+					)
+
+					It("should fall through to graph-based authorization for extension user type", func() {
+						attrs.Verb = "list"
+						attrs.User = &user.DefaultInfo{
+							Name:   "system:serviceaccount:" + v1beta1constants.GardenNamespace + ":extension-shoot--" + shootName + "--foo",
+							Groups: []string{"system:serviceaccounts", "system:serviceaccounts:" + v1beta1constants.GardenNamespace},
+						}
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("must specify field or label selector"))
+					})
+
+					DescribeTable("should fall through to graph-based authorization for write verbs",
+						func(verb string) {
+							attrs.Verb = verb
+							attrs.Name = v1beta1constants.GardenRoleShootServiceAccountIssuer
+
+							graph.EXPECT().HasPathFrom(graphutils.VertexTypeSecret, v1beta1constants.GardenNamespace, v1beta1constants.GardenRoleShootServiceAccountIssuer, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+							decision, reason, err := authorizer.Authorize(ctx, attrs)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("no relationship found"))
+						},
+						Entry("patch", "patch"),
+						Entry("update", "update"),
+					)
+
+					It("should fall through to graph-based authorization for delete verb", func() {
+						attrs.Verb = "delete"
+						attrs.Name = v1beta1constants.GardenRoleShootServiceAccountIssuer
+
+						graph.EXPECT().HasVertex(graphutils.VertexTypeSecret, v1beta1constants.GardenNamespace, v1beta1constants.GardenRoleShootServiceAccountIssuer).Return(true)
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeSecret, v1beta1constants.GardenNamespace, v1beta1constants.GardenRoleShootServiceAccountIssuer, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("no relationship found"))
 					})
 				})
 

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -220,6 +220,7 @@ func newBotanist(
 		ctx,
 		log,
 		gardenClient,
+		gardenClient,
 		clientSet,
 		nil, // gardenadm has no ShootClientMap
 		gardenletConfig,

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/oci"
 	"github.com/gardener/gardener/pkg/utils/retry"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 // NewCommand creates a new cobra.Command.
@@ -106,6 +107,16 @@ func run(ctx context.Context, opts *Options) error {
 		bootstrapClientSet, err := cmd.NewClientSetFromBootstrapToken(opts.ControlPlaneAddress, opts.CertificateAuthority, opts.BootstrapToken, kubernetes.GardenScheme)
 		if err != nil {
 			return fmt.Errorf("failed creating a new bootstrap garden client set: %w", err)
+		}
+
+		// Self-hosted shoot gardenlets require the garden cluster to be at least Kubernetes 1.34: the shoot authorizer
+		// enforces label selectors via AuthorizeWithSelectors, which was promoted to GA in 1.34.
+		gardenVersion, err := b.DiscoverKubernetesVersion(bootstrapClientSet)
+		if err != nil {
+			return fmt.Errorf("failed discovering garden cluster version: %w", err)
+		}
+		if !versionutils.ConstraintK8sGreaterEqual134.Check(gardenVersion) {
+			return fmt.Errorf("garden cluster must be at least Kubernetes 1.34 (got %s): self-hosted shoots require the AuthorizeWithSelectors feature gate which was promoted to GA in 1.34", gardenVersion.Original())
 		}
 
 		var (

--- a/pkg/gardenlet/controller/shoot/shoot/add.go
+++ b/pkg/gardenlet/controller/shoot/shoot/add.go
@@ -35,6 +35,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Clu
 	if r.GardenClient == nil {
 		r.GardenClient = gardenCluster.GetClient()
 	}
+	if r.GardenAPIReader == nil {
+		r.GardenAPIReader = gardenCluster.GetAPIReader()
+	}
 	if r.Recorder == nil {
 		r.Recorder = gardenCluster.GetEventRecorder(ControllerName + "-controller")
 	}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -58,6 +58,7 @@ const taskID = "initializeOperation"
 // Reconciler implements the main shoot reconciliation logic, i.e., creation, hibernation, migration and deletion.
 type Reconciler struct {
 	GardenClient                client.Client
+	GardenAPIReader             client.Reader
 	SeedClientSet               kubernetes.Interface
 	ShootClientMap              clientmap.ClientMap
 	Config                      gardenletconfigv1alpha1.GardenletConfiguration
@@ -373,6 +374,7 @@ func (r *Reconciler) initializeOperation(
 	op, err := operation.Initialize(
 		ctx,
 		log,
+		r.GardenAPIReader,
 		r.GardenClient,
 		r.SeedClientSet,
 		r.ShootClientMap,

--- a/pkg/gardenlet/operation/initialize.go
+++ b/pkg/gardenlet/operation/initialize.go
@@ -29,6 +29,7 @@ import (
 func Initialize(
 	ctx context.Context,
 	log logr.Logger,
+	gardenAPIReader client.Reader,
 	gardenClient client.Client,
 	seedClientSet kubernetes.Interface,
 	shootClientMap clientmap.ClientMap,
@@ -52,9 +53,6 @@ func Initialize(
 	)
 
 	if !v1beta1helper.IsShootSelfHosted(shoot.Spec.Provider.Workers) {
-		// TODO(rfranzke): Enable shoot gardenlet to read the gardener.cloud/role=shoot-service-account-issuer secret from
-		//  garden namespace (adapt authorizer) --> requires virtual garden to be at least 1.34 (this promotes the selector
-		//  feature gate to GA, hence, we can enforce the needed label selectors)
 		gardenSecrets, err = gardenerutils.ReadGardenSecrets(
 			ctx,
 			log,
@@ -86,6 +84,22 @@ func Initialize(
 			return nil, err
 		}
 	} else {
+		// The self-hosted gardenlet only needs the shoot service account issuer secret. The shoot authorizer
+		// only permits list/watch with the gardener.cloud/role=shoot-service-account-issuer label selector
+		// (enforced via AuthorizeWithSelectors, GA in Kubernetes 1.34), so we scope the list to that role.
+		// We use the uncached API reader because the self-hosted gardenlet uses SingleObjectCacheFunc for
+		// secrets (Get-by-name only) and the label-selector list would bypass the cache anyway.
+		gardenSecrets, err = gardenerutils.ReadGardenSecrets(
+			ctx,
+			log,
+			gardenAPIReader,
+			v1beta1constants.GardenNamespace,
+			v1beta1constants.GardenRoleShootServiceAccountIssuer,
+		)
+		if err != nil {
+			return nil, err
+		}
+
 		// See https://github.com/gardener/gardener/pull/14352
 		if config.ETCDConfig.FeatureGates == nil {
 			config.ETCDConfig.FeatureGates = make(map[string]bool)

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -246,11 +246,13 @@ func ReadInternalDomainSecret(ctx context.Context, c client.Reader, namespace st
 
 // ReadGardenSecrets reads the Kubernetes Secrets from the Garden cluster which are independent of Shoot clusters.
 // The Secret objects are stored on the Controller in order to pass them to created Garden objects later.
+// When roles are provided, only secrets whose gardener.cloud/role label matches one of the given values are listed.
 func ReadGardenSecrets(
 	ctx context.Context,
 	log logr.Logger,
 	c client.Reader,
 	namespace string,
+	roles ...string,
 ) (
 	map[string]*corev1.Secret,
 	error,
@@ -263,8 +265,17 @@ func ReadGardenSecrets(
 		numberOfShootServiceAccountIssuerSecrets = 0
 	)
 
+	roleReq := gardenRoleReq
+	if len(roles) > 0 {
+		req, err := labels.NewRequirement(v1beta1constants.GardenRole, selection.In, roles)
+		if err != nil {
+			return nil, fmt.Errorf("failed building role label requirement: %w", err)
+		}
+		roleReq = *req
+	}
+
 	secretList := &corev1.SecretList{}
-	if err := c.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(gardenRoleReq)}); err != nil {
+	if err := c.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(roleReq)}); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/area security
/kind enhancement

**What this PR does / why we need it**:
Self-hosted shoot gardenlets need to read the `shoot-service-account-issuer` secret (labeled `gardener.cloud/role=shoot-service-account-issuer`) from the `garden` namespace to populate `ServiceAccountIssuerHostname` and activate the managed issuer feature. The shoot authorizer is extended to permit `list`/`watch` of that secret scoped via label selector for self-hosted gardenlets, while extension service accounts remain on the graph-based path. `gardenadm connect` now fails early if the garden cluster is < 1.34, which is required for `AuthorizeWithSelectors` (GA in 1.34) to enforce the label constraint.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
`ReadGardenSecrets` gained a `roles ...string` variadic — when supplied it builds an `In` selector instead of `Exists`, so only the specified roles are fetched. The self-hosted path uses `GardenAPIReader` (uncached) because a label-selector list bypasses the `SingleObjectCacheFunc` cache anyway.

**Release note**:
```
NONE
```