### PR TITLE
[GEP-28] Merge self-hosted `Shoot` flow back into hosted `Shoot` flow

### DIFF
--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -202,6 +202,7 @@ build:
             - pkg/gardenlet/controller/backupentry
             - pkg/gardenlet/controller/controllerinstallation/controllerinstallation
             - pkg/gardenlet/controller/controllerinstallation/utils
+            - pkg/gardenlet/controller/shoot/shoot/helper
             - pkg/gardenlet/features
             - pkg/gardenlet/operation
             - pkg/gardenlet/operation/botanist

--- a/pkg/api/core/v1beta1/helper/shoot.go
+++ b/pkg/api/core/v1beta1/helper/shoot.go
@@ -789,6 +789,10 @@ func IsUpdateStrategyManualInPlace(updateStrategy *gardencorev1beta1.MachineUpda
 
 // IsShootIstioTLSTerminationEnabled returns true if the Istio TLS termination for the shoot kube-apiserver is enabled.
 func IsShootIstioTLSTerminationEnabled(shoot *gardencorev1beta1.Shoot) bool {
+	if IsShootSelfHosted(shoot.Spec.Provider.Workers) {
+		return false
+	}
+
 	value, ok := shoot.Annotations[v1beta1constants.ShootDisableIstioTLSTermination]
 	if !ok {
 		return true

--- a/pkg/api/core/v1beta1/helper/shoot_test.go
+++ b/pkg/api/core/v1beta1/helper/shoot_test.go
@@ -1923,21 +1923,40 @@ var _ = Describe("Helper", func() {
 		Entry("with ManualInPlaceUpdate  update strategy", new(gardencorev1beta1.ManualInPlaceUpdate), true),
 	)
 
-	DescribeTable("#IsShootIstioTLSTerminationEnabled",
-		func(shootAnnotations map[string]string, expected bool) {
-			shoot := &gardencorev1beta1.Shoot{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: shootAnnotations,
-				},
-			}
-			Expect(IsShootIstioTLSTerminationEnabled(shoot)).To(Equal(expected))
-		},
+	Describe("#IsShootIstioTLSTerminationEnabled", func() {
+		var shoot *gardencorev1beta1.Shoot
 
-		Entry("shoot has Istio TLS termination if it has no annotations", nil, true),
-		Entry("shoot has no Istio TLS termination if is disabled by annotation", map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "true"}, false),
-		Entry("shoot has no Istio TLS termination if is not disabled by annotation", map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "false"}, true),
-		Entry("shoot has no Istio TLS termination if it is annotated with a bogus value", map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "foobar"}, true),
-	)
+		BeforeEach(func() {
+			shoot = &gardencorev1beta1.Shoot{}
+		})
+
+		It("should return true when shoot has no annotations", func() {
+			Expect(IsShootIstioTLSTerminationEnabled(shoot)).To(BeTrue())
+		})
+
+		It("should return false when annotation is set to true", func() {
+			shoot.Annotations = map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "true"}
+			Expect(IsShootIstioTLSTerminationEnabled(shoot)).To(BeFalse())
+		})
+
+		It("should return true when annotation is set to false", func() {
+			shoot.Annotations = map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "false"}
+			Expect(IsShootIstioTLSTerminationEnabled(shoot)).To(BeTrue())
+		})
+
+		It("should return true when annotation is set to a bogus value", func() {
+			shoot.Annotations = map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "foobar"}
+			Expect(IsShootIstioTLSTerminationEnabled(shoot)).To(BeTrue())
+		})
+
+		It("should return false for self-hosted shoot regardless of annotation", func() {
+			shoot.Annotations = map[string]string{"shoot.gardener.cloud/disable-istio-tls-termination": "false"}
+			shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
+				{ControlPlane: &gardencorev1beta1.WorkerControlPlane{}},
+			}
+			Expect(IsShootIstioTLSTerminationEnabled(shoot)).To(BeFalse())
+		})
+	})
 
 	Describe("#GetBackupConfigForShoot", func() {
 		var (

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -112,7 +112,7 @@ func run(ctx context.Context, opts *Options) error {
 			Dependencies: flow.NewTaskIDs(deployNamespaces, initializeSecretsManagement),
 		})
 		_ = g.AddGroup(
-			b.ReconcileGardenerResourceManagerTaskGroup(true, true, false).
+			b.ReconcileGardenerResourceManagerTaskGroup(true, false, false).
 				WithDependencies(deployPriorityClassCritical),
 		)
 		_                             = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -182,7 +182,7 @@ func run(ctx context.Context, opts *Options) error {
 		})
 
 		_ = g.AddGroup(
-			b.ReconcileETCDsTaskGroup(shootIsGarden).
+			b.ReconcileETCDsTaskGroup(shootIsGarden, false, false).
 				WithDependencies(syncPointBootstrapped, reconcileBackupEntry).
 				SkipIf(opts.UseBootstrapEtcd),
 		)

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -342,28 +342,21 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			SkipIf:       !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(waitUntilEtcdBackupsCopied),
 		})
-		deployETCD = g.Add(flow.Task{
-			Name:         "Deploying main and events etcd",
-			Fn:           flow.TaskFn(b.DeployEtcd).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(b.Shoot, defaultTimeout)),
-			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilBackupEntryInGardenReconciled, waitUntilEtcdBackupsCopied),
-		})
+		waitUntilEtcdReady = g.AddGroup(b.ReconcileETCDsTaskGroup(false, flowCtx.isRestoringHAControlPlane, flowCtx.skipReadiness).WithDependencies(
+			waitUntilBackupEntryInGardenReconciled,
+			waitUntilEtcdBackupsCopied,
+		))
 		destroySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Destroying source backup entry",
 			Fn:           b.DestroySourceBackupEntry,
 			SkipIf:       !flowCtx.allowBackup || !b.Shoot.IsRestorePhase(),
