### PR TITLE
feat(operator): allow Garden API server for web terminals

### DIFF
--- a/pkg/component/gardener/dashboard/terminal/configmap.go
+++ b/pkg/component/gardener/dashboard/terminal/configmap.go
@@ -6,23 +6,25 @@ package terminal
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 const dataKeyConfig = "config.yaml"
 
-func (t *terminal) configMap() *corev1.ConfigMap {
+func (t *terminal) configMap() (*corev1.ConfigMap, error) {
 	// This is the name of ServiceAccounts when the Gardener Dashboard creates Terminal resources, see
 	// https://github.com/gardener/dashboard/blob/b99a6ef584eec26dee95028d755f5ebdf5973b2c/backend/lib/services/terminals/index.js#L45-L46
 	dashboardServiceAccountName := "dashboard-webterminal"
 	allowedAPIServerURLs, err := json.Marshal(append([]string{}, t.values.AllowedAPIServerURLs...))
-	utilruntime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("failed marshalling allowed API server URLs: %w", err)
+	}
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -50,6 +52,9 @@ server:
 `},
 	}
 
-	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
-	return configMap
+	if err := kubernetesutils.MakeUnique(configMap); err != nil {
+		return nil, fmt.Errorf("failed making ConfigMap unique: %w", err)
+	}
+
+	return configMap, nil
 }

--- a/pkg/component/gardener/dashboard/terminal/configmap.go
+++ b/pkg/component/gardener/dashboard/terminal/configmap.go
@@ -11,6 +11,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -52,9 +53,6 @@ server:
 `},
 	}
 
-	if err := kubernetesutils.MakeUnique(configMap); err != nil {
-		return nil, fmt.Errorf("failed making ConfigMap unique: %w", err)
-	}
-
+	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
 	return configMap, nil
 }

