### PR TITLE
[GEP-28] E2E test ensures shoot `gardenlet` reconciles successfully

### DIFF
--- a/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
@@ -306,6 +306,57 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 					))
 				}
 			}, SpecTimeout(5*time.Minute))
+
+			// `gardenadm connect` deploys the shoot gardenlet and registers the `Shoot` in the garden cluster. However,
+			// after `gardenadm init`, the status indicates a successful reconciliation, and since the shoot gardenlet
+			// is configured to only proactively reconcile in the maintenance time window, we have to explicitly request
+			// a reconciliation from it. This is to test whether its `Shoot` controller works as expected.
+			Context("shoot gardenlet reconciles self-hosted shoot", func() {
+				var s *e2egardener.ShootContext
+
+				BeforeAll(func() {
+					s = (&e2egardener.TestContext{
+						GardenClientSet: gardenClientSet,
+						GardenClient:    gardenClientSet.Client(),
+						GardenKomega:    New(gardenClientSet.Client()),
+					}).ForShoot(shoot)
+				})
+
+				It("should annotate the shoot to trigger reconciliation", func(ctx SpecContext) {
+					patch := client.MergeFrom(s.Shoot.DeepCopy())
+					metav1.SetMetaDataAnnotation(&s.Shoot.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+					Eventually(ctx, func() error {
+						return s.GardenClient.Patch(ctx, s.Shoot, patch)
+					}).Should(Succeed())
+				}, SpecTimeout(time.Minute))
+
+				It("should wait for the self-hosted shoot to be reconciled and healthy", func(ctx SpecContext) {
+					Eventually(ctx, func(g Gomega) bool {
+						g.Expect(s.GardenKomega.Get(s.Shoot)()).To(Succeed())
+						// TODO(rfranzke): Uncomment this code and remove the manual checks once the Shoot controller
+						//  has progressed and the .status.conditions properly reflect healthiness.
+						//
+						// completed, _ := shootoperation.ReconciliationSuccessful(s.Shoot)
+						// return completed
+
+						if s.Shoot.Generation != s.Shoot.Status.ObservedGeneration {
+							return false
+						}
+						if len(s.Shoot.Status.Conditions) == 0 && s.Shoot.Status.LastOperation == nil {
+							return false
+						}
+						if shoot.Status.LastOperation != nil {
+							switch shoot.Status.LastOperation.Type {
+							case gardencorev1beta1.LastOperationTypeCreate, gardencorev1beta1.LastOperationTypeReconcile, gardencorev1beta1.LastOperationTypeRestore:
+								if shoot.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
+									return false
+								}
+							}
+						}
+						return true
+					}).WithPolling(30 * time.Second).Should(BeTrue())
+				}, SpecTimeout(30*time.Minute))
+			})
 		})
 
 		Context("self-hosted shoot -> seed promotion", Ordered, Label("seed"), func() {


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind test

**What this PR does / why we need it**:
After `gardenadm connect`, the shoot `gardenlet` is deployed but only reconciles the `Shoot` proactively during the maintenance window (since `gardenadm init` already set the status to successful). This PR adds an e2e test that explicitly triggers a reconciliation via `gardener.cloud/operation=reconcile` and waits for the `Shoot` to reach a healthy, reconciled state — verifying the shoot `gardenlet`'s `Shoot` controller works end-to-end.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:

**Release note**:
```
NONE
```