### PR TITLE
Increase timeout to 10m for VerifyInPlaceUpdateStart

### DIFF
--- a/test/utils/shoots/update/inplace/shoot.go
+++ b/test/utils/shoots/update/inplace/shoot.go
@@ -25,7 +25,7 @@ func ItShouldVerifyInPlaceUpdateStart(s *ShootContext, hasAutoInplaceUpdate, has
 
 	It("Verify in-place update start", func(ctx SpecContext) {
 		VerifyInPlaceUpdateStart(ctx, s.Log, s.GardenClient, s.Shoot, hasAutoInplaceUpdate, hasManualInplaceUpdate)
-	}, SpecTimeout(2*time.Minute))
+	}, SpecTimeout(10*time.Minute))
 }
 
 // VerifyInPlaceUpdateStart verifies that the in-place update has started by checking the


### PR DESCRIPTION
**What this PR does / why we need it**:

Increases the `Verify in-place update start` spec timeout from 2 to 10 minutes, aligning it with the sibling `Verify in-place update completion` spec.

#15443 raised the completion spec timeout from 5 to 10 minutes in response to flake issue #15400. The body of #15400 explicitly predicted that this sibling spec would flake for the same reason, but it was not touched by #15443. A recent e2e run (`pull-gardener-e2e-kind` on #15451) confirmed it: `create_update_delete.go:207` timed out at exactly 2m0.002s. The flake-tracking umbrella #15399 also lists `create_update_delete.go:207` as `[TIMEDOUT]`.

**Which issue(s) this PR fixes**:

Related to #15400
Follow-up to #15443

**Special notes for your reviewer**:

Test-only change in an e2e framework helper; no production code touched. The other two call sites of `VerifyInPlaceUpdateStart` (test/testmachinery) call the non-ginkgo helper directly and are unaffected.

**Release note**:

```other operator
NONE
```
