### PR TITLE
Remove unnecessary webhooks from virtual garden

### DIFF
--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1381,7 +1381,7 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 
 		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(systemComponentsNamespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
-	
+
 	if r.values.PodTopologySpreadConstraintsEnabled && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewPodTopologySpreadConstraintsMutatingWebhook(r.values.NamePrefix, namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1370,8 +1370,16 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 		}
 	}
 
-	if r.values.ResponsibilityMode == ForShootOrVirtualGarden {
-		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
+	if r.values.SystemComponentsConfigWebhookEnabled && !r.values.IsWorkerless {
+		systemComponentsNamespaceSelector := namespaceSelector.DeepCopy()
+		if r.values.ResponsibilityMode == ForRuntime {
+			if systemComponentsNamespaceSelector.MatchLabels == nil {
+				systemComponentsNamespaceSelector.MatchLabels = map[string]string{}
+			}
+			systemComponentsNamespaceSelector.MatchLabels[resourcesv1alpha1.SystemComponentsConfigConsider] = "true"
+		}
+
+		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(systemComponentsNamespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
 	if r.values.EndpointSliceHintsEnabled {

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1341,46 +1341,44 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 		}
 	}
 
-	webhooks := []admissionregistrationv1.MutatingWebhook{
-		r.newProjectedTokenMountMutatingWebhook(namespaceSelector, secretServerCA, buildClientConfigFn),
+	var webhooks []admissionregistrationv1.MutatingWebhook
+
+	if !r.values.IsWorkerless {
+		webhooks = append(webhooks, r.newProjectedTokenMountMutatingWebhook(namespaceSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.HighAvailabilityConfigWebhookEnabled {
+	if r.values.HighAvailabilityConfigWebhookEnabled && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewHighAvailabilityConfigMutatingWebhook(namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.SchedulingProfile != nil && *r.values.SchedulingProfile == gardencorev1beta1.SchedulingProfileBinPacking {
+	if r.values.SchedulingProfile != nil && *r.values.SchedulingProfile == gardencorev1beta1.SchedulingProfileBinPacking && !r.values.IsWorkerless {
 		// pod scheduler name webhook should be active on all namespaces
 		webhooks = append(webhooks, NewPodSchedulerNameMutatingWebhook(&metav1.LabelSelector{}, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.DefaultSeccompProfileEnabled {
+	if r.values.DefaultSeccompProfileEnabled && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewSeccompProfileMutatingWebhook(r.values.NamePrefix, namespaceSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.KubernetesServiceHost != nil {
+	if r.values.KubernetesServiceHost != nil && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewKubernetesServiceHostMutatingWebhook(nil, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.PodKubeAPIServerLoadBalancingWebhook.Enabled {
+	if r.values.PodKubeAPIServerLoadBalancingWebhook.Enabled && !r.values.IsWorkerless {
 		for _, config := range r.values.PodKubeAPIServerLoadBalancingWebhook.Configs {
 			webhooks = append(webhooks, NewPodKubeAPIServerLoadBalancingMutatingWebhook(&metav1.LabelSelector{MatchLabels: config.NamespaceSelector}, config.ObjectSelector, config.KubeAPIServerNamePrefix, secretServerCA, buildClientConfigFn))
 		}
 	}
 
-	if r.values.SystemComponentsConfigWebhookEnabled {
-		systemComponentsNamespaceSelector := namespaceSelector.DeepCopy()
-		if r.values.ResponsibilityMode == ForRuntime {
-			if systemComponentsNamespaceSelector.MatchLabels == nil {
-				systemComponentsNamespaceSelector.MatchLabels = map[string]string{}
-			}
-			systemComponentsNamespaceSelector.MatchLabels[resourcesv1alpha1.SystemComponentsConfigConsider] = "true"
-		}
-
-		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(systemComponentsNamespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
+	if r.values.ResponsibilityMode == ForShootOrVirtualGarden {
+		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.PodTopologySpreadConstraintsEnabled {
+	if r.values.EndpointSliceHintsEnabled {
+		webhooks = append(webhooks, NewEndpointSliceHintsMutatingWebhook(namespaceSelector, secretServerCA, buildClientConfigFn))
+	}
+
+	if r.values.PodTopologySpreadConstraintsEnabled && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewPodTopologySpreadConstraintsMutatingWebhook(r.values.NamePrefix, namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
@@ -2182,6 +2180,8 @@ func disableControllersAndWebhooksForWorkerlessShoot(config *resourcemanagerconf
 	config.Webhooks.HighAvailabilityConfig.Enabled = false
 	config.Webhooks.PodTopologySpreadConstraints.Enabled = false
 	config.Webhooks.KubernetesServiceHost.Enabled = false
+	config.Webhooks.SeccompProfile.Enabled = false
+	config.Webhooks.PodKubeAPIServerLoadBalancing.Enabled = false
 }
 
 func (r *resourceManager) healthPort() int32 {

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1381,11 +1381,7 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 
 		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(systemComponentsNamespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
-
-	if r.values.EndpointSliceHintsEnabled {
-		webhooks = append(webhooks, NewEndpointSliceHintsMutatingWebhook(namespaceSelector, secretServerCA, buildClientConfigFn))
-	}
-
+	
 	if r.values.PodTopologySpreadConstraintsEnabled && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewPodTopologySpreadConstraintsMutatingWebhook(r.values.NamePrefix, namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -371,12 +371,13 @@ func (r *resourceManager) Deploy(ctx context.Context) error {
 		}
 	}
 
+	config := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{}
 	configMap := r.emptyConfigMap()
 
 	fns := []flow.TaskFn{
 		r.ensureServiceAccount,
 		func(ctx context.Context) error {
-			return r.ensureConfigMap(ctx, configMap)
+			return r.ensureConfigMap(ctx, config, configMap)
 		},
 		r.ensureRBAC,
 		r.ensureService,
@@ -385,7 +386,9 @@ func (r *resourceManager) Deploy(ctx context.Context) error {
 		},
 		// Webhook configs must be applied directly after the deployment to avoid a situation where the GRM deployment
 		// is rolled out after a certificate (CA) rotation but the webhook configurations are not yet updated.
-		r.ensureWebhookConfiguration,
+		func(ctx context.Context) error {
+			return r.ensureWebhookConfiguration(ctx, config)
+		},
 		r.ensurePodDisruptionBudget,
 		r.ensureVPA,
 		r.ensureServiceMonitor,
@@ -542,8 +545,8 @@ func (r *resourceManager) emptyClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: name}}
 }
 
-func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1.ConfigMap) error {
-	config := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{
+func (r *resourceManager) ensureConfigMap(ctx context.Context, config *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration, configMap *corev1.ConfigMap) error {
+	*config = resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{
 		LeaderElection: componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 			LeaderElect:       new(true),
 			ResourceName:      r.values.NamePrefix + v1beta1constants.DeploymentNameGardenerResourceManager,
@@ -1210,18 +1213,18 @@ func (r *resourceManager) emptyServiceMonitor() *monitoringv1.ServiceMonitor {
 	return &monitoringv1.ServiceMonitor{ObjectMeta: monitoringutils.ConfigObjectMeta(r.values.NamePrefix+"gardener-resource-manager", r.namespace, r.getPrometheusLabel())}
 }
 
-func (r *resourceManager) ensureWebhookConfiguration(ctx context.Context) error {
+func (r *resourceManager) ensureWebhookConfiguration(ctx context.Context, config *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration) error {
 	if r.values.ResponsibilityMode == ForShootOrVirtualGarden {
-		return r.ensureShootResources(ctx)
+		return r.ensureShootResources(ctx, config)
 	}
 
-	if err := r.ensureMutatingWebhookConfiguration(ctx); err != nil {
+	if err := r.ensureMutatingWebhookConfiguration(ctx, config); err != nil {
 		return err
 	}
 	return r.ensureValidatingWebhookConfiguration(ctx)
 }
 
-func (r *resourceManager) ensureMutatingWebhookConfiguration(ctx context.Context) error {
+func (r *resourceManager) ensureMutatingWebhookConfiguration(ctx context.Context, config *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration) error {
 	if SkipWebhookDeployment {
 		return nil
 	}
@@ -1237,7 +1240,7 @@ func (r *resourceManager) ensureMutatingWebhookConfiguration(ctx context.Context
 		mutatingWebhookConfiguration.Labels = utils.MergeStringMaps(r.appLabel(), map[string]string{
 			v1beta1constants.LabelExcludeWebhookFromRemediation: "true",
 		})
-		mutatingWebhookConfiguration.Webhooks = r.newMutatingWebhookConfigurationWebhooks(secretServerCA, r.buildWebhookClientConfig)
+		mutatingWebhookConfiguration.Webhooks = r.newMutatingWebhookConfigurationWebhooks(secretServerCA, r.buildWebhookClientConfig, config)
 		return nil
 	})
 	return err
@@ -1277,7 +1280,7 @@ func (r *resourceManager) emptyValidatingWebhookConfiguration() *admissionregist
 	return &admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: r.values.NamePrefix + v1beta1constants.DeploymentNameGardenerResourceManager, Namespace: r.namespace}}
 }
 
-func (r *resourceManager) ensureShootResources(ctx context.Context) error {
+func (r *resourceManager) ensureShootResources(ctx context.Context, config *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration) error {
 	secretServerCA, found := r.secretsManager.Get(r.values.SecretNameServerCA)
 	if !found {
 		return fmt.Errorf("secret %q not found", r.values.SecretNameServerCA)
@@ -1308,7 +1311,7 @@ func (r *resourceManager) ensureShootResources(ctx context.Context) error {
 
 	mutatingWebhookConfiguration := r.emptyMutatingWebhookConfiguration()
 	mutatingWebhookConfiguration.Labels = r.appLabel()
-	mutatingWebhookConfiguration.Webhooks = r.newMutatingWebhookConfigurationWebhooks(secretServerCA, r.buildWebhookClientConfig)
+	mutatingWebhookConfiguration.Webhooks = r.newMutatingWebhookConfigurationWebhooks(secretServerCA, r.buildWebhookClientConfig, config)
 
 	data, err := registry.AddAllAndSerialize(
 		mutatingWebhookConfiguration,
@@ -1324,9 +1327,11 @@ func (r *resourceManager) newShootAccessSecret() *gardenerutils.AccessSecret {
 	return gardenerutils.NewShootAccessSecret(SecretNameShootAccess, r.namespace)
 }
 
+// Make sure to update disableControllersAndWebhooksForWorkerlessShoot when adding webhooks to this method which are not relevant for workerless shoots.
 func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 	secretServerCA *corev1.Secret,
 	buildClientConfigFn func(*corev1.Secret, string) admissionregistrationv1.WebhookClientConfig,
+	config *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration,
 ) []admissionregistrationv1.MutatingWebhook {
 	var (
 		namespaceSelector = r.buildWebhookNamespaceSelector()
@@ -1343,34 +1348,34 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 
 	var webhooks []admissionregistrationv1.MutatingWebhook
 
-	if !r.values.IsWorkerless {
+	if config.Webhooks.ProjectedTokenMount.Enabled {
 		webhooks = append(webhooks, r.newProjectedTokenMountMutatingWebhook(namespaceSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.HighAvailabilityConfigWebhookEnabled && !r.values.IsWorkerless {
+	if config.Webhooks.HighAvailabilityConfig.Enabled {
 		webhooks = append(webhooks, NewHighAvailabilityConfigMutatingWebhook(namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.SchedulingProfile != nil && *r.values.SchedulingProfile == gardencorev1beta1.SchedulingProfileBinPacking && !r.values.IsWorkerless {
+	if config.Webhooks.PodSchedulerName.Enabled && r.values.SchedulingProfile != nil {
 		// pod scheduler name webhook should be active on all namespaces
 		webhooks = append(webhooks, NewPodSchedulerNameMutatingWebhook(&metav1.LabelSelector{}, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.DefaultSeccompProfileEnabled && !r.values.IsWorkerless {
+	if config.Webhooks.SeccompProfile.Enabled {
 		webhooks = append(webhooks, NewSeccompProfileMutatingWebhook(r.values.NamePrefix, namespaceSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.KubernetesServiceHost != nil && !r.values.IsWorkerless {
+	if config.Webhooks.KubernetesServiceHost.Enabled && r.values.KubernetesServiceHost != nil {
 		webhooks = append(webhooks, NewKubernetesServiceHostMutatingWebhook(nil, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.PodKubeAPIServerLoadBalancingWebhook.Enabled && !r.values.IsWorkerless {
+	if config.Webhooks.PodKubeAPIServerLoadBalancing.Enabled {
 		for _, config := range r.values.PodKubeAPIServerLoadBalancingWebhook.Configs {
 			webhooks = append(webhooks, NewPodKubeAPIServerLoadBalancingMutatingWebhook(&metav1.LabelSelector{MatchLabels: config.NamespaceSelector}, config.ObjectSelector, config.KubeAPIServerNamePrefix, secretServerCA, buildClientConfigFn))
 		}
 	}
 
-	if r.values.SystemComponentsConfigWebhookEnabled && !r.values.IsWorkerless {
+	if config.Webhooks.SystemComponentsConfig.Enabled {
 		systemComponentsNamespaceSelector := namespaceSelector.DeepCopy()
 		if r.values.ResponsibilityMode == ForRuntime {
 			if systemComponentsNamespaceSelector.MatchLabels == nil {
@@ -1382,11 +1387,11 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(systemComponentsNamespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.PodTopologySpreadConstraintsEnabled && !r.values.IsWorkerless {
+	if config.Webhooks.PodTopologySpreadConstraints.Enabled {
 		webhooks = append(webhooks, NewPodTopologySpreadConstraintsMutatingWebhook(r.values.NamePrefix, namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.VPAInPlaceUpdatesEnabled {
+	if config.Webhooks.VPAInPlaceUpdates.Enabled {
 		webhooks = append(webhooks, NewInPlaceUpdatesWebhook(namespaceSelector, secretServerCA, buildClientConfigFn))
 	}
 
@@ -2186,6 +2191,8 @@ func disableControllersAndWebhooksForWorkerlessShoot(config *resourcemanagerconf
 	config.Webhooks.KubernetesServiceHost.Enabled = false
 	config.Webhooks.SeccompProfile.Enabled = false
 	config.Webhooks.PodKubeAPIServerLoadBalancing.Enabled = false
+	config.Webhooks.VPAInPlaceUpdates.Enabled = false
+	config.Webhooks.NodeAgentAuthorizer.Enabled = false
 }
 
 func (r *resourceManager) healthPort() int32 {

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1327,7 +1327,6 @@ func (r *resourceManager) newShootAccessSecret() *gardenerutils.AccessSecret {
 	return gardenerutils.NewShootAccessSecret(SecretNameShootAccess, r.namespace)
 }
 
-// Make sure to update disableControllersAndWebhooksForWorkerlessShoot when adding webhooks to this method which are not relevant for workerless shoots.
 func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 	secretServerCA *corev1.Secret,
 	buildClientConfigFn func(*corev1.Secret, string) admissionregistrationv1.WebhookClientConfig,

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1356,7 +1356,7 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 		webhooks = append(webhooks, NewHighAvailabilityConfigMutatingWebhook(namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if config.Webhooks.PodSchedulerName.Enabled && r.values.SchedulingProfile != nil {
+	if config.Webhooks.PodSchedulerName.Enabled {
 		// pod scheduler name webhook should be active on all namespaces
 		webhooks = append(webhooks, NewPodSchedulerNameMutatingWebhook(&metav1.LabelSelector{}, secretServerCA, buildClientConfigFn))
 	}
@@ -1365,7 +1365,7 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 		webhooks = append(webhooks, NewSeccompProfileMutatingWebhook(r.values.NamePrefix, namespaceSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if config.Webhooks.KubernetesServiceHost.Enabled && r.values.KubernetesServiceHost != nil {
+	if config.Webhooks.KubernetesServiceHost.Enabled {
 		webhooks = append(webhooks, NewKubernetesServiceHostMutatingWebhook(nil, secretServerCA, buildClientConfigFn))
 	}
 

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -457,12 +457,12 @@ var _ = Describe("ResourceManager", func() {
 						Enabled: false,
 					},
 					NodeAgentAuthorizer: resourcemanagerconfigv1alpha1.NodeAgentAuthorizerWebhookConfig{
-						Enabled:                true,
+						Enabled:                !isWorkerless,
 						AuthorizeWithSelectors: new(true),
 						MachineNamespace:       cfg.MachineNamespace,
 					},
 					VPAInPlaceUpdates: resourcemanagerconfigv1alpha1.VPAInPlaceUpdatesConfig{
-						Enabled: true,
+						Enabled: !isWorkerless,
 					},
 				},
 			}
@@ -1279,11 +1279,11 @@ metadata:
   labels:
     app: gardener-resource-manager
   name: gardener-resource-manager-shoot
-  namespace: fake-ns
-webhooks:`
+  namespace: fake-ns`
 
 			if !cfg.IsWorkerless {
 				out += `
+webhooks:
 - admissionReviewVersions:
   - v1beta1
   - v1
@@ -1580,7 +1580,8 @@ webhooks:`
   sideEffects: None
   timeoutSeconds: 10`
 			}
-			out += `
+			if !cfg.IsWorkerless {
+				out += `
 - admissionReviewVersions:
   - v1beta1
   - v1
@@ -1614,6 +1615,7 @@ webhooks:`
   sideEffects: None
   timeoutSeconds: 10
 `
+			}
 			return out
 		}
 
@@ -2532,6 +2534,20 @@ subjects:
 				actualConfigMap.ResourceVersion = ""
 				configMap.ResourceVersion = ""
 				Expect(actualConfigMap).To(DeepEqual(configMap))
+
+				By("verify that all workerless-disabled webhooks are turned off in the component config")
+				actualConfig := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{}
+				Expect(runtime.DecodeInto(codec, []byte(actualConfigMap.Data["config.yaml"]), actualConfig)).To(Succeed())
+				Expect(actualConfig.Webhooks.PodSchedulerName.Enabled).To(BeFalse())
+				Expect(actualConfig.Webhooks.SystemComponentsConfig.Enabled).To(BeFalse())
+				Expect(actualConfig.Webhooks.ProjectedTokenMount.Enabled).To(BeFalse())
+				Expect(actualConfig.Webhooks.HighAvailabilityConfig.Enabled).To(BeFalse())
+				Expect(actualConfig.Webhooks.PodTopologySpreadConstraints.Enabled).To(BeFalse())
+				Expect(actualConfig.Webhooks.SeccompProfile.Enabled).To(BeFalse())
+				Expect(actualConfig.Webhooks.KubernetesServiceHost.Enabled).To(BeFalse())
+				Expect(actualConfig.Webhooks.PodKubeAPIServerLoadBalancing.Enabled).To(BeFalse())
+				Expect(actualConfig.Webhooks.VPAInPlaceUpdates.Enabled).To(BeFalse())
+				Expect(actualConfig.Webhooks.NodeAgentAuthorizer.Enabled).To(BeFalse())
 
 				actualClusterRole := &rbacv1.ClusterRole{}
 				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: clusterRoleName}, actualClusterRole)).To(Succeed())

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -1280,7 +1280,10 @@ metadata:
     app: gardener-resource-manager
   name: gardener-resource-manager-shoot
   namespace: fake-ns
-webhooks:
+webhooks:`
+
+			if !cfg.IsWorkerless {
+				out += `
 - admissionReviewVersions:
   - v1beta1
   - v1
@@ -1426,6 +1429,8 @@ webhooks:
     - pods
   sideEffects: None
   timeoutSeconds: 2`
+			}
+
 			if cfg.PodKubeAPIServerLoadBalancingWebhook.Enabled {
 				out += `
 - admissionReviewVersions:
@@ -1491,7 +1496,9 @@ webhooks:
   sideEffects: None
   timeoutSeconds: 10`
 			}
-			out += `
+
+			if !cfg.IsWorkerless {
+				out += `
 - admissionReviewVersions:
   - v1beta1
   - v1
@@ -1528,7 +1535,9 @@ webhooks:
     - pods
   sideEffects: None
   timeoutSeconds: 10`
-			if matchLabelKeysInPodTopologySpreadFeatureGateDisabled {
+			}
+
+			if matchLabelKeysInPodTopologySpreadFeatureGateDisabled && !cfg.IsWorkerless {
 				out += `
 - admissionReviewVersions:
   - v1beta1
@@ -2481,6 +2490,26 @@ subjects:
 
 				resourceManager = New(fakeClient, deployNamespace, sm, cfg)
 				resourceManager.SetSecrets(secrets)
+
+				compressedData, err := test.BrotliCompressionForManifests(mutatingWebhookConfigurationYAML(), clusterRoleBindingTargetYAML)
+				Expect(err).NotTo(HaveOccurred())
+
+				managedResourceSecret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "managedresource-shoot-core-gardener-resource-manager",
+						Namespace: deployNamespace,
+					},
+					Type: corev1.SecretTypeOpaque,
+					Data: map[string][]byte{
+						"data.yaml.br": compressedData,
+					},
+				}
+				utilruntime.Must(kubernetesutils.MakeUnique(managedResourceSecret))
+
+				managedResource.Spec.SecretRefs = []corev1.LocalObjectReference{
+					{Name: managedResourceSecret.Name},
+				}
+				utilruntime.Must(references.InjectAnnotations(managedResource))
 			})
 
 			It("should disable controllers and webhooks properly in resource manager configuration", func() {

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -134,6 +134,7 @@ var _ = Describe("ResourceManager", func() {
 		managedResource                                      *resourcesv1alpha1.ManagedResource
 		matchLabelKeysInPodTopologySpreadFeatureGateDisabled bool
 		fetchAndValidateWebhookConfiguration                 func(actualConfigMap *corev1.ConfigMap, actualManagedResourceSecret *corev1.Secret)
+		validateWebhookConfiguration                         func(actualConfig *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration, actualMutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, actualValidatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration)
 	)
 
 	BeforeEach(func() {
@@ -2096,7 +2097,7 @@ subjects:
 		}
 		utilruntime.Must(references.InjectAnnotations(managedResource))
 
-		validateWebhookConfiguration := func(
+		validateWebhookConfiguration = func(
 			actualConfig *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration,
 			actualMutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration,
 			actualValidatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration) {
@@ -2162,47 +2163,30 @@ subjects:
 			actualConfigMap *corev1.ConfigMap,
 			actualManagedResourceSecret *corev1.Secret,
 		) {
+			if cfg.ResponsibilityMode != ForShootOrVirtualGarden {
+				Fail("unexpected responsibility mode: " + string(cfg.ResponsibilityMode))
+			}
+
 			actualConfig := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{}
 			Expect(runtime.DecodeInto(codec, []byte(actualConfigMap.Data["config.yaml"]), actualConfig)).To(Succeed())
 
 			actualMutatingWebhookConfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{}
 			actualValidatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-
-			switch cfg.ResponsibilityMode {
-			case ForRuntime:
-				{
-					if actualManagedResourceSecret != nil {
-						Fail("actualManagedResourceSecret should be nil for ForRuntime responsibility mode")
-					}
-					Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, actualMutatingWebhookConfiguration)).To(Succeed())
-					Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, actualValidatingWebhookConfiguration)).To(Succeed())
-
-					break
+			manifests, err := test.ExtractManifestsFromManagedResourceData(actualManagedResourceSecret.Data)
+			Expect(err).NotTo(HaveOccurred())
+			for _, manifest := range manifests {
+				typeMeta := &metav1.TypeMeta{}
+				if err := yaml.Unmarshal([]byte(manifest), typeMeta); err != nil {
+					continue
 				}
-			case ForShootOrVirtualGarden:
-				{
-					manifests, err := test.ExtractManifestsFromManagedResourceData(actualManagedResourceSecret.Data)
-					Expect(err).NotTo(HaveOccurred())
-
-					for _, manifest := range manifests {
-						typeMeta := &metav1.TypeMeta{}
-						if err := yaml.Unmarshal([]byte(manifest), typeMeta); err != nil {
-							continue
-						}
-						switch typeMeta.Kind {
-						case "MutatingWebhookConfiguration":
-							Expect(runtime.DecodeInto(codec, []byte(manifest), actualMutatingWebhookConfiguration)).To(Succeed())
-						case "ValidatingWebhookConfiguration":
-							Expect(runtime.DecodeInto(codec, []byte(manifest), actualValidatingWebhookConfiguration)).To(Succeed())
-						}
-					}
-					break
-				}
-			default:
-				{
-					Fail("unexpected responsibility mode: " + string(cfg.ResponsibilityMode))
+				switch typeMeta.Kind {
+				case "MutatingWebhookConfiguration":
+					Expect(runtime.DecodeInto(codec, []byte(manifest), actualMutatingWebhookConfiguration)).To(Succeed())
+				case "ValidatingWebhookConfiguration":
+					Expect(runtime.DecodeInto(codec, []byte(manifest), actualValidatingWebhookConfiguration)).To(Succeed())
 				}
 			}
+
 			validateWebhookConfiguration(actualConfig, actualMutatingWebhookConfiguration, actualValidatingWebhookConfiguration)
 		}
 	})
@@ -2829,7 +2813,10 @@ subjects:
 				validatingWebhookConfiguration.ResourceVersion = ""
 				Expect(actualValidatingWebhookConfiguration).To(DeepEqual(validatingWebhookConfiguration))
 
-				fetchAndValidateWebhookConfiguration(actualConfigMap, nil)
+				actualConfig := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{}
+				Expect(runtime.DecodeInto(codec, []byte(actualConfigMap.Data["config.yaml"]), actualConfig)).To(Succeed())
+
+				validateWebhookConfiguration(actualConfig, actualMutatingWebhookConfiguration, actualValidatingWebhookConfiguration)
 			})
 		})
 	})

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -133,8 +133,6 @@ var _ = Describe("ResourceManager", func() {
 		managedResourceSecret                                *corev1.Secret
 		managedResource                                      *resourcesv1alpha1.ManagedResource
 		matchLabelKeysInPodTopologySpreadFeatureGateDisabled bool
-		fetchAndValidateWebhookConfiguration                 func(actualConfigMap *corev1.ConfigMap, actualManagedResourceSecret *corev1.Secret)
-		validateWebhookConfiguration                         func(actualConfig *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration, actualMutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, actualValidatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration)
 	)
 
 	BeforeEach(func() {
@@ -2097,98 +2095,6 @@ subjects:
 		}
 		utilruntime.Must(references.InjectAnnotations(managedResource))
 
-		validateWebhookConfiguration = func(
-			actualConfig *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration,
-			actualMutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration,
-			actualValidatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration) {
-
-			By("Verify that the mutating webhook configuration is consistent")
-
-			expectedNumEnabledMutatingWebhooks := 0
-			if actualConfig.Webhooks.HighAvailabilityConfig.Enabled {
-				expectedNumEnabledMutatingWebhooks++
-				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "high-availability-config.resources.gardener.cloud")))
-			}
-			if actualConfig.Webhooks.KubernetesServiceHost.Enabled {
-				expectedNumEnabledMutatingWebhooks++
-				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "kubernetes-service-host.resources.gardener.cloud")))
-			}
-			if actualConfig.Webhooks.SystemComponentsConfig.Enabled {
-				expectedNumEnabledMutatingWebhooks++
-				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "system-components-config.resources.gardener.cloud")))
-			}
-			if actualConfig.Webhooks.PodKubeAPIServerLoadBalancing.Enabled {
-				expectedNumEnabledMutatingWebhooks += len(cfg.PodKubeAPIServerLoadBalancingWebhook.Configs)
-				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", ContainSubstring("kube-apiserver-load-balancing.resources.gardener.cloud"))))
-			}
-			if actualConfig.Webhooks.PodSchedulerName.Enabled {
-				expectedNumEnabledMutatingWebhooks++
-				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "pod-scheduler-name.resources.gardener.cloud")))
-			}
-			if actualConfig.Webhooks.PodTopologySpreadConstraints.Enabled {
-				expectedNumEnabledMutatingWebhooks++
-				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "pod-topology-spread-constraints.resources.gardener.cloud")))
-			}
-			if actualConfig.Webhooks.ProjectedTokenMount.Enabled {
-				expectedNumEnabledMutatingWebhooks++
-				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "projected-token-mount.resources.gardener.cloud")))
-			}
-			if actualConfig.Webhooks.SeccompProfile.Enabled {
-				expectedNumEnabledMutatingWebhooks++
-				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "seccomp-profile.resources.gardener.cloud")))
-			}
-			if actualConfig.Webhooks.VPAInPlaceUpdates.Enabled {
-				expectedNumEnabledMutatingWebhooks++
-				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "vpa-in-place-updates.resources.gardener.cloud")))
-			}
-			Expect(actualMutatingWebhookConfiguration.Webhooks).To(HaveLen(expectedNumEnabledMutatingWebhooks))
-
-			expectedNumEnabledValidatingWebhooks := 0
-			if actualConfig.Webhooks.CRDDeletionProtection.Enabled {
-				expectedNumEnabledValidatingWebhooks += 2 // crd and cr, see NewCRDDeletionProtectionValidatingWebhooks in pkg/component/gardener/resourcemanager/resource_manager.go
-
-				Expect(actualValidatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "crd-deletion-protection.resources.gardener.cloud")))
-				Expect(actualValidatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "cr-deletion-protection.resources.gardener.cloud")))
-			}
-			if actualConfig.Webhooks.ExtensionValidation.Enabled {
-				expectedNumEnabledValidatingWebhooks += 13 // the list of length 13 is hardcoded in NewExtensionValidationValidatingWebhooks, see pkg/component/gardener/resourcemanager/resource_manager.go
-				Expect(actualValidatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", ContainSubstring("validation.extensions."))))
-			}
-			Expect(actualValidatingWebhookConfiguration.Webhooks).To(HaveLen(expectedNumEnabledValidatingWebhooks))
-
-			// actualConfig.Webhooks.NodeAgentAuthorizer is an authorization webhook, which works differently and is not tested here.
-		}
-
-		fetchAndValidateWebhookConfiguration = func(
-			actualConfigMap *corev1.ConfigMap,
-			actualManagedResourceSecret *corev1.Secret,
-		) {
-			if cfg.ResponsibilityMode != ForShootOrVirtualGarden {
-				Fail("unexpected responsibility mode: " + string(cfg.ResponsibilityMode))
-			}
-
-			actualConfig := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{}
-			Expect(runtime.DecodeInto(codec, []byte(actualConfigMap.Data["config.yaml"]), actualConfig)).To(Succeed())
-
-			actualMutatingWebhookConfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{}
-			actualValidatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-			manifests, err := test.ExtractManifestsFromManagedResourceData(actualManagedResourceSecret.Data)
-			Expect(err).NotTo(HaveOccurred())
-			for _, manifest := range manifests {
-				typeMeta := &metav1.TypeMeta{}
-				if err := yaml.Unmarshal([]byte(manifest), typeMeta); err != nil {
-					continue
-				}
-				switch typeMeta.Kind {
-				case "MutatingWebhookConfiguration":
-					Expect(runtime.DecodeInto(codec, []byte(manifest), actualMutatingWebhookConfiguration)).To(Succeed())
-				case "ValidatingWebhookConfiguration":
-					Expect(runtime.DecodeInto(codec, []byte(manifest), actualValidatingWebhookConfiguration)).To(Succeed())
-				}
-			}
-
-			validateWebhookConfiguration(actualConfig, actualMutatingWebhookConfiguration, actualValidatingWebhookConfiguration)
-		}
 	})
 
 	Describe("#Deploy", func() {
@@ -2257,7 +2163,7 @@ subjects:
 						actualManagedResourceSecret := &corev1.Secret{}
 						Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: managedResourceSecret.Name}, actualManagedResourceSecret)).To(Succeed())
 
-						fetchAndValidateWebhookConfiguration(configMap, actualManagedResourceSecret)
+						fetchAndValidateWebhookConfiguration(configMap, actualManagedResourceSecret, &cfg)
 
 						actualRole := &rbacv1.Role{}
 						Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: watchedNamespace, Name: "gardener-resource-manager"}, actualRole)).To(Succeed())
@@ -2366,7 +2272,7 @@ subjects:
 						configMap.ResourceVersion = ""
 						Expect(actualConfigMap).To(DeepEqual(configMap))
 
-						fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret)
+						fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret, &cfg)
 
 						actualManagedResource := &resourcesv1alpha1.ManagedResource{}
 						Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, actualManagedResource)).To(Succeed())
@@ -2455,7 +2361,7 @@ subjects:
 					managedResourceSecret.ResourceVersion = ""
 					Expect(actualManagedResourceSecret).To(DeepEqual(managedResourceSecret))
 
-					fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret)
+					fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret, &cfg)
 
 					actualManagedResource := &resourcesv1alpha1.ManagedResource{}
 					Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, actualManagedResource)).To(Succeed())
@@ -2547,7 +2453,7 @@ subjects:
 				managedResourceSecret.ResourceVersion = ""
 				Expect(actualManagedResourceSecret).To(DeepEqual(managedResourceSecret))
 
-				fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret)
+				fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret, &cfg)
 
 				actualManagedResource := &resourcesv1alpha1.ManagedResource{}
 				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, actualManagedResource)).To(Succeed())
@@ -2695,7 +2601,7 @@ subjects:
 				managedResourceSecret.ResourceVersion = ""
 				Expect(actualManagedResourceSecret).To(DeepEqual(managedResourceSecret))
 
-				fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret)
+				fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret, &cfg)
 
 				actualManagedResource := &resourcesv1alpha1.ManagedResource{}
 				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, actualManagedResource)).To(Succeed())
@@ -2816,7 +2722,7 @@ subjects:
 				actualConfig := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{}
 				Expect(runtime.DecodeInto(codec, []byte(actualConfigMap.Data["config.yaml"]), actualConfig)).To(Succeed())
 
-				validateWebhookConfiguration(actualConfig, actualMutatingWebhookConfiguration, actualValidatingWebhookConfiguration)
+				validateWebhookConfiguration(actualConfig, actualMutatingWebhookConfiguration, actualValidatingWebhookConfiguration, &cfg)
 			})
 		})
 	})
@@ -3296,4 +3202,98 @@ func init() {
 	)
 
 	codec = serializer.NewCodecFactory(scheme).CodecForVersions(ser, ser, versions, versions)
+}
+
+func validateWebhookConfiguration(
+	actualConfig *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration,
+	actualMutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration,
+	actualValidatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration,
+	cfg *Values,
+) {
+	GinkgoHelper()
+	By("Verify that the mutating webhook configuration is consistent")
+
+	expectedNumEnabledMutatingWebhooks := 0
+	if actualConfig.Webhooks.HighAvailabilityConfig.Enabled {
+		expectedNumEnabledMutatingWebhooks++
+		Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "high-availability-config.resources.gardener.cloud")))
+	}
+	if actualConfig.Webhooks.KubernetesServiceHost.Enabled {
+		expectedNumEnabledMutatingWebhooks++
+		Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "kubernetes-service-host.resources.gardener.cloud")))
+	}
+	if actualConfig.Webhooks.SystemComponentsConfig.Enabled {
+		expectedNumEnabledMutatingWebhooks++
+		Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "system-components-config.resources.gardener.cloud")))
+	}
+	if actualConfig.Webhooks.PodKubeAPIServerLoadBalancing.Enabled {
+		expectedNumEnabledMutatingWebhooks += len(cfg.PodKubeAPIServerLoadBalancingWebhook.Configs)
+		Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", ContainSubstring("kube-apiserver-load-balancing.resources.gardener.cloud"))))
+	}
+	if actualConfig.Webhooks.PodSchedulerName.Enabled {
+		expectedNumEnabledMutatingWebhooks++
+		Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "pod-scheduler-name.resources.gardener.cloud")))
+	}
+	if actualConfig.Webhooks.PodTopologySpreadConstraints.Enabled {
+		expectedNumEnabledMutatingWebhooks++
+		Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "pod-topology-spread-constraints.resources.gardener.cloud")))
+	}
+	if actualConfig.Webhooks.ProjectedTokenMount.Enabled {
+		expectedNumEnabledMutatingWebhooks++
+		Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "projected-token-mount.resources.gardener.cloud")))
+	}
+	if actualConfig.Webhooks.SeccompProfile.Enabled {
+		expectedNumEnabledMutatingWebhooks++
+		Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "seccomp-profile.resources.gardener.cloud")))
+	}
+	if actualConfig.Webhooks.VPAInPlaceUpdates.Enabled {
+		expectedNumEnabledMutatingWebhooks++
+		Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "vpa-in-place-updates.resources.gardener.cloud")))
+	}
+	Expect(actualMutatingWebhookConfiguration.Webhooks).To(HaveLen(expectedNumEnabledMutatingWebhooks))
+
+	expectedNumEnabledValidatingWebhooks := 0
+	if actualConfig.Webhooks.CRDDeletionProtection.Enabled {
+		expectedNumEnabledValidatingWebhooks += 2 // crd and cr, see NewCRDDeletionProtectionValidatingWebhooks in pkg/component/gardener/resourcemanager/resource_manager.go
+
+		Expect(actualValidatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "crd-deletion-protection.resources.gardener.cloud")))
+		Expect(actualValidatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "cr-deletion-protection.resources.gardener.cloud")))
+	}
+	if actualConfig.Webhooks.ExtensionValidation.Enabled {
+		expectedNumEnabledValidatingWebhooks += 13 // the list of length 13 is hardcoded in NewExtensionValidationValidatingWebhooks, see pkg/component/gardener/resourcemanager/resource_manager.go
+		Expect(actualValidatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", ContainSubstring("validation.extensions."))))
+	}
+	Expect(actualValidatingWebhookConfiguration.Webhooks).To(HaveLen(expectedNumEnabledValidatingWebhooks))
+
+	// actualConfig.Webhooks.NodeAgentAuthorizer is an authorization webhook, which works differently and is not tested here.
+}
+
+func fetchAndValidateWebhookConfiguration(actualConfigMap *corev1.ConfigMap, actualManagedResourceSecret *corev1.Secret, cfg *Values) {
+	GinkgoHelper()
+
+	if cfg.ResponsibilityMode != ForShootOrVirtualGarden {
+		Fail("unexpected responsibility mode: " + string(cfg.ResponsibilityMode))
+	}
+
+	actualConfig := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{}
+	Expect(runtime.DecodeInto(codec, []byte(actualConfigMap.Data["config.yaml"]), actualConfig)).To(Succeed())
+
+	actualMutatingWebhookConfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{}
+	actualValidatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+	manifests, err := test.ExtractManifestsFromManagedResourceData(actualManagedResourceSecret.Data)
+	Expect(err).NotTo(HaveOccurred())
+	for _, manifest := range manifests {
+		typeMeta := &metav1.TypeMeta{}
+		if err := yaml.Unmarshal([]byte(manifest), typeMeta); err != nil {
+			continue
+		}
+		switch typeMeta.Kind {
+		case "MutatingWebhookConfiguration":
+			Expect(runtime.DecodeInto(codec, []byte(manifest), actualMutatingWebhookConfiguration)).To(Succeed())
+		case "ValidatingWebhookConfiguration":
+			Expect(runtime.DecodeInto(codec, []byte(manifest), actualValidatingWebhookConfiguration)).To(Succeed())
+		}
+	}
+
+	validateWebhookConfiguration(actualConfig, actualMutatingWebhookConfiguration, actualValidatingWebhookConfiguration, cfg)
 }

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -2140,7 +2140,7 @@ subjects:
 				expectedNumEnabledMutatingWebhooks++
 				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "vpa-in-place-updates.resources.gardener.cloud")))
 			}