-			Dependencies: flow.NewTaskIDs(deployETCD),
+			Dependencies: flow.NewTaskIDs(waitUntilEtcdReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until source backup entry has been deleted",
 			Fn:           b.Shoot.Components.SourceBackupEntry.WaitCleanup,
 			SkipIf:       !flowCtx.allowBackup || flowCtx.skipReadiness || !b.Shoot.IsRestorePhase(),
 			Dependencies: flow.NewTaskIDs(destroySourceBackupEntry),
-		})
-		waitUntilEtcdReady = g.Add(flow.Task{
-			Name:         "Waiting until main and event etcd report readiness",
-			Fn:           b.WaitUntilEtcdsReady,
-			SkipIf:       (!flowCtx.isRestoringHAControlPlane && b.Shoot.HibernationEnabled) || flowCtx.skipReadiness,
-			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
 		deployExtensionResourcesBeforeKAPI = g.Add(flow.Task{
 			Name:         "Deploying extension resources before kube-apiserver",
@@ -384,7 +377,6 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			}).RetryUntilTimeout(defaultInterval, flowCtx.deployKubeAPIServerTaskTimeout),
 			Dependencies: flow.NewTaskIDs(
 				initializeSecretsManagement,
-				deployETCD,
 				waitUntilEtcdReady,
 				waitUntilKubeAPIServerServiceIsReady,
 				waitUntilExtensionResourcesBeforeKAPIReady,
@@ -993,7 +985,7 @@ func (r *Reconciler) setupReconcileSelfHostedShootFlow(ctx context.Context, b *b
 		})
 
 		_ = g.AddGroup(
-			b.ReconcileETCDsTaskGroup(shootIsGarden).
+			b.ReconcileETCDsTaskGroup(shootIsGarden, flowCtx.isRestoringHAControlPlane, flowCtx.skipReadiness).
 				WithDependencies(waitUntilBackupEntryInGardenReconciled),
 		)
 		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false, ""))

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -153,13 +153,8 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 	}
 
-	setupFlow := r.setupReconcileHostedShootFlow
-	if b.Shoot.IsSelfHosted() {
-		setupFlow = r.setupReconcileSelfHostedShootFlow
-	}
-
 	graph := flow.NewGraph(fmt.Sprintf("Shoot cluster %s", utils.IifString(flowCtx.isRestoring, "restoration", "reconciliation")))
-	if err := setupFlow(ctx, b, flowCtx, graph); err != nil {
+	if err := r.setupShootReconciliationFlow(ctx, b, flowCtx, graph); err != nil {
 		err = fmt.Errorf("setting up reconciliation flow failed: %w", err)
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 	}
@@ -214,7 +209,18 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	return nil
 }
 