--- a/pkg/component/gardener/dashboard/terminal/configmap.go
+++ b/pkg/component/gardener/dashboard/terminal/configmap.go
@@ -5,6 +5,7 @@
 package terminal
 
 import (
+	"encoding/json"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -20,6 +21,8 @@ func (t *terminal) configMap() *corev1.ConfigMap {
 	// This is the name of ServiceAccounts when the Gardener Dashboard creates Terminal resources, see
 	// https://github.com/gardener/dashboard/blob/b99a6ef584eec26dee95028d755f5ebdf5973b2c/backend/lib/services/terminals/index.js#L45-L46
 	dashboardServiceAccountName := "dashboard-webterminal"
+	allowedAPIServerURLs, err := json.Marshal(append([]string{}, t.values.AllowedAPIServerURLs...))
+	utilruntime.Must(err)
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -29,6 +32,7 @@ func (t *terminal) configMap() *corev1.ConfigMap {
 		},
 		Data: map[string]string{dataKeyConfig: `apiVersion: dashboard.gardener.cloud/v1alpha1
 kind: ControllerManagerConfiguration
+allowedAPIServerURLs: ` + string(allowedAPIServerURLs) + `
 controllers:
   serviceAccount:
     allowedServiceAccountNames:

--- a/pkg/component/gardener/dashboard/terminal/terminal.go
+++ b/pkg/component/gardener/dashboard/terminal/terminal.go
@@ -95,7 +95,10 @@ func (t *terminal) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	configMap := t.configMap()
+	configMap, err := t.configMap()
+	if err != nil {
+		return err
+	}
 
 	runtimeResources, err := runtimeRegistry.AddAllAndSerialize(
 		t.service(),

--- a/pkg/component/gardener/dashboard/terminal/terminal.go
+++ b/pkg/component/gardener/dashboard/terminal/terminal.go
@@ -44,6 +44,8 @@ var TimeoutWaitForManagedResource = 5 * time.Minute
 type Values struct {
 	// Image defines the container image of terminal-controller-manager.
 	Image string
+	// AllowedAPIServerURLs is the exact-match allowlist for explicit API server URLs.
+	AllowedAPIServerURLs []string
 	// RuntimeVersion is the Kubernetes version of the runtime cluster.
 	RuntimeVersion *semver.Version
 	// TopologyAwareRoutingEnabled determines whether topology aware hints are intended.

--- a/pkg/component/gardener/dashboard/terminal/terminal_test.go
+++ b/pkg/component/gardener/dashboard/terminal/terminal_test.go
@@ -57,6 +57,7 @@ var _ = Describe("Terminal", func() {
 		namespace                  = "some-namespace"
 
 		image                string
+		allowedAPIServerURLs []string
 		topologyAwareRouting bool
 		runtimeVersion       *semver.Version
 
@@ -94,6 +95,7 @@ var _ = Describe("Terminal", func() {
 		ctx = context.Background()
 
 		image = "terminal-image:latest"
+		allowedAPIServerURLs = []string{"https://api.example.com"}
 		topologyAwareRouting = false
 
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
@@ -177,31 +179,7 @@ var _ = Describe("Terminal", func() {
 			},
 		}
 
-		configMap = &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "terminal-controller-manager",
-				Namespace: namespace,
-				Labels:    map[string]string{"app": "terminal-controller-manager"},
-			},
-			Data: map[string]string{"config.yaml": `apiVersion: dashboard.gardener.cloud/v1alpha1
-kind: ControllerManagerConfiguration
-controllers:
-  serviceAccount:
-    allowedServiceAccountNames:
-    - dashboard-webterminal
-honourCleanupProjectMembership: true
-honourServiceAccountRefHostCluster: false
-leaderElection:
-  leaderElect: true
-  resourceNamespace: kube-system
-server:
-  healthProbes:
-    port: 8081
-  metrics:
-    port: 8443
-`},
-		}
-		utilruntime.Must(kubernetesutils.MakeUnique(configMap))
+		configMap = expectedConfigMap(namespace, `["https://api.example.com"]`)
 
 		deployment = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -595,6 +573,7 @@ server:
 	JustBeforeEach(func() {
 		values = Values{
 			Image:                       image,
+			AllowedAPIServerURLs:        allowedAPIServerURLs,
 			TopologyAwareRoutingEnabled: topologyAwareRouting,
 			RuntimeVersion:              runtimeVersion,
 		}
@@ -718,6 +697,30 @@ server:
 
 				Expect(managedResourceRuntime).To(consistOf(expectedRuntimeObjects...))
 				Expect(managedResourceVirtual).To(consistOf(expectedVirtualObjects...))
+			})
+
+			When("the allowed API server URL input is nil", func() {
+				BeforeEach(func() {
+					allowedAPIServerURLs = nil
+					configMap = expectedConfigMap(namespace, `[]`)
+					setExpectedDeploymentConfigMap(deployment, configMap.Name)
+				})
+
+				It("should render an empty allowlist", func() {
+					Expect(managedResourceRuntime).To(consistOf(expectedRuntimeObjects...))
+				})
+			})
+
+			When("the allowed API server URL input is empty", func() {
+				BeforeEach(func() {
+					allowedAPIServerURLs = []string{}
+					configMap = expectedConfigMap(namespace, `[]`)
+					setExpectedDeploymentConfigMap(deployment, configMap.Name)
+				})
+
+				It("should render an empty allowlist", func() {
+					Expect(managedResourceRuntime).To(consistOf(expectedRuntimeObjects...))
+				})
 			})
 
 			Context("secrets", func() {
@@ -1013,6 +1016,46 @@ server:
 		})
 	})
 })
+
+func expectedConfigMap(namespace, allowedAPIServerURLs string) *corev1.ConfigMap {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "terminal-controller-manager",
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "terminal-controller-manager"},
+		},
+		Data: map[string]string{"config.yaml": `apiVersion: dashboard.gardener.cloud/v1alpha1
+kind: ControllerManagerConfiguration
+allowedAPIServerURLs: ` + allowedAPIServerURLs + `
+controllers:
+  serviceAccount:
+    allowedServiceAccountNames:
+    - dashboard-webterminal
+honourCleanupProjectMembership: true
+honourServiceAccountRefHostCluster: false
+leaderElection:
+  leaderElect: true
+  resourceNamespace: kube-system
+server:
+  healthProbes:
+    port: 8081
+  metrics:
+    port: 8443
+`},
+	}
+	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
+	return configMap
+}
+
+func setExpectedDeploymentConfigMap(deployment *appsv1.Deployment, configMapName string) {
+	oldConfigMapName := deployment.Spec.Template.Spec.Volumes[0].ConfigMap.Name
+	oldAnnotationKey := references.AnnotationKey(references.KindConfigMap, oldConfigMapName)
+	delete(deployment.Annotations, oldAnnotationKey)
+	delete(deployment.Spec.Template.Annotations, oldAnnotationKey)
+
+	deployment.Spec.Template.Spec.Volumes[0].ConfigMap.Name = configMapName
+	utilruntime.Must(references.InjectAnnotations(deployment))
+}
 
 var (
 	healthyManagedResourceStatus = resourcesv1alpha1.ManagedResourceStatus{

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1319,7 +1319,7 @@ func (r *Reconciler) newGardenerDashboard(
 	values := gardenerdashboard.Values{
 		Image:            image.String(),
 		LogLevel:         logger.InfoLevel,
-		APIServerURL:     v1beta1helper.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0].Name),
+		APIServerURL:     virtualGardenAPIServerHost(garden),
 		EnableTokenLogin: true,
 		Ingress: gardenerdashboard.IngressValues{
 			Enabled:                   true,
@@ -1327,10 +1327,6 @@ func (r *Reconciler) newGardenerDashboard(
 			TLSSecretName:             dashboardTLSSecretName(garden, wildcardCertSecretName),
 			IstioIngressGatewayLabels: ingressGatewayValues[0].Labels,
 		},
-	}
-
-	if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI != nil {
-		values.APIServerURL = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI.DomainPatterns[0]
 	}
 
 	if config := garden.Spec.VirtualCluster.Gardener.Dashboard; config != nil {
@@ -1378,7 +1374,10 @@ func (r *Reconciler) newTerminalControllerManager(garden *operatorv1alpha1.Garde
 	}
 
 	values := terminal.Values{
-		Image:                       image.String(),
+		Image: image.String(),
+		// Must match the dashboard's apiServerUrl: Garden terminals set
+		// spec.target.apiServer.server to that exact value.
+		AllowedAPIServerURLs:        []string{"https://" + virtualGardenAPIServerHost(garden)},
 		RuntimeVersion:              r.RuntimeVersion,
 		TopologyAwareRoutingEnabled: helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),
 	}
@@ -1389,6 +1388,15 @@ func (r *Reconciler) newTerminalControllerManager(garden *operatorv1alpha1.Garde
 	}
 
 	return deployer, nil
+}
+
+// virtualGardenAPIServerHost returns the virtual garden kube-apiserver hostname used by the
+// dashboard (apiServerUrl) and terminal-controller-manager (allowedAPIServerURLs).
+func virtualGardenAPIServerHost(garden *operatorv1alpha1.Garden) string {
+	if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI != nil {
+		return garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI.DomainPatterns[0]
+	}
+	return v1beta1helper.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0].Name)
 }
 
 func (r *Reconciler) newFluentOperator() (component.DeployWaiter, error) {

--- a/pkg/operator/controller/garden/garden/components_test.go
+++ b/pkg/operator/controller/garden/garden/components_test.go
@@ -13,6 +13,43 @@ import (
 )
 
 var _ = Describe("Components", func() {
+	Describe("#virtualGardenAPIServerHost", func() {
+		It("should return api.<domain> from the primary DNS domain", func() {
+			garden := &operatorv1alpha1.Garden{
+				Spec: operatorv1alpha1.GardenSpec{
+					VirtualCluster: operatorv1alpha1.VirtualCluster{
+						DNS: operatorv1alpha1.DNS{
+							Domains: []operatorv1alpha1.DNSDomain{{Name: "garden.example.com"}},
+						},
+					},
+				},
+			}
+
+			Expect(virtualGardenAPIServerHost(garden)).To(Equal("api.garden.example.com"))
+		})
+
+		It("should prefer the first SNI domain pattern when configured", func() {
+			garden := &operatorv1alpha1.Garden{
+				Spec: operatorv1alpha1.GardenSpec{
+					VirtualCluster: operatorv1alpha1.VirtualCluster{
+						DNS: operatorv1alpha1.DNS{
+							Domains: []operatorv1alpha1.DNSDomain{{Name: "garden.example.com"}},
+						},
+						Kubernetes: operatorv1alpha1.Kubernetes{
+							KubeAPIServer: &operatorv1alpha1.KubeAPIServerConfig{
+								SNI: &operatorv1alpha1.SNI{
+									DomainPatterns: []string{"api.custom.example.com", "api.other.example.com"},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(virtualGardenAPIServerHost(garden)).To(Equal("api.custom.example.com"))
+		})
+	})
+
 	Describe("#getLoadBalancerServiceProxyProtocol", func() {
 		DescribeTable("should return the proxy protocol setting",
 			func(allowed bool) {


### PR DESCRIPTION
/area dashboard
/kind enhancement

**What this PR does / why we need it**:

The terminal-controller-manager PR https://github.com/gardener/terminal-controller-manager/pull/533 restricts explicit Terminal API server targets to the URLs configured in `allowedAPIServerURLs`.

Gardener Dashboard always sets an explicit API server URL for Garden terminals. Without adding this URL to the allowlist, TCM will reject these Terminal resources after the new validation is enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This change is forward-compatible with the currently deployed TCM version: older TCM binaries ignore the unknown `allowedAPIServerURLs` configuration field.

**Release note**:

```feature operator
The virtual Garden API server URL is added to terminal-controller-manager's allowlist so that Garden web terminals remain available with restricted API server targets.
```