-			Expect(len(actualMutatingWebhookConfiguration.Webhooks)).To(Equal(expectedNumEnabledMutatingWebhooks))
+			Expect(actualMutatingWebhookConfiguration.Webhooks).To(HaveLen(expectedNumEnabledMutatingWebhooks))
 
 			expectedNumEnabledValidatingWebhooks := 0
 			if actualConfig.Webhooks.CRDDeletionProtection.Enabled {
@@ -2153,7 +2153,7 @@ subjects:
 				expectedNumEnabledValidatingWebhooks += 13 // the list of length 13 is hardcoded in NewExtensionValidationValidatingWebhooks, see pkg/component/gardener/resourcemanager/resource_manager.go
 				Expect(actualValidatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", ContainSubstring("validation.extensions."))))
 			}
-			Expect(len(actualValidatingWebhookConfiguration.Webhooks)).To(Equal(expectedNumEnabledValidatingWebhooks))
+			Expect(actualValidatingWebhookConfiguration.Webhooks).To(HaveLen(expectedNumEnabledValidatingWebhooks))
 
 			// actualConfig.Webhooks.NodeAgentAuthorizer is an authorization webhook, which works differently and is not tested here.
 		}

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/yaml"
 
 	resourcemanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/resourcemanager/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -132,6 +133,7 @@ var _ = Describe("ResourceManager", func() {
 		managedResourceSecret                                *corev1.Secret
 		managedResource                                      *resourcesv1alpha1.ManagedResource
 		matchLabelKeysInPodTopologySpreadFeatureGateDisabled bool
+		fetchAndValidateWebhookConfiguration                 func(actualConfigMap *corev1.ConfigMap, actualManagedResourceSecret *corev1.Secret)
 	)
 
 	BeforeEach(func() {
@@ -2093,6 +2095,116 @@ subjects:
 			},
 		}
 		utilruntime.Must(references.InjectAnnotations(managedResource))
+
+		validateWebhookConfiguration := func(
+			actualConfig *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration,
+			actualMutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration,
+			actualValidatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration) {
+
+			By("Verify that the mutating webhook configuration is consistent")
+
+			expectedNumEnabledMutatingWebhooks := 0
+			if actualConfig.Webhooks.HighAvailabilityConfig.Enabled {
+				expectedNumEnabledMutatingWebhooks++
+				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "high-availability-config.resources.gardener.cloud")))
+			}
+			if actualConfig.Webhooks.KubernetesServiceHost.Enabled {
+				expectedNumEnabledMutatingWebhooks++
+				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "kubernetes-service-host.resources.gardener.cloud")))
+			}
+			if actualConfig.Webhooks.SystemComponentsConfig.Enabled {
+				expectedNumEnabledMutatingWebhooks++
+				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "system-components-config.resources.gardener.cloud")))
+			}
+			if actualConfig.Webhooks.PodKubeAPIServerLoadBalancing.Enabled {
+				expectedNumEnabledMutatingWebhooks += len(cfg.PodKubeAPIServerLoadBalancingWebhook.Configs)
+				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", ContainSubstring("kube-apiserver-load-balancing.resources.gardener.cloud"))))
+			}
+			if actualConfig.Webhooks.PodSchedulerName.Enabled {
+				expectedNumEnabledMutatingWebhooks++
+				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "pod-scheduler-name.resources.gardener.cloud")))
+			}
+			if actualConfig.Webhooks.PodTopologySpreadConstraints.Enabled {
+				expectedNumEnabledMutatingWebhooks++
+				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "pod-topology-spread-constraints.resources.gardener.cloud")))
+			}
+			if actualConfig.Webhooks.ProjectedTokenMount.Enabled {
+				expectedNumEnabledMutatingWebhooks++
+				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "projected-token-mount.resources.gardener.cloud")))
+			}
+			if actualConfig.Webhooks.SeccompProfile.Enabled {
+				expectedNumEnabledMutatingWebhooks++
+				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "seccomp-profile.resources.gardener.cloud")))
+			}
+			if actualConfig.Webhooks.VPAInPlaceUpdates.Enabled {
+				expectedNumEnabledMutatingWebhooks++
+				Expect(actualMutatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "vpa-in-place-updates.resources.gardener.cloud")))
+			}
+			Expect(len(actualMutatingWebhookConfiguration.Webhooks)).To(Equal(expectedNumEnabledMutatingWebhooks))
+
+			expectedNumEnabledValidatingWebhooks := 0
+			if actualConfig.Webhooks.CRDDeletionProtection.Enabled {
+				expectedNumEnabledValidatingWebhooks += 2 // crd and cr, see NewCRDDeletionProtectionValidatingWebhooks in pkg/component/gardener/resourcemanager/resource_manager.go
+
+				Expect(actualValidatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "crd-deletion-protection.resources.gardener.cloud")))
+				Expect(actualValidatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", "cr-deletion-protection.resources.gardener.cloud")))
+			}
+			if actualConfig.Webhooks.ExtensionValidation.Enabled {
+				expectedNumEnabledValidatingWebhooks += 13 // the list of length 13 is hardcoded in NewExtensionValidationValidatingWebhooks, see pkg/component/gardener/resourcemanager/resource_manager.go
+				Expect(actualValidatingWebhookConfiguration.Webhooks).To(ContainElement(HaveField("Name", ContainSubstring("validation.extensions."))))
+			}
+			Expect(len(actualValidatingWebhookConfiguration.Webhooks)).To(Equal(expectedNumEnabledValidatingWebhooks))
+
+			// actualConfig.Webhooks.NodeAgentAuthorizer is an authorization webhook, which works differently and is not tested here.
+		}
+
+		fetchAndValidateWebhookConfiguration = func(
+			actualConfigMap *corev1.ConfigMap,
+			actualManagedResourceSecret *corev1.Secret,
+		) {
+			actualConfig := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{}
+			Expect(runtime.DecodeInto(codec, []byte(actualConfigMap.Data["config.yaml"]), actualConfig)).To(Succeed())
+
+			actualMutatingWebhookConfiguration := &admissionregistrationv1.MutatingWebhookConfiguration{}
+			actualValidatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+
+			switch cfg.ResponsibilityMode {
+			case ForRuntime:
+				{
+					if actualManagedResourceSecret != nil {
+						Fail("actualManagedResourceSecret should be nil for ForRuntime responsibility mode")
+					}
+					Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, actualMutatingWebhookConfiguration)).To(Succeed())
+					Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, actualValidatingWebhookConfiguration)).To(Succeed())
+
+					break
+				}
+			case ForShootOrVirtualGarden:
+				{
+					manifests, err := test.ExtractManifestsFromManagedResourceData(actualManagedResourceSecret.Data)
+					Expect(err).NotTo(HaveOccurred())
+
+					for _, manifest := range manifests {
+						typeMeta := &metav1.TypeMeta{}
+						if err := yaml.Unmarshal([]byte(manifest), typeMeta); err != nil {
+							continue
+						}
+						switch typeMeta.Kind {
+						case "MutatingWebhookConfiguration":
+							Expect(runtime.DecodeInto(codec, []byte(manifest), actualMutatingWebhookConfiguration)).To(Succeed())
+						case "ValidatingWebhookConfiguration":
+							Expect(runtime.DecodeInto(codec, []byte(manifest), actualValidatingWebhookConfiguration)).To(Succeed())
+						}
+					}
+					break
+				}
+			default:
+				{
+					Fail("unexpected responsibility mode: " + string(cfg.ResponsibilityMode))
+				}
+			}
+			validateWebhookConfiguration(actualConfig, actualMutatingWebhookConfiguration, actualValidatingWebhookConfiguration)
+		}
 	})
 
 	Describe("#Deploy", func() {
@@ -2157,6 +2269,11 @@ subjects:
 						actualConfigMap.ResourceVersion = ""
 						configMap.ResourceVersion = ""
 						Expect(actualConfigMap).To(DeepEqual(configMap))
+
+						actualManagedResourceSecret := &corev1.Secret{}
+						Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: managedResourceSecret.Name}, actualManagedResourceSecret)).To(Succeed())
+
+						fetchAndValidateWebhookConfiguration(configMap, actualManagedResourceSecret)
 
 						actualRole := &rbacv1.Role{}
 						Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: watchedNamespace, Name: "gardener-resource-manager"}, actualRole)).To(Succeed())
