### PR TITLE
Add reconcile timeout for gardener-node-agent lease reconcile

### DIFF
--- a/pkg/nodeagent/controller/certificate/add.go
+++ b/pkg/nodeagent/controller/certificate/add.go
@@ -32,7 +32,10 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	return builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+			ReconciliationTimeout:   controllerutils.DefaultReconciliationTimeout,
+		}).
 		WatchesRawSource(controllerutils.EnqueueOnce).
 		Complete(r)
 }

--- a/pkg/nodeagent/controller/lease/add.go
+++ b/pkg/nodeagent/controller/lease/add.go
@@ -5,6 +5,8 @@
 package lease
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
@@ -38,6 +40,13 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, nodePredicate predicate.P
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&corev1.Node{}, builder.WithPredicates(nodePredicate, predicateutils.ForEventTypes(predicateutils.Create))).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+			// Bound each renewal attempt so that a hung API request (e.g. a write blocking on a half-open
+			// connection after a network disruption) cannot occupy the single reconcile worker indefinitely
+			// and silently stall the heartbeat. The timeout is kept well below the lease duration so that a
+			// stuck attempt is cancelled and re-queued long before the Lease would expire.
+			ReconciliationTimeout: time.Duration(r.LeaseDurationSeconds) * time.Second / 4,
+		}).
 		Complete(r)
 }

--- a/pkg/nodeagent/controller/lease/add.go
+++ b/pkg/nodeagent/controller/lease/add.go
@@ -42,11 +42,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, nodePredicate predicate.P
 		For(&corev1.Node{}, builder.WithPredicates(nodePredicate, predicateutils.ForEventTypes(predicateutils.Create))).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
-			// Bound each renewal attempt so that a hung API request (e.g. a write blocking on a half-open
-			// connection after a network disruption) cannot occupy the single reconcile worker indefinitely
-			// and silently stall the heartbeat. The timeout is kept well below the lease duration so that a
-			// stuck attempt is cancelled and re-queued long before the Lease would expire.
-			ReconciliationTimeout: time.Duration(r.LeaseDurationSeconds) * time.Second / 4,
+			ReconciliationTimeout:   time.Duration(r.LeaseDurationSeconds) * time.Second,
 		}).
 		Complete(r)
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

This PR sets the `ReconcileTimeout` for the `Lease` controller in the Gardener node agent.

I noticed a `gardener-node-agent stopped running on node <node>` error on one of the shoots after a rolling update of the worker nodes in the seed cluster. The error did not go away and I did not want to reconcile the shoot cluster, so I started investigating.

The logs of the Gardener node agent on the offending node showed a few failed reconcile attempts of the lease and then nothing for hours. The process and systemd unit was still healthy. The theory is that the HTTP connection for the update request of the lease got stuck in an invalid state when the kube-apiserver was moved to a new node. Since there was no timeout specified the connection could stay stuck forever. Since there is only one concurrent reconcile for the `Lease`, the lease will never refresh again. A reconcile timeout will prevent this from happening again. 

There is also no other mechanism in Gardener that would lead to an automatic recovery. Only a shoot reconcile will probably help.

Manually restarting the Gardener node-agent on the node resolved the problem immediately.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add a reconcile timeout for the lease controller in Gardener node agent
```