-func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanistpkg.Botanist, flowCtx flowContext, g *flow.Graph) error {
+func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botanistpkg.Botanist, flowCtx flowContext, g *flow.Graph) error {
+	// If the Shoot is a self-hosted shoot, we have to check if it also is the garden runtime cluster. In this case,
+	// gardener-operator is taking over responsibility of some components (e.g., etcd-druid). Detect this by checking whether a Garden resource exists.
+	shootIsGarden := false
+	if b.Shoot.IsSelfHosted() {
+		var err error
+		shootIsGarden, err = gardenletutils.ClusterIsGarden(ctx, b.SeedClientSet.Client())
+		if err != nil {
+			return fmt.Errorf("failed checking whether shoot is garden: %w", err)
+		}
+	}
+
 	var (
 		deployExtensionAfterKAPIMsg = "Deploying extension resources after kube-apiserver"
 		waitExtensionAfterKAPIMsg   = "Waiting until extension resources handled after kube-apiserver are ready"
@@ -233,12 +239,14 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		ensureShootClusterIdentity = g.Add(flow.Task{
 			Name:         "Ensuring Shoot cluster identity",
 			Fn:           flow.TaskFn(b.EnsureShootClusterIdentity).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		deployCloudProviderSecret                    = g.AddGroup(b.DeployCloudProviderSecretTaskGroup())
 		reconcileIstioInternalLoadbalancingConfigMap = g.Add(flow.Task{
 			Name:         "Reconcile Istio internal load balancing ConfigMap",
 			Fn:           flow.TaskFn(b.ReconcileIstioInternalLoadBalancingConfigMap).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		_                           = g.AddGroup(b.ReconcileCustomResourceDefinitionsTaskGroup())
@@ -250,12 +258,13 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		initialValiDeployment = g.Add(flow.Task{
 			Name:         "Deploying initial shoot logging stack in Seed",
 			Fn:           flow.TaskFn(b.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       flowCtx.isHibernatingShootWithWorkers,
+			SkipIf:       flowCtx.isHibernatingShootWithWorkers || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployNamespace, initializeSecretsManagement),
 		})
 		deployReferencedResources = g.Add(flow.Task{
 			Name:         "Deploying referenced resources",
 			Fn:           flow.TaskFn(b.DeployReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		waitUntilInfrastructureReady = g.AddGroup(
@@ -265,61 +274,79 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		deployKubeAPIServerService = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes API server service in the Seed cluster",
 			Fn:           flow.TaskFn(b.Shoot.Components.ControlPlane.KubeAPIServerService.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootClusterIdentity, initializeSecretsManagement).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		waitUntilKubeAPIServerServiceIsReady = g.Add(flow.Task{
 			Name:         "Waiting until Kubernetes API server service in the Seed cluster has reported readiness",
 			Fn:           b.Shoot.Components.ControlPlane.KubeAPIServerService.Wait,
-			SkipIf:       b.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerService),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Ensuring advertised addresses for the Shoot",
 			Fn:           b.UpdateAdvertisedAddresses,
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilKubeAPIServerServiceIsReady),
 		})
 		deployInternalDomainDNSRecord = g.Add(flow.Task{
 			Name: "Deploying internal domain DNS record",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
+			Fn: func(ctx context.Context) error {
 				if err := b.DeployOrDestroyInternalDNSRecord(ctx); err != nil {
 					return err
 				}
 				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskDeployDNSRecordInternal)
-			}),
-			SkipIf:       b.Shoot.HibernationEnabled,
+			},
+			SkipIf:       b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Deploying external domain DNS record",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
+			Fn: func(ctx context.Context) error {
 				if err := b.DeployOrDestroyExternalDNSRecord(ctx); err != nil {
 					return err
 				}
 				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskDeployDNSRecordExternal)
-			}),
-			SkipIf:       b.Shoot.HibernationEnabled,
+			},
+			SkipIf:       b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
 		})
 		deploySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Deploying source backup entry",
 			Fn:           b.DeploySourceBackupEntry,
-			SkipIf:       !flowCtx.isCopyOfBackupsRequired,
+			SkipIf:       !flowCtx.isCopyOfBackupsRequired || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		waitUntilSourceBackupEntryInGardenReconciled = g.Add(flow.Task{
 			Name:         "Waiting until the source backup entry has been reconciled",
 			Fn:           b.Shoot.Components.SourceBackupEntry.Wait,
-			SkipIf:       flowCtx.skipReadiness || !flowCtx.isCopyOfBackupsRequired,
+			SkipIf:       flowCtx.skipReadiness || !flowCtx.isCopyOfBackupsRequired || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deploySourceBackupEntry),
 		})
+		deployBackupBucketInGarden = g.Add(flow.Task{
+			Name: "Deploying BackupBucket for ETCD data",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.BackupBucket.Deploy(ctx)
+			},
+			SkipIf:       !flowCtx.allowBackup || !b.Shoot.IsSelfHosted(),
+			Dependencies: flow.NewTaskIDs(deployNamespace),
+		})
+		waitUntilBackupBucketInGardenReconciled = g.Add(flow.Task{
+			Name: "Waiting until the BackupBucket for ETCD data has been reconciled",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.BackupBucket.Wait(ctx)
+			},
+			SkipIf:       flowCtx.skipReadiness || !flowCtx.allowBackup || !b.Shoot.IsSelfHosted(),
+			Dependencies: flow.NewTaskIDs(deployBackupBucketInGarden),
+		})
 		deployBackupEntryInGarden = g.Add(flow.Task{
-			Name:         "Deploying backup entry",
+			Name:         "Deploying BackupEntry for ETCD data",
 			Fn:           b.DeployBackupEntry,
 			SkipIf:       !flowCtx.allowBackup,
-			Dependencies: flow.NewTaskIDs(deployNamespace, waitUntilSourceBackupEntryInGardenReconciled),
+			Dependencies: flow.NewTaskIDs(deployNamespace, waitUntilSourceBackupEntryInGardenReconciled, waitUntilBackupBucketInGardenReconciled),
 		})
 		waitUntilBackupEntryInGardenReconciled = g.Add(flow.Task{
-			Name:         "Waiting until the backup entry has been reconciled",
+			Name:         "Waiting until the BackupEntry for ETCD data has been reconciled",
 			Fn:           b.Shoot.Components.BackupEntry.Wait,
 			SkipIf:       flowCtx.skipReadiness || !flowCtx.allowBackup,
 			Dependencies: flow.NewTaskIDs(deployBackupEntryInGarden),
@@ -342,32 +369,32 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			SkipIf:       !flowCtx.isCopyOfBackupsRequired,
 			Dependencies: flow.NewTaskIDs(waitUntilEtcdBackupsCopied),
 		})
-		waitUntilEtcdReady = g.AddGroup(b.ReconcileETCDsTaskGroup(false, flowCtx.isRestoringHAControlPlane, flowCtx.skipReadiness).WithDependencies(
+		waitUntilEtcdReady = g.AddGroup(b.ReconcileETCDsTaskGroup(shootIsGarden, flowCtx.isRestoringHAControlPlane, flowCtx.skipReadiness).WithDependencies(
 			waitUntilBackupEntryInGardenReconciled,
 			waitUntilEtcdBackupsCopied,
 		))
 		destroySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Destroying source backup entry",
 			Fn:           b.DestroySourceBackupEntry,
-			SkipIf:       !flowCtx.allowBackup || !b.Shoot.IsRestorePhase(),
+			SkipIf:       !flowCtx.allowBackup || !b.Shoot.IsRestorePhase() || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilEtcdReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until source backup entry has been deleted",
 			Fn:           b.Shoot.Components.SourceBackupEntry.WaitCleanup,
-			SkipIf:       !flowCtx.allowBackup || flowCtx.skipReadiness || !b.Shoot.IsRestorePhase(),
+			SkipIf:       !flowCtx.allowBackup || flowCtx.skipReadiness || !b.Shoot.IsRestorePhase() || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(destroySourceBackupEntry),
 		})
 		deployExtensionResourcesBeforeKAPI = g.Add(flow.Task{
 			Name:         "Deploying extension resources before kube-apiserver",
 			Fn:           flow.TaskFn(b.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, deployReferencedResources, waitUntilInfrastructureReady),
 		})
 		waitUntilExtensionResourcesBeforeKAPIReady = g.Add(flow.Task{
 			Name:         "Waiting until extension resources handled before kube-apiserver are ready",
 			Fn:           b.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
-			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesBeforeKAPI),
 		})
 		deployKubeAPIServer = g.Add(flow.Task{
@@ -375,6 +402,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.DeployKubeAPIServer(ctx)
 			}).RetryUntilTimeout(defaultInterval, flowCtx.deployKubeAPIServerTaskTimeout),