@@ -2259,6 +2376,14 @@ subjects:
 						managedResourceSecret.ResourceVersion = ""
 						Expect(actualManagedResourceSecret).To(DeepEqual(managedResourceSecret))
 
+						actualConfigMap := &corev1.ConfigMap{}
+						Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: configMap.Name}, actualConfigMap)).To(Succeed())
+						actualConfigMap.ResourceVersion = ""
+						configMap.ResourceVersion = ""
+						Expect(actualConfigMap).To(DeepEqual(configMap))
+
+						fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret)
+
 						actualManagedResource := &resourcesv1alpha1.ManagedResource{}
 						Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, actualManagedResource)).To(Succeed())
 						actualManagedResource.ResourceVersion = ""
@@ -2345,6 +2470,8 @@ subjects:
 					actualManagedResourceSecret.ResourceVersion = ""
 					managedResourceSecret.ResourceVersion = ""
 					Expect(actualManagedResourceSecret).To(DeepEqual(managedResourceSecret))
+
+					fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret)
 
 					actualManagedResource := &resourcesv1alpha1.ManagedResource{}
 					Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, actualManagedResource)).To(Succeed())
@@ -2435,6 +2562,8 @@ subjects:
 				actualManagedResourceSecret.ResourceVersion = ""
 				managedResourceSecret.ResourceVersion = ""
 				Expect(actualManagedResourceSecret).To(DeepEqual(managedResourceSecret))
