### PR TITLE
Retry gardener API resource creations in credentialsbinding integration test

### DIFF
--- a/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
+++ b/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
@@ -5,8 +5,6 @@
 package credentialsbinding_test
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -117,7 +115,7 @@ var _ = Describe("CredentialsBinding controller test", func() {
 			// for the resource yet) and can reject the request with 503 ServiceUnavailable.
 			Eventually(func() error {
 				return testClient.Create(ctx, shoot)
-			}).WithTimeout(30 * time.Second).Should(Succeed())
+			}).Should(Succeed())
 			log.Info("Created Shoot for test", "shoot", client.ObjectKeyFromObject(shoot))
 
 			By("Wait until manager has observed shoot")
@@ -134,14 +132,14 @@ var _ = Describe("CredentialsBinding controller test", func() {
 		// Quota is also served by the gardener API server, so retry it for the same reason.
 		Eventually(func() error {
 			return testClient.Create(ctx, quota)
-		}).WithTimeout(30 * time.Second).Should(Succeed())
+		}).Should(Succeed())
 		log.Info("Created Quota for test", "quota", client.ObjectKeyFromObject(quota))
 
 		By("Create CredentialsBinding")
 		// Retry the creation, see the comment above about the gardener API server warm-up.
 		Eventually(func() error {
 			return testClient.Create(ctx, credentialsBinding)
-		}).WithTimeout(30 * time.Second).Should(Succeed())
+		}).Should(Succeed())
 		log.Info("Created CredentialsBinding for test", "credentialsBinding", client.ObjectKeyFromObject(credentialsBinding))
 
 		DeferCleanup(func() {

--- a/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
+++ b/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
@@ -5,6 +5,8 @@
 package credentialsbinding_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -115,7 +117,7 @@ var _ = Describe("CredentialsBinding controller test", func() {
 			// for the resource yet) and can reject the request with 503 ServiceUnavailable.
 			Eventually(func() error {
 				return testClient.Create(ctx, shoot)
-			}).Should(Succeed())
+			}).WithTimeout(30 * time.Second).Should(Succeed())
 			log.Info("Created Shoot for test", "shoot", client.ObjectKeyFromObject(shoot))
 
 			By("Wait until manager has observed shoot")
@@ -129,14 +131,17 @@ var _ = Describe("CredentialsBinding controller test", func() {
 		log.Info("Created Secret for test", "secret", client.ObjectKeyFromObject(secret))
 
 		By("Create Quota")
-		Expect(testClient.Create(ctx, quota)).To(Succeed())
+		// Quota is also served by the gardener API server, so retry it for the same reason.
+		Eventually(func() error {
+			return testClient.Create(ctx, quota)
+		}).WithTimeout(30 * time.Second).Should(Succeed())
 		log.Info("Created Quota for test", "quota", client.ObjectKeyFromObject(quota))
 
 		By("Create CredentialsBinding")
 		// Retry the creation, see the comment above about the gardener API server warm-up.
 		Eventually(func() error {
 			return testClient.Create(ctx, credentialsBinding)
-		}).Should(Succeed())
+		}).WithTimeout(30 * time.Second).Should(Succeed())
 		log.Info("Created CredentialsBinding for test", "credentialsBinding", client.ObjectKeyFromObject(credentialsBinding))
 
 		DeferCleanup(func() {

--- a/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
+++ b/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
@@ -110,7 +110,12 @@ var _ = Describe("CredentialsBinding controller test", func() {
 			// Otherwise, the controller might clean up the CredentialsBinding too early because it thinks all referencing shoots
 			// are gone. Similar to https://github.com/gardener/gardener/issues/6486
 			By("Create Shoot")
-			Expect(testClient.Create(ctx, shoot)).To(Succeed())
+			// Retry the creation: when the first spec of the suite runs, the gardener API server might
+			// still be warming up (e.g., the quota admission plugin has not registered its evaluator
+			// for the resource yet) and can reject the request with 503 ServiceUnavailable.
+			Eventually(func() error {
+				return testClient.Create(ctx, shoot)
+			}).Should(Succeed())
 			log.Info("Created Shoot for test", "shoot", client.ObjectKeyFromObject(shoot))
 
 			By("Wait until manager has observed shoot")
@@ -128,7 +133,10 @@ var _ = Describe("CredentialsBinding controller test", func() {
 		log.Info("Created Quota for test", "quota", client.ObjectKeyFromObject(quota))
 
 		By("Create CredentialsBinding")
-		Expect(testClient.Create(ctx, credentialsBinding)).To(Succeed())
+		// Retry the creation, see the comment above about the gardener API server warm-up.
+		Eventually(func() error {
+			return testClient.Create(ctx, credentialsBinding)
+		}).Should(Succeed())
 		log.Info("Created CredentialsBinding for test", "credentialsBinding", client.ObjectKeyFromObject(credentialsBinding))
 
 		DeferCleanup(func() {

--- a/test/integration/gardenlet/tokenrequestor/workloadidentity/workloadidentity_test.go
+++ b/test/integration/gardenlet/tokenrequestor/workloadidentity/workloadidentity_test.go
@@ -81,7 +81,12 @@ var _ = Describe("WorkloadIdentity TokenRequestor tests", func() {
 	It("should behave correctly when: create w/o label, update w/ label, delete w/ label", func() {
 		secret.Labels = nil
 		Expect(testClient.Create(ctx, secret)).To(Succeed())
-		Expect(testClient.Create(ctx, workloadIdentity)).To(Succeed())
+		// Retry the creation: when the first spec of the suite runs, the gardener API server might
+		// still be warming up (e.g., the quota admission plugin has not registered its evaluator
+		// for the resource yet) and can reject the request with 503 ServiceUnavailable.
+		Eventually(func() error {
+			return testClient.Create(ctx, workloadIdentity)
+		}).Should(Succeed())
 		Expect(testClient.Get(ctx, client.ObjectKeyFromObject(workloadIdentity), workloadIdentity)).To(Succeed())
 
 		Consistently(func(g Gomega) {


### PR DESCRIPTION
The credentialsbinding integration suite flaked in multiple PRs (tracked in #15399) with:

```
the server is currently unable to handle the request (post credentialsbindings.security.gardener.cloud)
```

at `credentialsbinding_test.go:131` (the `Create CredentialsBinding` in the `JustBeforeEach`). Example: PR #15352, `pull-gardener-integration`, build `2081169002473721856`.

**Root cause:** the gardener API server can still be warming up when the first spec of the suite runs. The quota admission plugin registers its evaluator for `credentialsbindings.security.gardener.cloud` asynchronously shortly after the API server starts serving — in the failing build, the evaluator was registered ~14ms after the POST that got rejected with 503 `ServiceUnavailable`. Only the first spec can hit this; the remaining specs pass because the evaluator is registered by then (the failing run: `3 Passed | 1 Failed`).

**Fix:** wrap the Shoot, Quota and CredentialsBinding creations in `Eventually` with an explicit `WithTimeout(30 * time.Second)` so they are retried until the API server is ready. All three are gardener API-group resources (`core.gardener.cloud` / `security.gardener.cloud`) served by the same gardener API server and subject to the same admission warm-up race; the `Secret` creation is left as-is (core/v1, never observed flaking). The `Eventually(Create)` pattern follows `test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go`.

**Verification:** `gofmt`, `go vet`, ginkgolinter (v0.23.0) clean; the full suite passes locally (`go test ./test/integration/controllermanager/credentialsbinding/` — ok).
