### PR TITLE
Grant `gardener-admission-controller` get, list, watch permissions for `internalsecrets` and `shootstates`

### DIFF
--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -840,6 +840,7 @@ func clusterRole() *rbacv1.ClusterRole {
 					"backupentries",
 					"controllerdeployments",
 					"controllerinstallations",
+					"internalsecrets",
 					"secretbindings",
 					"seeds",
 					"shoots",

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -844,6 +844,7 @@ func clusterRole() *rbacv1.ClusterRole {
 					"secretbindings",
 					"seeds",
 					"shoots",
+					"shootstates",
 					"projects",
 				},
 				Verbs: []string{"get", "list", "watch"},

--- a/pkg/component/gardener/admissioncontroller/rbac.go
+++ b/pkg/component/gardener/admissioncontroller/rbac.go
@@ -37,6 +37,7 @@ func (a *gardenerAdmissionController) clusterRole() *rbacv1.ClusterRole {
 					"backupentries",
 					"controllerdeployments",
 					"controllerinstallations",
+					"internalsecrets",
 					"secretbindings",
 					"seeds",
 					"shoots",

--- a/pkg/component/gardener/admissioncontroller/rbac.go
+++ b/pkg/component/gardener/admissioncontroller/rbac.go
@@ -41,6 +41,7 @@ func (a *gardenerAdmissionController) clusterRole() *rbacv1.ClusterRole {
 					"secretbindings",
 					"seeds",
 					"shoots",
+					"shootstates",
 					"projects",
 				},
 				Verbs: []string{"get", "list", "watch"},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
PR #14091 introduced a shortcut for `CREATE` requests in seed-restriction handler of `gardener-admission-controller`.
However, it does not have read permissions for `internalsecrets` so there are errors like this in its logs.

```
2026-08-11 09:09:13	
{"error":"internalsecrets.core.gardener.cloud \"xyz.ca-client\" is forbidden: User \"system:serviceaccount:kube-system:gardener-admission-controller\" cannot get resource \"internalsecrets\" in API group \"core.gardener.cloud\" in the namespace \"garden-xyz\"","level":"error","logger":"webhook.seedrestriction","msg":"Failed to get object, continuing with normal admission checks","requestGroup":"core.gardener.cloud","requestKind":"InternalSecret","requestName":"xyz.ca-client","requestNamespace":"garden-xyz","requestVersion":"v1beta1","seedName":"abc","stacktrace":"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/seedrestriction.(*Handler).Handle\n\t/go/src/github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go:86\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/webhook/admission/webhook.go:181\nsigs.k8s.io/controller-runtime/pkg/... <truncated 1237 bytes>
```

Same for `shootstates`
```
{"error":"shootstates.core.gardener.cloud \"xyz\" is forbidden: User \"system:serviceaccount:kube-system:gardener-admission-controller\" cannot get resource \"shootstates\" in API group \"core.gardener.cloud\" in the namespace \"garden-xyz\"","level":"error","logger":"webhook.seedrestriction","msg":"Failed to get object, continuing with normal admission checks","requestGroup":"core.gardener.cloud","requestKind":"ShootState","requestName":"xyz","requestNamespace":"garden-xyz","requestVersion":"v1beta1","seedName":"abc","stacktrace":"github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/seedrestriction.(*Handler).Handle\n\t/go/src/github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go:86\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/webhook/admission/webhook.go:181\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP\... <truncated 1198 bytes>
```

This PR grants the required `get`, `list`, `watch` permissions to `gardener-admission-controller` that it run this shortcut successfully. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Missing `get`, `list`, `watch` permissions for `internalsecrets` and `shootstates` have been granted to `gardener-admission-controller`.
```