+
+				fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret)
 
 				actualManagedResource := &resourcesv1alpha1.ManagedResource{}
 				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, actualManagedResource)).To(Succeed())
@@ -2535,20 +2664,6 @@ subjects:
 				configMap.ResourceVersion = ""
 				Expect(actualConfigMap).To(DeepEqual(configMap))
 
-				By("verify that all workerless-disabled webhooks are turned off in the component config")
-				actualConfig := &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{}
-				Expect(runtime.DecodeInto(codec, []byte(actualConfigMap.Data["config.yaml"]), actualConfig)).To(Succeed())
-				Expect(actualConfig.Webhooks.PodSchedulerName.Enabled).To(BeFalse())
-				Expect(actualConfig.Webhooks.SystemComponentsConfig.Enabled).To(BeFalse())
-				Expect(actualConfig.Webhooks.ProjectedTokenMount.Enabled).To(BeFalse())
-				Expect(actualConfig.Webhooks.HighAvailabilityConfig.Enabled).To(BeFalse())
-				Expect(actualConfig.Webhooks.PodTopologySpreadConstraints.Enabled).To(BeFalse())
-				Expect(actualConfig.Webhooks.SeccompProfile.Enabled).To(BeFalse())
-				Expect(actualConfig.Webhooks.KubernetesServiceHost.Enabled).To(BeFalse())
-				Expect(actualConfig.Webhooks.PodKubeAPIServerLoadBalancing.Enabled).To(BeFalse())
-				Expect(actualConfig.Webhooks.VPAInPlaceUpdates.Enabled).To(BeFalse())
-				Expect(actualConfig.Webhooks.NodeAgentAuthorizer.Enabled).To(BeFalse())
-
 				actualClusterRole := &rbacv1.ClusterRole{}
 				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: clusterRoleName}, actualClusterRole)).To(Succeed())
 				actualClusterRole.ResourceVersion = ""
