### PR TITLE
Optimize e2e CI execution time with `SpecPriority`

### DIFF
--- a/test/e2e/gardener/managedseed/create_rotate_delete.go
+++ b/test/e2e/gardener/managedseed/create_rotate_delete.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gardener/gardener/test/utils/rotation"
 )
 
-var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), Ordered, func() {
+var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), Ordered, PriorityLonger, func() {
 	var s *ManagedSeedContext
 
 	BeforeTestSetup(func() {

--- a/test/e2e/gardener/project/project_roles.go
+++ b/test/e2e/gardener/project/project_roles.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/gardener/gardener/test/e2e/gardener"
 )
 
-var _ = Describe("Project Tests", Ordered, Label("Project", "default"), func() {
+var _ = Describe("Project Tests", Ordered, Label("Project", "default"), PriorityFast, func() {
 	var s *ProjectContext
 
 	var (

--- a/test/e2e/gardener/seed/renew_garden_access_secrets.go
+++ b/test/e2e/gardener/seed/renew_garden_access_secrets.go
@@ -29,7 +29,7 @@ import (
 )
 
 var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
-	Describe("Garden Cluster Access For Seed Components", Ordered, func() {
+	Describe("Garden Cluster Access For Seed Components", Ordered, PriorityFast, func() {
 		var (
 			s                *SeedContext
 			seedNamespace    string

--- a/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
+++ b/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
@@ -19,7 +19,7 @@ import (
 )
 
 var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
-	Describe("Renew gardenlet kubeconfig", Ordered, func() {
+	Describe("Renew gardenlet kubeconfig", Ordered, PriorityFast, func() {
 		var (
 			s        *SeedContext
 			verifier rotation.GardenletKubeconfigRotationVerifier

--- a/test/e2e/gardener/shoot/create_delete_failed.go
+++ b/test/e2e/gardener/shoot/create_delete_failed.go
@@ -16,7 +16,7 @@ import (
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
-	Describe("Create and Delete Failed Shoot", func() {
+	Describe("Create and Delete Failed Shoot", PriorityFast, func() {
 		Context("Shoot with invalid DNS configuration", Ordered, func() {
 			var s *ShootContext
 

--- a/test/e2e/gardener/shoot/create_delete_unprivileged.go
+++ b/test/e2e/gardener/shoot/create_delete_unprivileged.go
@@ -22,7 +22,7 @@ import (
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
-	Describe("Create and Delete Unprivileged Shoot. Test expected shoot logs", Ordered, Label("unprivileged", "basic", "observability"), func() {
+	Describe("Create and Delete Unprivileged Shoot. Test expected shoot logs", Ordered, Label("unprivileged", "basic", "observability"), PriorityLong, func() {
 		var s *ShootContext
 
 		BeforeTestSetup(func() {

--- a/test/e2e/gardener/shoot/create_encr_provider_change_delete.go
+++ b/test/e2e/gardener/shoot/create_encr_provider_change_delete.go
@@ -37,7 +37,7 @@ func init() {
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	Describe("Create Shoot, Change Encryption Provider Type and Delete Shoot", Label("encryption-provider-change"), func() {
-		Context("Shoot with workers", Ordered, func() {
+		Context("Shoot with workers", Ordered, PriorityLong, func() {
 			var s *ShootContext
 
 			BeforeTestSetup(func() {

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -66,15 +66,15 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			ItShouldWaitForShootToBeDeleted(s)
 		}
 
-		Context("Shoot with workers", Label("basic"), Ordered, func() {
+		Context("Shoot with workers", Label("basic"), Ordered, PriorityLong, func() {
 			test(NewTestContext().ForShoot(DefaultShoot("e2e-wake-up")))
 		})
 
-		Context("Workerless Shoot", Label("workerless"), Ordered, func() {
+		Context("Workerless Shoot", Label("workerless"), Ordered, PriorityLong, func() {
 			test(NewTestContext().ForShoot(DefaultWorkerlessShoot("e2e-wake-up")))
 		})
 
-		Context("Shoot with workers with NamespacedCloudProfile", Label("basic"), Ordered, func() {
+		Context("Shoot with workers with NamespacedCloudProfile", Label("basic"), Ordered, PriorityLong, func() {
 			var s *ShootContext
 
 			BeforeTestSetup(func() {

--- a/test/e2e/gardener/shoot/create_migrate_delete.go
+++ b/test/e2e/gardener/shoot/create_migrate_delete.go
@@ -14,6 +14,7 @@ import (
 
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/test/e2e"
 	. "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/e2e/gardener/seed"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
@@ -92,15 +93,15 @@ var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func(
 		ItShouldWaitForShootToBeDeleted(s)
 	}
 
-	Context("Shoot with workers", Ordered, func() {
+	Context("Shoot with workers", Ordered, PriorityLonger, func() {
 		test(NewTestContext().ForShoot(DefaultShoot("e2e-migrate")))
 	})
 
-	Context("Workerless Shoot", Label("workerless"), Ordered, func() {
+	Context("Workerless Shoot", Label("workerless"), Ordered, PriorityLong, func() {
 		test(NewTestContext().ForShoot(DefaultWorkerlessShoot("e2e-migrate")))
 	})
 
-	Context("Hibernated Shoot", Label("hibernated"), Ordered, func() {
+	Context("Hibernated Shoot", Label("hibernated"), Ordered, PriorityLong, func() {
 		shoot := DefaultShoot("e2e-mgr-hib")
 		shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
 			Enabled: new(true),

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -433,7 +433,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		}
 
 		Context("Shoot with workers", Label("basic"), func() {
-			Context("with workers rollout", Label("with-workers-rollout"), Ordered, func() {
+			Context("with workers rollout", Label("with-workers-rollout"), Ordered, PriorityLonger, func() {
 				var s *ShootContext
 
 				BeforeTestSetup(func() {
@@ -455,7 +455,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				test(s, false, false, true)
 			})
 
-			Context("without workers rollout", Label("without-workers-rollout"), Ordered, func() {
+			Context("without workers rollout", Label("without-workers-rollout"), Ordered, PriorityLonger, func() {
 				var s *ShootContext
 
 				BeforeTestSetup(func() {
@@ -482,7 +482,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			})
 		})
 
-		Context("Workerless Shoot", Label("workerless"), Ordered, func() {
+		Context("Workerless Shoot", Label("workerless"), Ordered, PriorityLong, func() {
 			test(NewTestContext().ForShoot(DefaultWorkerlessShoot("e2e-rotate")), false, false, false)
 		})
 	})

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -259,15 +259,15 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			ItShouldWaitForShootToBeDeleted(s)
 		}
 
-		Context("Shoot with workers", Label("basic"), Ordered, func() {
+		Context("Shoot with workers", Label("basic"), Ordered, PriorityLong, func() {
 			test(NewTestContext().ForShoot(DefaultShoot("e2e-default")), false)
 		})
 
-		Context("Shoot with only in-place workers", Label("basic", "in-place"), Ordered, func() {
+		Context("Shoot with only in-place workers", Label("basic", "in-place"), Ordered, PriorityLong, func() {
 			test(NewTestContext().ForShoot(DefaultShoot("e2e-inplace")), true)
 		})
 
-		Context("Shoot with workers and layer 4 load balancing", Ordered, Label("basic"), func() {
+		Context("Shoot with workers and layer 4 load balancing", Ordered, Label("basic"), PriorityLong, func() {
 			shoot := DefaultShoot("e2e-layer4-lb")
 			metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.ShootDisableIstioTLSTermination, "true")
 			test(NewTestContext().ForShoot(shoot), false)

--- a/test/e2e/ginkgo.go
+++ b/test/e2e/ginkgo.go
@@ -15,6 +15,17 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// These decorators are used to prioritize long-running tests cases ("boulders first, then sand"),
+// see https://onsi.github.io/ginkgo/#prioritizing-specs.
+const (
+	// PriorityLonger is used for the longest-running tests (typically > 30 minutes).
+	PriorityLonger = SpecPriority(10)
+	// PriorityLong is used for long-running tests (typically > 15 minutes).
+	PriorityLong = SpecPriority(5)
+	// PriorityFast is used for fast tests (typically < 3 minutes).
+	PriorityFast = SpecPriority(-1)
+)
+
 // BeforeTestSetup looks like a ginkgo setup node but runs the given function right away, i.e., during ginkgo's tree
 // construction. It's sole purpose is to structure test setup code similar to BeforeEach and friends, while allowing to
 // use the side effects when constructing further test nodes.


### PR DESCRIPTION
**How to categorize this PR?**
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR introduces `SpecPriority` decorators to long-running e2e tests to prioritize their execution ("boulders first, then sand"), see [Ginkgo docs](https://onsi.github.io/ginkgo/#prioritizing-specs). This is intended to reduce the total wall-clock time of CI jobs by starting the most time-consuming tests as early as possible. Note that this will not speed up jobs more than the shortest execution time we already observe (chance might order them fortunately), but it will prevent "unfortunate ordering" and yield more consistently low execution times.

The priorities were determined based on the script in https://gist.github.com/timebertt/690bc3559c821d43d9915845ec100cf1. The script was executed for the past 20 successful test runs of the following periodic jobs that typically take more than an hour:
- ci-gardener-e2e-kind
- ci-gardener-e2e-kind-ha-multi-node
- ci-gardener-e2e-kind-ha-multi-zone
- ci-gardener-e2e-kind-ha-multi-zone-upgrade
- ci-gardener-e2e-kind-ipv6
- ci-gardener-e2e-kind-migration-ha-multi-node

Priorities are assigned based on the maximum p50 duration across these jobs:
- PriorityLonger (10): > 30 minutes
- PriorityLong (5): > 15 minutes
- PriorityFast (-1): < 3 minutes

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
The constants `PriorityLonger`, `PriorityLong`, and `PriorityFast` were introduced in `test/e2e/ginkgo.go` to centralize the priority values.

**Release note**:
```other operator
NONE
```