+			SkipIf: b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(
 				initializeSecretsManagement,
 				waitUntilEtcdReady,
@@ -385,12 +413,13 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		waitUntilKubeAPIServerIsReady = g.Add(flow.Task{
 			Name:         "Waiting until Kubernetes API server rolled out",
 			Fn:           b.Shoot.Components.ControlPlane.KubeAPIServer.Wait,
-			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServer),
 		})
 		deployKubeAPIServerServiceSNISettings = g.Add(flow.Task{
 			Name:         "Deploying and waiting for Kubernetes API server service SNI settings in the Seed cluster",
 			Fn:           flow.TaskFn(b.DeployKubeAPIServerSNI).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
 		})
 		_ = g.Add(flow.Task{
@@ -402,17 +431,17 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		scaleEtcdAfterRestore = g.Add(flow.Task{
 			Name:         "Scaling main and events etcd after kube-apiserver is ready",
 			Fn:           flow.TaskFn(b.ScaleUpETCD).RetryUntilTimeout(defaultInterval, helper.GetEtcdDeployTimeout(b.Shoot, defaultTimeout)),
-			SkipIf:       !flowCtx.isRestoringHAControlPlane,
+			SkipIf:       !flowCtx.isRestoringHAControlPlane || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilEtcdReady, waitUntilKubeAPIServerIsReady),
 		})
 		waitUntilEtcdScaledAfterRestore = g.Add(flow.Task{
 			Name:         "Waiting until main and events etcd scaled up after kube-apiserver is ready",
 			Fn:           flow.TaskFn(b.WaitUntilEtcdsReady),
-			SkipIf:       !flowCtx.isRestoringHAControlPlane || flowCtx.skipReadiness,
+			SkipIf:       !flowCtx.isRestoringHAControlPlane || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(scaleEtcdAfterRestore),
 		})
 		waitUntilGardenerResourceManagerReady = g.AddGroup(
-			b.ReconcileGardenerResourceManagerTaskGroup(true, true, flowCtx.skipReadiness).
+			b.ReconcileGardenerResourceManagerTaskGroup(true, shootIsGarden, flowCtx.skipReadiness).
 				WithDependencies(waitUntilKubeAPIServerIsReady),
 		)
 		_ = g.Add(flow.Task{
@@ -426,7 +455,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			SkipIf: !sets.New(
 				gardencorev1beta1.RotationPreparing,
 				gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
-			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)),
+			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)) || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
 		waitUntilControlPlaneReady = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness).WithDependencies(
@@ -436,24 +465,25 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		deployVPNSeedServer           = g.Add(flow.Task{
 			Name:         "Deploying vpn-seed-server",
 			Fn:           flow.TaskFn(b.DeployVPNServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployNamespace, waitUntilGardenerResourceManagerReady),
 		})
 		deployGardenerAccess = g.Add(flow.Task{
 			Name:         "Deploying Gardener shoot access resources",
 			Fn:           flow.TaskFn(b.Shoot.Components.GardenerAccess.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		initializeShootClients = g.Add(flow.Task{
 			Name:         "Initializing connection to Shoot",
 			Fn:           flow.TaskFn(b.InitializeDesiredShootClients).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployGardenerAccess),
 		})
 		_ = g.Add(flow.Task{
-			Name: "Sync public service account signing keys to Garden cluster",
-			Fn:   b.SyncPublicServiceAccountKeys,
-			SkipIf: b.Shoot.HibernationEnabled ||
-				!v1beta1helper.HasManagedIssuer(b.Shoot.GetInfo()),
+			Name:         "Sync public service account signing keys to Garden cluster",
+			Fn:           b.SyncPublicServiceAccountKeys,
+			SkipIf:       b.Shoot.HibernationEnabled || !v1beta1helper.HasManagedIssuer(b.Shoot.GetInfo()) || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
 		rewriteResourcesAddLabel = g.Add(flow.Task{
@@ -461,7 +491,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, b.Logger, b.SeedClientSet.Client(), b.ShootClientSet, b.SecretsManager, b.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer, b.Shoot.ResourcesToEncrypt, b.Shoot.EncryptedResources, gardenerutils.DefaultGVKsForEncryption())
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf: b.Shoot.HibernationEnabled ||
+			SkipIf: b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted() ||
 				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
 					sets.New(b.Shoot.ResourcesToEncrypt...).Equal(sets.New(b.Shoot.EncryptedResources...)) && (b.Shoot.EncryptionProviderToUse == b.Shoot.UsedEncryptionProvider ||
 					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting)),
@@ -469,10 +499,10 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		})
 		snapshotETCD = g.Add(flow.Task{
 			Name: "Snapshotting ETCD after modification of encryption config or resources are re-encrypted with new ETCD encryption key",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
+			Fn: func(ctx context.Context) error {
 				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, b.SeedClientSet.Client(), b.SnapshotEtcd, b.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer)
-			}),
-			SkipIf: !flowCtx.allowBackup || b.Shoot.HibernationEnabled ||
+			},
+			SkipIf: !flowCtx.allowBackup || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted() ||
 				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
 					sets.New(b.Shoot.ResourcesToEncrypt...).Equal(sets.New(b.Shoot.EncryptedResources...)) && (b.Shoot.EncryptionProviderToUse == b.Shoot.UsedEncryptionProvider ||
 					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting)),
@@ -520,7 +550,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 
 				return nil
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf: b.Shoot.HibernationEnabled ||
+			SkipIf: b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted() ||
 				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting &&
 					sets.New(b.Shoot.ResourcesToEncrypt...).Equal(sets.New(b.Shoot.EncryptedResources...)) && (b.Shoot.EncryptionProviderToUse == b.Shoot.UsedEncryptionProvider ||
 					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPreparing ||
@@ -532,31 +562,32 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.ControlPlane.KubeScheduler.Deploy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Reconciling Kubernetes vertical pod autoscaler",
 			Fn:           flow.TaskFn(b.DeployVerticalPodAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying dependency-watchdog shoot access resources",
 			Fn:           flow.TaskFn(b.DeployDependencyWatchdogAccess).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		deployKubeControllerManager = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes controller manager",
 			Fn:           flow.TaskFn(b.DeployKubeControllerManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilGardenerResourceManagerReady),
 		})
 
 		waitUntilKubeControllerManagerReady = g.Add(flow.Task{
 			Name:         "Waiting until kube-controller-manager reports readiness",
 			Fn:           b.Shoot.Components.ControlPlane.KubeControllerManager.Wait,
-			SkipIf:       flowCtx.skipReadiness || (!saKeyRotationPreparing && !caRotationPreparing),
+			SkipIf:       flowCtx.skipReadiness || (!saKeyRotationPreparing && !caRotationPreparing) || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager),
 		})
 		createNewServiceAccountSecrets = g.Add(flow.Task{
@@ -564,7 +595,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.CreateNewServiceAccountSecrets(ctx, b.Logger, b.ShootClientSet.Client(), b.SecretsManager)
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf:       !saKeyRotationPreparing,
+			SkipIf:       !saKeyRotationPreparing || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilKubeControllerManagerReady),
 		})
 		_ = g.Add(flow.Task{
@@ -572,7 +603,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.DeleteOldServiceAccountSecrets(ctx, b.Logger, b.ShootClientSet.Client(), b.Shoot.GetInfo().Status.Credentials.Rotation.ServiceAccountKey.LastInitiationFinishedTime.Time)
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf:       v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting,
+			SkipIf:       v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilKubeControllerManagerReady),
 		})
 		waitUntilKubeRootCAConfigMapsUpdated = g.Add(flow.Task{
@@ -584,18 +615,19 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		deleteBastions = g.Add(flow.Task{
 			Name:         "Deleting Bastions",
 			Fn:           b.DeleteBastions,
-			SkipIf:       flowCtx.shootSSHAccessEnabled,
+			SkipIf:       flowCtx.shootSSHAccessEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady),
 		})
 		deployExtensionResourcesAfterKAPI = g.Add(flow.Task{
 			Name:         deployExtensionAfterKAPIMsg,
 			Fn:           flow.TaskFn(b.DeployExtensionsAfterKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, initializeShootClients),
 		})
 		waitUntilExtensionResourcesAfterKAPIReady = g.Add(flow.Task{
 			Name:         waitExtensionAfterKAPIMsg,
 			Fn:           b.Shoot.Components.Extensions.Extension.WaitAfterKubeAPIServer,
-			SkipIf:       flowCtx.skipReadiness,
+			SkipIf:       flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterKAPI),
 		})
 		waitUntilOperatingSystemConfigReady = g.AddGroup(b.ReconcileOperatingSystemConfigTaskGroup(flowCtx.skipReadiness).WithDependencies(
@@ -619,12 +651,13 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.DeployClusterIdentity(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Populating static manifests from seed to shoot",
 			Fn:           flow.TaskFn(b.PopulateStaticManifestsFromSeedToShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, waitUntilShootNamespacesReady),
 		})
 		deployMetricsServer = g.Add(flow.Task{
@@ -632,14 +665,14 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.SystemComponents.MetricsServer.Deploy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployVPNShoot = g.Add(flow.Task{
 			Name:   "Deploying vpn-shoot system component",
 			Fn:     flow.TaskFn(b.DeployVPNShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, waitUntilGardenerResourceManagerReady, deployKubeScheduler, deployVPNSeedServer, waitUntilShootNamespacesReady),
 		})
@@ -648,7 +681,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.SystemComponents.VPNShoot.Wait(ctx)
 			}),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted() || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployVPNShoot),
 		})
 		deployNodeProblemDetector = g.Add(flow.Task{
@@ -656,7 +689,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.SystemComponents.NodeProblemDetector.Deploy(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, waitUntilOperatingSystemConfigReady, waitUntilShootNamespacesReady),
 		})