@@ -2595,6 +2710,8 @@ subjects:
 				actualManagedResourceSecret.ResourceVersion = ""
 				managedResourceSecret.ResourceVersion = ""
 				Expect(actualManagedResourceSecret).To(DeepEqual(managedResourceSecret))
+
+				fetchAndValidateWebhookConfiguration(actualConfigMap, actualManagedResourceSecret)
 
 				actualManagedResource := &resourcesv1alpha1.ManagedResource{}
 				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, actualManagedResource)).To(Succeed())
@@ -2711,6 +2828,8 @@ subjects:
 				actualValidatingWebhookConfiguration.ResourceVersion = ""
 				validatingWebhookConfiguration.ResourceVersion = ""
 				Expect(actualValidatingWebhookConfiguration).To(DeepEqual(validatingWebhookConfiguration))
+
+				fetchAndValidateWebhookConfiguration(actualConfigMap, nil)
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
Unnecessary webhooks were deployed into the virtual garden (for workload API resources like `pods`). The example given was the projected-token-mount webhook.

This PR ensures no webhooks are deployed into workerless shoots by making newMutatingWebhookConfigurationWebhooks respect the config.Webhooks.*.Enable configuration.
In workerless shoots, all of these flags are set to `false` by disableControllersAndWebhooksForWorkerlessShoot. 

**Which issue(s) this PR fixes**:
Fixes #13289

**Special notes for your reviewer**:
The first four commits are verbatim from the closed PR https://github.com/gardener/gardener/pull/14693. I included them for the sake of completeness, but in a subsequent commit I refactored a bit.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```