### PR TITLE
Increase timeout to 5m for `VerifyInPlaceUpdateStart`

### DIFF
--- a/test/utils/shoots/update/inplace/shoot.go
+++ b/test/utils/shoots/update/inplace/shoot.go
@@ -25,7 +25,7 @@ func ItShouldVerifyInPlaceUpdateStart(s *ShootContext, hasAutoInplaceUpdate, has
 
 	It("Verify in-place update start", func(ctx SpecContext) {
 		VerifyInPlaceUpdateStart(ctx, s.Log, s.GardenClient, s.Shoot, hasAutoInplaceUpdate, hasManualInplaceUpdate)
-	}, SpecTimeout(2*time.Minute))
+	}, SpecTimeout(5*time.Minute))
 }
 
 // VerifyInPlaceUpdateStart verifies that the in-place update has started by checking the


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #15443, which raised the `SpecTimeout` of `ItShouldVerifyInPlaceUpdateCompletion` from 5m to 10m to deflake the timeout reported in #15400. Issue #15400 itself predicted the sibling spec would flake for the same reason:

> the same reason the sibling `Verify in-place update start` (`create_update_delete.go:207`) also shows up as flaky

That prediction has played out:

- A `pull-gardener-e2e-kind` run on #15451 timed out at exactly **2m0.002s** in the `Verify in-place update start` spec. That PR only changes `_test.go` files under `pkg/api/core/.../helper`, which nothing in the e2e path depends on, so the timeout is unrelated to the PR's changes.
- The umbrella flake issue #15399 lists `create_update_delete.go:207` with `[TIMEDOUT]`.

This PR raises the `SpecTimeout` of `ItShouldVerifyInPlaceUpdateStart` from 2m to 5m.

**Why 5m and not 10m:** unlike the completion spec, the start spec performs no real-node operations — it only waits for gardenlet to set `.status.inPlaceUpdates` and the `ManualInPlaceWorkersUpdated` constraint. It should therefore normally be faster than completion. 5m gives 2.5x headroom over the observed failure while keeping the budget below the completion spec's 10m, so a genuinely stuck update start still fails relatively quickly. Happy to raise to 10m if parity is preferred.

**Which issue(s) this PR fixes**:
Part of #15399

**Special notes for your reviewer**:

- Test-only, one line, following the approach of #15443.
- `gofmt`, `go vet` and `go build` clean locally.

**Release note**:
```other
NONE
```