@@ -670,44 +703,42 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		deployAPIServerProxy = g.Add(flow.Task{
 			Name:   "Deploying apiserver-proxy",
 			Fn:     flow.TaskFn(b.DeployAPIServerProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployBlackboxExporter = g.Add(flow.Task{
 			Name:   "Deploying blackbox-exporter",
 			Fn:     flow.TaskFn(b.ReconcileBlackboxExporterCluster).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployNodeExporter = g.Add(flow.Task{
-			Name: "Deploying node-exporter",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.ReconcileNodeExporter(ctx)
-			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			Name:   "Deploying node-exporter",
+			Fn:     flow.TaskFn(b.ReconcileNodeExporter).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployKubernetesDashboard = g.Add(flow.Task{
 			Name:   "Deploying addon Kubernetes Dashboard",
 			Fn:     flow.TaskFn(b.DeployKubernetesDashboard).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployNginxIngressAddon = g.Add(flow.Task{
 			Name:   "Deploying addon Nginx Ingress Controller",
 			Fn:     flow.TaskFn(b.DeployNginxIngressAddon).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployManagedResourceForGardenerNodeAgent = g.Add(flow.Task{
 			Name:         "Deploying managed resources for the gardener-node-agent",
 			Fn:           flow.TaskFn(b.DeployManagedResourceForGardenerNodeAgent).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
 
@@ -723,11 +754,12 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			deployKubernetesDashboard,
 			deployNginxIngressAddon,
 		)
+		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false, ""))
 
 		scaleClusterAutoscalerToZero = g.Add(flow.Task{
 			Name:         "Scaling down cluster autoscaler",
 			Fn:           flow.TaskFn(b.ScaleClusterAutoscalerToZero).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || !b.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployManagedResourceForGardenerNodeAgent),
 		})
 		_ = g.AddGroup(b.ReconcileMachineControllerManagerTaskGroup().WithDependencies(
@@ -736,55 +768,59 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			waitUntilOperatingSystemConfigReady,
 			createNewServiceAccountSecrets,
 			scaleClusterAutoscalerToZero,
+			reconcileStaticControlPlanePods,
 		))
 		waitUntilWorkerReady = g.AddGroup(b.ReconcileWorkerTaskGroup(flowCtx.skipReadiness).WithDependencies(
 			deployManagedResourceForGardenerNodeAgent,
 			waitUntilKubeRootCAConfigMapsUpdated,
+			waitUntilOperatingSystemConfigReady,
 		))
 		_ = g.Add(flow.Task{
 			Name:         "Checking if we have dual-stack pod CIDRs in nodes",
 			Fn:           b.CheckPodCIDRsInNodes,
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Scaling down machine-controller-manager",
 			Fn:           flow.TaskFn(b.ScaleMachineControllerManagerToZero).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || !b.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
 		})
 
 		deploySeedLogging = g.Add(flow.Task{
 			Name:         "Deploying shoot logging stack in Seed",
 			Fn:           flow.TaskFn(b.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initialValiDeployment, waitUntilGardenerResourceManagerReady).InsertIf(flowCtx.isHibernatingShootWithWorkers, waitUntilWorkerReady),
 		})
 		deployPlutonoForLogging = g.Add(flow.Task{
 			Name:         "Reconciling Plutono for Shoot in Seed for the logging stack",
 			Fn:           flow.TaskFn(b.DeployPlutono).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deploySeedLogging),
 		})
 		nginxLBReady = g.Add(flow.Task{
 			Name:         "Waiting until nginx ingress LoadBalancer is ready",
 			Fn:           b.WaitUntilNginxIngressServiceIsReady,
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || !v1beta1helper.NginxIngressEnabled(b.Shoot.GetInfo().Spec.Addons),
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || !v1beta1helper.NginxIngressEnabled(b.Shoot.GetInfo().Spec.Addons) || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilWorkerReady, ensureShootClusterIdentity),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Deploying nginx ingress DNS record",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
+			Fn: func(ctx context.Context) error {
 				if err := b.DeployOrDestroyIngressDNSRecord(ctx); err != nil {
 					return err
 				}
 				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskDeployDNSRecordIngress)
-			}),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			},
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(nginxLBReady),
 		})
 		waitUntilTunnelConnectionExists = g.Add(flow.Task{
 			Name:         "Waiting until the Kubernetes API server can connect to the Shoot workers",
 			Fn:           b.WaitUntilTunnelConnectionExists,
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, reconcileSystemComponents, waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
@@ -792,60 +828,68 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: func(ctx context.Context) error {
 				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)
 			},
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady, waitUntilTunnelConnectionExists),
 		})
 		deployAlertmanager = g.Add(flow.Task{
 			Name:         "Reconciling Shoot Alertmanager",
 			Fn:           flow.TaskFn(b.DeployAlertManager).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		waitUntilAlertmanagerReconciled = g.Add(flow.Task{
 			Name:         "Waiting until Shoot Alertmanager is reconciled",
 			Fn:           b.WaitForAlertManager,
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployAlertmanager),
 		})
 		deployPrometheus = g.Add(flow.Task{
 			Name:         "Reconciling Shoot Prometheus",
 			Fn:           flow.TaskFn(b.DeployPrometheus).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		waitUntilPrometheusReconciled = g.Add(flow.Task{
 			Name:         "Waiting until Shoot Prometheus is reconciled",
 			Fn:           b.WaitForPrometheus,
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployPrometheus),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying control plane blackbox-exporter",
 			Fn:           flow.TaskFn(b.ReconcileBlackboxExporterControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilTunnelConnectionExists, waitUntilWorkerReady).InsertIf(!flowCtx.hasNodesCIDR, waitUntilInfrastructureReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Reconciling kube-state-metrics for Shoot in Seed for the monitoring stack",
 			Fn:           flow.TaskFn(b.DeployKubeStateMetrics).RetryUntilTimeout(defaultInterval, 2*time.Minute),
-			SkipIf:       b.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployPrometheus, deployAlertmanager),
 		})
 		deployPlutonoForMonitoring = g.Add(flow.Task{
 			Name:         "Reconciling Plutono for Shoot in Seed for the monitoring stack",
 			Fn:           flow.TaskFn(b.DeployPlutono).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployPrometheus, deployAlertmanager),
 		})
 		waitUntilPlutonoReconciled = g.Add(flow.Task{
 			Name:         "Waiting until Plutono for Shoot in Seed is reconciled",
 			Fn:           b.WaitForPlutono,
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployPlutonoForLogging, deployPlutonoForMonitoring),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying istio-basic-auth-server",
 			Fn:           flow.TaskFn(b.Shoot.Components.ControlPlane.IstioBasicAuthServer.Deploy).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilAlertmanagerReconciled, waitUntilPrometheusReconciled, waitUntilPlutonoReconciled),
 		})
 
 		hibernateControlPlane = g.Add(flow.Task{
 			Name:         "Hibernating control plane",
 			Fn:           flow.TaskFn(b.HibernateControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
-			SkipIf:       !b.Shoot.HibernationEnabled,
+			SkipIf:       !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, deployPrometheus, deployAlertmanager, deploySeedLogging, waitUntilWorkerReady, waitUntilExtensionResourcesAfterKAPIReady, waitUntilEtcdScaledAfterRestore),
 		})
 
@@ -854,48 +898,49 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 		hibernateExtensionResourcesAfterKAPIHibernation = g.Add(flow.Task{
 			Name:         "Hibernating extension resources after kube-apiserver hibernation",
 			Fn:           flow.TaskFn(b.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       !b.Shoot.HibernationEnabled,
+			SkipIf:       !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until extension resources hibernated after kube-apiserver hibernation are ready",
 			Fn:           b.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
-			SkipIf:       flowCtx.skipReadiness || !b.Shoot.HibernationEnabled,
+			SkipIf:       flowCtx.skipReadiness || !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(hibernateExtensionResourcesAfterKAPIHibernation),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying ingress domain DNS record if hibernated",
 			Fn:           b.DestroyIngressDNSRecord,
-			SkipIf:       !b.Shoot.HibernationEnabled,
+			SkipIf:       !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying external domain DNS record if hibernated",
 			Fn:           b.DestroyExternalDNSRecord,
-			SkipIf:       !b.Shoot.HibernationEnabled,
+			SkipIf:       !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying internal domain DNS record if hibernated",
 			Fn:           b.DestroyInternalDNSRecord,
-			SkipIf:       !b.Shoot.HibernationEnabled,
+			SkipIf:       !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		deleteStaleExtensionResources = g.Add(flow.Task{
 			Name:         "Deleting stale extension resources",
 			Fn:           flow.TaskFn(b.Shoot.Components.Extensions.Extension.DeleteStaleResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until stale extension resources are deleted",
 			Fn:           b.Shoot.Components.Extensions.Extension.WaitCleanupStaleResources,
-			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deleteStaleExtensionResources),
 		})
 		deployContainerRuntimeResources = g.Add(flow.Task{
 			Name:         "Deploying container runtime resources",
 			Fn:           flow.TaskFn(b.DeployContainerRuntime).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, initializeShootClients),
 		})
 		_ = g.Add(flow.Task{
@@ -903,7 +948,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.ContainerRuntime.Wait(ctx)
 			}),
-			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness,
+			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployContainerRuntimeResources),
 		})
 		deleteStaleContainerRuntimeResources = g.Add(flow.Task{
@@ -911,89 +956,28 @@ func (r *Reconciler) setupReconcileHostedShootFlow(_ context.Context, b *botanis
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.ContainerRuntime.DeleteStaleResources(ctx)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless,
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Waiting until stale container runtime resources are deleted",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
+			Fn: func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.ContainerRuntime.WaitCleanupStaleResources(ctx)
-			}),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness,
+			},
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deleteStaleContainerRuntimeResources),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Restarting control plane pods",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
+			Fn: func(ctx context.Context) error {
 				if err := b.RestartControlPlanePods(ctx); err != nil {
 					return err
 				}
 				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskRestartControlPlanePods)
