### PR TITLE
Fix nil pointer dereference in zero-downtime validator AfterAll cleanup

### DIFF
--- a/test/e2e/gardener/shoot/internal/zerodowntimevalidator/validator.go
+++ b/test/e2e/gardener/shoot/internal/zerodowntimevalidator/validator.go
@@ -72,6 +72,13 @@ func (j *Job) AfterAllDeleteJob(s *ShootContext) {
 	GinkgoHelper()
 
 	AfterAll(func(ctx SpecContext) {
+		// In ordered containers, the seed client might not have been initialized if a previous spec failed,
+		// e.g., before ItShouldInitializeSeedClient ran. Skip the deletion in this case to avoid a panic
+		// that would mask the actual failure.
+		if s.SeedClient == nil {
+			return
+		}
+
 		j.initJobIfNeeded(s)
 		Eventually(ctx, func() error {
 			return s.SeedClient.Delete(ctx, j.job, client.PropagationPolicy(metav1.DeletePropagationForeground))


### PR DESCRIPTION
Follow-up on the secondary issue reported in #15326: the nil pointer dereference in `AfterAllDeleteJob` when a spec is interrupted before the seed client is initialized.

**What happened / why this is needed**

In ordered e2e containers (e.g., `create_update_delete.go`, `gardenerupgrade/create_upgrade_delete.go`), ginkgo still runs `AfterAll` cleanup nodes when an earlier spec failed and the remaining specs are skipped. The seed client (`ShootContext.SeedClient`) is only initialized by the `ItShouldInitializeSeedClient` spec, so if a failure happens before that spec ran (for example the flaky `Wait for Shoot to be reconciled` spec referenced in #15326), `s.SeedClient` is nil and the `Delete` call in the cleanup node panics. That panic masks the actual failure and interrupts the remaining cleanup, as described in #15326.

**Fix**

As suggested in the issue, return early from the cleanup node when the seed client was not initialized. In that state no validator job can have been deployed through this client, so there is nothing to delete. The initialized path is unchanged.

Note for the `gardenerupgrade` flow: if the post-upgrade run fails to (re-)initialize the seed client, the job deployed by the pre-upgrade run is not deleted by this node — the same was true before this change (the code panicked in exactly that state and also left the job behind), and the job is reclaimed when the shoot control plane namespace is torn down.

**Verification**

- `gofmt`, `go vet`, `go build ./test/e2e/...` clean
- ginkgolinter (v0.23.0, the pinned version) clean
