### PR TITLE
Fix Ingress NGINX Migration Guide for Shoot Owners

### DIFF
--- a/docs/operations/nginx_ingress.md
+++ b/docs/operations/nginx_ingress.md
@@ -246,9 +246,10 @@ spec:
     providerConfig:
       apiVersion: traefik.extensions.gardener.cloud/v1alpha1
       kind: TraefikConfig
-      replicas: 2
-      # KubernetesIngressNGINX enables NGINX annotation compatibility
-      ingressProvider: KubernetesIngressNGINX
+      spec:
+        replicas: 2
+        # KubernetesIngressNGINX enables NGINX annotation compatibility
+        ingressProvider: KubernetesIngressNGINX
 ```
 
 Apply the change and wait for the Shoot to reconcile:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/area networking
/kind bug

**What this PR does / why we need it**:

Fix Ingress NGINX Migration Guide for Shoot Owners.

The `providerConfig` of the traefik extension has a `spec` on the top-level, which was forgotten previously.

**Which issue(s) this PR fixes**:
Part of #13448

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```

/cc @DockToFuture 