-			}),
-			SkipIf:       !flowCtx.requestControlPlanePodsRestart,
+			},
+			SkipIf:       !flowCtx.requestControlPlanePodsRestart || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager, waitUntilControlPlaneReady),
 		})
-	)
-
-	return nil
-}
-
-func (r *Reconciler) setupReconcileSelfHostedShootFlow(ctx context.Context, b *botanistpkg.Botanist, flowCtx flowContext, g *flow.Graph) error {
-	// If the self-hosted shoot is also the garden runtime cluster, then gardener-operator is taking over
-	// responsibility of some components (e.g., etcd-druid). Detect this by checking whether a Garden resource exists.
-	shootIsGarden, err := gardenletutils.ClusterIsGarden(ctx, b.SeedClientSet.Client())
-	if err != nil {
-		return fmt.Errorf("failed checking whether shoot is garden: %w", err)
-	}
-
-	var (
-		_                                = g.AddGroup(b.DeployNamespacesTaskGroup())
-		_                                = g.AddGroup(b.DeployCloudProviderSecretTaskGroup())
-		_                                = g.AddGroup(b.ReconcileCustomResourceDefinitionsTaskGroup())
-		_                                = g.AddGroup(b.ReconcileClusterResourceTaskGroup())
-		_                                = g.AddGroup(b.InitializeSecretsManagementTaskGroup())
-		reconcileGardenerResourceManager = g.AddGroup(b.ReconcileGardenerResourceManagerTaskGroup(true, shootIsGarden, flowCtx.skipReadiness))
-		_                                = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())
-		_                                = g.AddGroup(b.ReconcileInfrastructureTaskGroup(flowCtx.skipReadiness))
-		_                                = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
-		_                                = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
-		reconcileSystemComponents        = g.AddGroup(b.ReconcileSystemComponentsTaskGroup(flowCtx.kubeProxyEnabled, flowCtx.skipReadiness))
-
-		deployBackupBucketInGarden = g.Add(flow.Task{
-			Name:         "Deploying BackupBucket for ETCD data",
-			Fn:           b.Shoot.Components.BackupBucket.Deploy,
-			SkipIf:       !flowCtx.allowBackup,
-			Dependencies: flow.NewTaskIDs(reconcileGardenerResourceManager, reconcileSystemComponents),
-		})
-		waitUntilBackupBucketInGardenReconciled = g.Add(flow.Task{
-			Name:         "Waiting until the backup bucket has been reconciled",
-			Fn:           b.Shoot.Components.BackupBucket.Wait,
-			SkipIf:       flowCtx.skipReadiness || !flowCtx.allowBackup,
-			Dependencies: flow.NewTaskIDs(deployBackupBucketInGarden),
-		})
-		deployBackupEntryInGarden = g.Add(flow.Task{
-			Name:         "Deploying BackupEntry for ETCD data",
-			Fn:           b.DeployBackupEntry,
-			SkipIf:       !flowCtx.allowBackup,
-			Dependencies: flow.NewTaskIDs(waitUntilBackupBucketInGardenReconciled),
-		})
-		waitUntilBackupEntryInGardenReconciled = g.Add(flow.Task{
-			Name:         "Waiting until the backup entry has been reconciled",
-			Fn:           b.Shoot.Components.BackupEntry.Wait,
-			SkipIf:       flowCtx.skipReadiness || !flowCtx.allowBackup,
-			Dependencies: flow.NewTaskIDs(deployBackupEntryInGarden),
-		})
-
-		_ = g.AddGroup(
-			b.ReconcileETCDsTaskGroup(shootIsGarden, flowCtx.isRestoringHAControlPlane, flowCtx.skipReadiness).
-				WithDependencies(waitUntilBackupEntryInGardenReconciled),
-		)
-		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false, ""))
-		_                               = g.AddGroup(
-			b.ReconcileMachineControllerManagerTaskGroup().
-				WithDependencies(reconcileStaticControlPlanePods),
-		)
-		_ = g.AddGroup(b.ReconcileWorkerTaskGroup(flowCtx.skipReadiness))
 	)
 
 	return nil

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -314,7 +314,7 @@ func (b *Botanist) ReconcileOperatingSystemConfigTaskGroup(skipReadiness bool) f
 			TaskGroupInitializeSecretsManagement,
 			TaskGroupDeployCloudProviderSecret,
 			TaskGroupReconcileGardenerResourceManager,
-		)
+		).SkipIf(b.Shoot.IsSelfHosted() && !b.isGardenadmBootstrap())
 
 		deployOperatingSystemConfig = g.Add(flow.Task{
 			Name: "Deploying OperatingSystemConfig resources for worker pools",
@@ -633,7 +633,7 @@ func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd boo
 			TaskGroupReconcileGardenerResourceManager,
 			TaskGroupReconcileControlPlane,
 			TaskGroupReconcileETCDs,
-		)
+		).SkipIf(!b.Shoot.IsSelfHosted())
 
 		deployControlPlaneDeployments = g.Add(flow.Task{
 			Name: "Deploying control plane components as Deployments/StatefulSets and updating gardener-node-agent Secret",

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -23,6 +23,7 @@ import (
 	seedsystem "github.com/gardener/gardener/pkg/component/seed/system"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerextensions "github.com/gardener/gardener/pkg/extensions"
+	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot/helper"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -569,21 +570,22 @@ const TaskGroupReconcileETCDs flow.TaskID = "TaskGroupReconcileETCDs"
 
 // ReconcileETCDsTaskGroup returns the flow.TaskGroup for deploying etcd-druid, the ETCDs resources, and waiting for
 // their readiness.
-func (b *Botanist) ReconcileETCDsTaskGroup(shootIsGarden bool) flow.TaskGroup {
+func (b *Botanist) ReconcileETCDsTaskGroup(shootIsGarden, isRestoringHAControlPlane, skipReadiness bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileETCDs).WithDependencies(
 			TaskGroupInitializeSecretsManagement,
 			TaskGroupDeployCloudProviderSecret,
-			TaskGroupReconcileGardenerResourceManager,
 		)
 
 		deployEtcdDruid = g.Add(flow.Task{
-			Name:   "Deploying ETCD Druid",
-			Fn:     b.Shoot.Components.ControlPlane.EtcdDruid.Deploy,
-			SkipIf: shootIsGarden,
+			Name: "Deploying ETCD Druid",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.ControlPlane.EtcdDruid.Deploy(ctx)
+			},
+			SkipIf: shootIsGarden || !b.Shoot.IsSelfHosted(),
 		})
-		deployEtcds = g.Add(flow.Task{
-			Name: "Deploying main and events ETCDs",
+		configureEtcd = g.Add(flow.Task{
+			Name: "Configuring static pod control plane node IP addresses for ETCDs",
 			Fn: func(ctx context.Context) error {
 				nodes, err := b.ListControlPlaneNodes(ctx)
 				if err != nil {
@@ -597,13 +599,19 @@ func (b *Botanist) ReconcileETCDsTaskGroup(shootIsGarden bool) flow.TaskGroup {
 
 				b.Shoot.Components.ControlPlane.EtcdMain.SetStaticPodControlPlaneNodesIPAddresses(ip)
 				b.Shoot.Components.ControlPlane.EtcdEvents.SetStaticPodControlPlaneNodesIPAddresses(ip)
-				return b.DeployEtcd(ctx)
+				return nil
 			},
-			Dependencies: flow.NewTaskIDs(deployEtcdDruid),
+			SkipIf: !b.Shoot.IsSelfHosted(),
+		})
+		deployEtcds = g.Add(flow.Task{
+			Name:         "Deploying main and events ETCDs",
+			Fn:           flow.TaskFn(b.DeployEtcd).RetryUntilTimeout(5*time.Second, helper.GetEtcdDeployTimeout(b.Shoot, 30*time.Second)),
+			Dependencies: flow.NewTaskIDs(deployEtcdDruid, configureEtcd),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until main and event ETCDs have been reconciled",
 			Fn:           b.WaitUntilEtcdsReady,
+			SkipIf:       (!isRestoringHAControlPlane && b.Shoot.HibernationEnabled) || skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployEtcds),
 		})
 	)

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -145,13 +145,15 @@ const TaskGroupReconcileGardenerResourceManager flow.TaskID = "TaskGroupReconcil
 
 // ReconcileGardenerResourceManagerTaskGroup returns the flow.TaskGroup for deploying the gardener-resource-manager
 // instances. It waits for their readiness and also deploys the seed and shoot system resources afterwards.
-func (b *Botanist) ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, skipRuntimeResourceManager, skipReadiness bool) flow.TaskGroup {
+func (b *Botanist) ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, shootIsGarden, skipReadiness bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileGardenerResourceManager).WithDependencies(
 			TaskGroupDeployNamespaces,
 			TaskGroupInitializeSecretsManagement,
 			TaskGroupReconcileCustomResourceDefinitions,
 		)
+
+		skipRuntimeResourceManager = !b.Shoot.IsSelfHosted() || shootIsGarden || b.isGardenadmBootstrap()
 
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name: "Deploying gardener-resource-manager",


### PR DESCRIPTION
> [!NOTE]
> ✅ This PR depends on https://github.com/gardener/gardener/pull/15368 and https://github.com/gardener/gardener/pull/15413 which must be merged first. Hence, it remains in draft state until then.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
With this PR, the self-hosted `Shoot` flow in `gardenlet`'s `Shoot` reconciler is merged back into the big flow for hosted `Shoot`s. All tasks (except those that already were executed in the self-hosted `Shoot` flow before) are skipped for now.

Next steps:
- Iteratively go over this single, harmonized flow and activate relevant tasks also for self-hosted (i.e., remove the `SkipIf`s).
- On the way, try to find reasonable task groups to make the flow a bit thinner/better readable.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
