### PR TITLE
[GEP-28] `gardenadm restore`: Reuse and run the bootstrap control plane and init flows of `gardenadm init`

### DIFF
--- a/docs/cli-reference/gardenadm/gardenadm_init.md
+++ b/docs/cli-reference/gardenadm/gardenadm_init.md
@@ -23,13 +23,12 @@ gardenadm init --config-dir /path/to/manifests --zone zone-a
 ### Options
 
 ```
-      --backup-data-path string   Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
-  -d, --config-dir string         Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
-      --force                     If set, the init command will be executed even if the control plane is already initialized.
-  -h, --help                      help for init
-      --use-bootstrap-etcd        If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This can be useful for testing purposes to save time.
-      --use-host-network          If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.
-  -z, --zone string               Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.
+  -d, --config-dir string    Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
+      --force                If set, the init command will be executed even if the control plane is already initialized.
+  -h, --help                 help for init
+      --use-bootstrap-etcd   If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This can be useful for testing purposes to save time.
+      --use-host-network     If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.
+  -z, --zone string          Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -57,10 +57,6 @@ type GardenadmBotanist struct {
 	// topology.kubernetes.io/zone label on the node resource.
 	Zone *string
 
-	// BackupDataPath is the local path on the node where the etcd backup data is stored.
-	// When set, the bootstrap etcd will be initialized from this path using the Local storage provider.
-	BackupDataPath string
-
 	operatingSystemConfigSecret *corev1.Secret
 
 	// controlPlaneMachines is set by ListControlPlaneMachines during `gardenadm bootstrap`.

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -36,12 +36,12 @@ import (
 
 // DeployOperatingSystemConfigSecretForBootstrap deploys the OperatingSystemConfig resource and adds its content into
 // a Secret so that gardener-node-agent can read it and reconcile its content.
-func (b *GardenadmBotanist) DeployOperatingSystemConfigSecretForBootstrap(ctx context.Context) error {
-	if err := b.DeployControlPlaneDeployments(ctx, true, false, b.BackupDataPath); err != nil {
+func (b *GardenadmBotanist) DeployOperatingSystemConfigSecretForBootstrap(ctx context.Context, backupDataPath string) error {
+	if err := b.DeployControlPlaneDeployments(ctx, true, false, backupDataPath); err != nil {
 		return fmt.Errorf("failed deploying control plane deployments: %w", err)
 	}
 
-	oscData, controlPlaneWorkerPoolName, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, true, false, b.BackupDataPath)
+	oscData, controlPlaneWorkerPoolName, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, true, false, backupDataPath)
 	if err != nil {
 		return fmt.Errorf("failed deploying OperatingSystemConfig: %w", err)
 	}

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -61,12 +61,19 @@ gardenadm init --config-dir /path/to/manifests --zone zone-a`,
 	return cmd
 }
 
+// run bootstraps the control plane and then runs the main init flow that deploys the shoot components.
 func run(ctx context.Context, opts *Options) error {
-	b, err := bootstrapControlPlane(ctx, opts)
+	b, err := BootstrapControlPlane(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("failed bootstrapping control plane: %w", err)
 	}
 
+	return RunInitFlow(ctx, b, opts)
+}
+
+// RunInitFlow runs the main init flow that deploys the shoot components on an already-bootstrapped control plane.
+// It is exported so that the `gardenadm restore` command can reuse the same graph.
+func RunInitFlow(ctx context.Context, b *gardenadmbotanist.GardenadmBotanist, opts *Options) error {
 	dir := filepath.Dir(cmd.ConfigDirLocation)
 	if err := b.FS.MkdirAll(dir, os.ModeDir); err != nil {
 		return fmt.Errorf("failed creating config directory location dir %s: %w", dir, err)
@@ -287,7 +294,9 @@ see https://gardener.cloud/docs/gardener/shoot/shoot_access/.
 	return nil
 }
 
-func bootstrapControlPlane(ctx context.Context, opts *Options) (*gardenadmbotanist.GardenadmBotanist, error) {
+// BootstrapControlPlane bootstraps the control plane node and returns a GardenadmBotanist connected to the API server.
+// It is exported so that the `gardenadm restore` command can reuse the same graph.
+func BootstrapControlPlane(ctx context.Context, opts *Options) (*gardenadmbotanist.GardenadmBotanist, error) {
 	b, err := gardenadmbotanist.NewGardenadmBotanistFromManifests(ctx, opts.Log, nil, opts.ConfigDir, true)
 	if err != nil {
 		return nil, err

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -193,7 +193,7 @@ func RunInitFlow(ctx context.Context, b *gardenadmbotanist.GardenadmBotanist, op
 				WithDependencies(syncPointBootstrapped, reconcileBackupEntry).
 				SkipIf(opts.UseBootstrapEtcd),
 		)
-		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(opts.UseBootstrapEtcd, ""))
+		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(opts.UseBootstrapEtcd))
 
 		_ = g.Add(flow.Task{
 			Name:         "Finalizing ETCD bootstrap transition (cleanup bootstrap ETCD left-overs)",
@@ -307,8 +307,6 @@ func BootstrapControlPlane(ctx context.Context, opts *Options, backupDataPath st
 		b.Zone = new(opts.Zone)
 	}
 
-	b.BackupDataPath = backupDataPath
-
 	kubeconfigFileExists, err := b.FS.Exists(botanist.PathKubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed checking whether kubeconfig file %s exists: %w", botanist.PathKubeconfig, err)
@@ -350,8 +348,10 @@ func BootstrapControlPlane(ctx context.Context, opts *Options, backupDataPath st
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement),
 		})
 		deployOperatingSystemConfigSecretForNodeAgent = g.Add(flow.Task{
-			Name:         "Generating OperatingSystemConfig and deploying Secret for gardener-node-agent",
-			Fn:           b.DeployOperatingSystemConfigSecretForBootstrap,
+			Name: "Generating OperatingSystemConfig and deploying Secret for gardener-node-agent",
+			Fn: func(ctx context.Context) error {
+				return b.DeployOperatingSystemConfigSecretForBootstrap(ctx, backupDataPath)
+			},
 			SkipIf:       kubeconfigFileExists,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement),
 		})

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -63,7 +63,7 @@ gardenadm init --config-dir /path/to/manifests --zone zone-a`,
 
 // run bootstraps the control plane and then runs the main init flow that deploys the shoot components.
 func run(ctx context.Context, opts *Options) error {
-	b, err := BootstrapControlPlane(ctx, opts)
+	b, err := BootstrapControlPlane(ctx, opts, "")
 	if err != nil {
 		return fmt.Errorf("failed bootstrapping control plane: %w", err)
 	}
@@ -193,7 +193,7 @@ func RunInitFlow(ctx context.Context, b *gardenadmbotanist.GardenadmBotanist, op
 				WithDependencies(syncPointBootstrapped, reconcileBackupEntry).
 				SkipIf(opts.UseBootstrapEtcd),
 		)
-		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(opts.UseBootstrapEtcd, opts.BackupDataPath))
+		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(opts.UseBootstrapEtcd, ""))
 
 		_ = g.Add(flow.Task{
 			Name:         "Finalizing ETCD bootstrap transition (cleanup bootstrap ETCD left-overs)",
@@ -295,8 +295,9 @@ see https://gardener.cloud/docs/gardener/shoot/shoot_access/.
 }
 
 // BootstrapControlPlane bootstraps the control plane node and returns a GardenadmBotanist connected to the API server.
+// When backupDataPath is non-empty, the bootstrap etcd is initialized from that local snapshot for disaster recovery.
 // It is exported so that the `gardenadm restore` command can reuse the same graph.
-func BootstrapControlPlane(ctx context.Context, opts *Options) (*gardenadmbotanist.GardenadmBotanist, error) {
+func BootstrapControlPlane(ctx context.Context, opts *Options, backupDataPath string) (*gardenadmbotanist.GardenadmBotanist, error) {
 	b, err := gardenadmbotanist.NewGardenadmBotanistFromManifests(ctx, opts.Log, nil, opts.ConfigDir, true)
 	if err != nil {
 		return nil, err
@@ -306,7 +307,7 @@ func BootstrapControlPlane(ctx context.Context, opts *Options) (*gardenadmbotani
 		b.Zone = new(opts.Zone)
 	}
 
-	b.BackupDataPath = opts.BackupDataPath
+	b.BackupDataPath = backupDataPath
 
 	kubeconfigFileExists, err := b.FS.Exists(botanist.PathKubeconfig)
 	if err != nil {

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -34,12 +34,6 @@ type Options struct {
 	// If it has exactly one zone configured, that zone is automatically applied and the flag is optional.
 	// If it has no zones configured, this flag must not be set.
 	Zone string
-	// BackupDataPath is the local path on the node where the etcd backup data is stored.
-	// When set, the bootstrap etcd will be initialized from this path using the Local storage provider.
-	// The path is expected to have the structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2.
-	//
-	// TODO(ialidzhikov): Remove this option in favor of the same BackupDataPath option in the `gardenadm restore` command.
-	BackupDataPath string
 }
 
 // ParseArgs parses the arguments to the options.
@@ -78,6 +72,4 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.UseHostNetwork, "use-host-network", false, "If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.")
 	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
 	fs.BoolVar(&o.Force, "force", false, "If set, the init command will be executed even if the control plane is already initialized.")
-	// TODO(ialidzhikov): Remove this flag in favor of the same `--backup-data-path` flag in the `gardenadm restore` command.
-	fs.StringVar(&o.BackupDataPath, "backup-data-path", "", "Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2")
 }

--- a/pkg/gardenadm/cmd/restore/restore.go
+++ b/pkg/gardenadm/cmd/restore/restore.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	gardenadmbotanist "github.com/gardener/gardener/pkg/gardenadm/botanist"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
+	initcmd "github.com/gardener/gardener/pkg/gardenadm/cmd/init"
 )
 
 // NewCommand creates a new cobra.Command.
@@ -51,6 +53,31 @@ gardenadm restore --config-dir /path/to/manifests --backup-data-path /path/to/et
 	return cmd
 }
 
-func run(_ context.Context, _ *Options) error {
-	return fmt.Errorf("the gardenadm restore command is not implemented yet, see https://github.com/gardener/gardener/issues/15279 for more details")
+func run(ctx context.Context, opts *Options) error {
+	initOpts := &initcmd.Options{
+		Options:         opts.Options,
+		ManifestOptions: opts.ManifestOptions,
+		// Restore requires an etcd backup, which only a control plane using etcd-druid (not the bootstrap etcd)
+		// produces. Hence, restore always transitions to etcd-druid and does not expose --use-bootstrap-etcd.
+		UseBootstrapEtcd: false,
+		UseHostNetwork:   false,
+		Zone:             opts.Zone,
+	}
+
+	b, err := initcmd.BootstrapControlPlane(ctx, initOpts, opts.BackupDataPath)
+	if err != nil {
+		return fmt.Errorf("failed bootstrapping control plane: %w", err)
+	}
+
+	if err := performRequiredCleanups(ctx, b, opts.PriorNodeName); err != nil {
+		return fmt.Errorf("failed performing required cleanups: %w", err)
+	}
+
+	return initcmd.RunInitFlow(ctx, b, initOpts)
+}
+
+func performRequiredCleanups(_ context.Context, _ *gardenadmbotanist.GardenadmBotanist, _ string) error {
+	// TODO(ialidzhikov): Implement the required cleanups before running the init flow.
+	// For more details, see https://github.com/gardener/gardener/issues/15279.
+	return nil
 }

--- a/pkg/gardenadm/cmd/restore/restore.go
+++ b/pkg/gardenadm/cmd/restore/restore.go
@@ -6,13 +6,13 @@ package restore
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
 	gardenadmbotanist "github.com/gardener/gardener/pkg/gardenadm/botanist"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	initcmd "github.com/gardener/gardener/pkg/gardenadm/cmd/init"
+	"github.com/gardener/gardener/pkg/utils/flow"
 )
 
 // NewCommand creates a new cobra.Command.
@@ -64,20 +64,36 @@ func run(ctx context.Context, opts *Options) error {
 		Zone:             opts.Zone,
 	}
 
-	b, err := initcmd.BootstrapControlPlane(ctx, initOpts, opts.BackupDataPath)
-	if err != nil {
-		return fmt.Errorf("failed bootstrapping control plane: %w", err)
+	var (
+		b *gardenadmbotanist.GardenadmBotanist
+
+		g = flow.NewGraph("restore")
+
+		bootstrapControlPlane = g.Add(flow.Task{
+			Name: "Bootstrapping control plane",
+			Fn: func(ctx context.Context) error {
+				var err error
+				b, err = initcmd.BootstrapControlPlane(ctx, initOpts, opts.BackupDataPath)
+				return err
+			},
+		})
+		// TODO(ialidzhikov): Implement the required cleanups before running the init flow.
+		// For more details, see https://github.com/gardener/gardener/issues/15279.
+		_ = g.Add(flow.Task{
+			Name: "Running init flow",
+			Fn: func(ctx context.Context) error {
+				return initcmd.RunInitFlow(ctx, b, initOpts)
+			},
+			Dependencies: flow.NewTaskIDs(bootstrapControlPlane),
+		})
+	)
+
+	if err := g.Compile().Run(ctx, flow.Opts{
+		Log:              opts.Log,
+		ProgressReporter: flow.NewCommandLineProgressReporter(opts.ErrOut),
+	}); err != nil {
+		return flow.Errors(err)
 	}
 
-	if err := performRequiredCleanups(ctx, b, opts.PriorNodeName); err != nil {
-		return fmt.Errorf("failed performing required cleanups: %w", err)
-	}
-
-	return initcmd.RunInitFlow(ctx, b, initOpts)
-}
-
-func performRequiredCleanups(_ context.Context, _ *gardenadmbotanist.GardenadmBotanist, _ string) error {
-	// TODO(ialidzhikov): Implement the required cleanups before running the init flow.
-	// For more details, see https://github.com/gardener/gardener/issues/15279.
 	return nil
 }

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -754,7 +754,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			deployKubernetesDashboard,
 			deployNginxIngressAddon,
 		)
-		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false, ""))
+		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false))
 
 		scaleClusterAutoscalerToZero = g.Add(flow.Task{
 			Name:         "Scaling down cluster autoscaler",

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -628,7 +628,7 @@ const TaskGroupReconcileStaticPods flow.TaskID = "TaskGroupReconcileStaticPods"
 // deployments to the cluster (with replicas=0). It then translates them into static pod manifests, adds them to the
 // OperatingSystemConfig, updates the ManagedResource containing the gardener-node-agent OSC Secret, and waits for the
 // changes to be rolled out.
-func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd bool, backupDataPath string) flow.TaskGroup {
+func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileStaticPods).WithDependencies(
 			TaskGroupInitializeSecretsManagement,
@@ -646,7 +646,7 @@ func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd boo
 		deployControlPlaneDeployments = g.Add(flow.Task{
 			Name: "Deploying control plane components as Deployments/StatefulSets and updating gardener-node-agent Secret",
 			Fn: func(ctx context.Context) error {
-				return b.DeployStaticControlPlaneDeployments(ctx, useBootstrapEtcd, backupDataPath)
+				return b.DeployStaticControlPlaneDeployments(ctx, useBootstrapEtcd)
 			},
 		})
 		// 'gardenadm init' creates the OperatingSystemConfig and gardener-node-agent secrets based on the Shoot

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -147,17 +147,17 @@ func (b *Botanist) staticControlPlaneComponents(useBootstrapEtcd, useShootAccess
 // DeployStaticControlPlaneDeployments deploys the deployments for the static control plane components. It also updates
 // the OperatingSystemConfig, waits for it to be reconciled by the OS extension, and deploys the ManagedResource
 // containing the Secret with OperatingSystemConfig for gardener-node-agent.
-func (b *Botanist) DeployStaticControlPlaneDeployments(ctx context.Context, useBootstrapEtcd bool, bootstrapEtcdBackupPath string) error {
+func (b *Botanist) DeployStaticControlPlaneDeployments(ctx context.Context, useBootstrapEtcd bool) error {
 	useShootAccessTokens, err := b.useShootAccessTokensForSelfHostedShootControlPlane(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to check whether static auth tokens for self-hosted shoot control plane components can be synced: %w", err)
 	}
 
-	if err := b.DeployControlPlaneDeployments(ctx, useBootstrapEtcd, useShootAccessTokens, bootstrapEtcdBackupPath); err != nil {
+	if err := b.DeployControlPlaneDeployments(ctx, useBootstrapEtcd, useShootAccessTokens, ""); err != nil {
 		return fmt.Errorf("failed deploying control plane deployments: %w", err)
 	}
 
-	if _, _, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, useBootstrapEtcd, useShootAccessTokens, bootstrapEtcdBackupPath); err != nil {
+	if _, _, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, useBootstrapEtcd, useShootAccessTokens, ""); err != nil {
 		return fmt.Errorf("failed deploying OperatingSystemConfig: %w", err)
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area disaster-recovery control-plane ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the `gardenadm restore` command to reuse and run the bootstrap control plane and init flows of `gardenadm init`.
The main differences between `gardenadm restore` and `gardenadm init` are:
- `gardenadm restore` bootstraps the control plane with a bootstrap etcd using the provided etcd backup path; `gardenadm init` bootstraps the control plane with a fresh bootstrap etcd.
- `gardenad restore` performs required cleanups before running the init flow. For more details, see https://github.com/gardener/gardener/issues/15279. These cleanups will be contributed in a follow-up PR.
- `gardenadm restore` requires ShootState, BackupBucket and BackupEntry in the manifests dir. It restores the Secrets from the ShootState while `gardenadm init` always generates new set of Secrets. Additionally, it restores the etcd (the non-bootstrap etcd) from the provided BackupBucket and BackupEntry while `gardenadm init` always runs the etcd without restoring it from a prior BackupBucket and BackupEntry.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/15279

**Special notes for your reviewer**:
~~This PR is based on https://github.com/gardener/gardener/pull/15453. It is put on hold until https://github.com/gardener/gardener/pull/15453 is merged.~~
~~/hold~~

To test this change in local setup, use the disaster recovery scripts in the [Unmanaged infrastructure PoC](https://github.com/Kostov6/gardener/tree/poc/local-gapi-unmanaged-same-node) branch.

```bash
# Prerequisite
./hack/dr-kind-connect-up.sh

# Restore the control plane Node
./hack/dr-unmanaged-same-node.sh
```

The init flow triggered by `gardenadm restore` as expected fails with:
```
2026-08-13T08:09:31.889Z	ERROR	Error	{"flow": "init", "task": "Waiting until gardener-resource-manager reports readiness", "error": "1 error occurred:\n\t* retry failed with context deadline exceeded, last error: ReplicaSet \"gardener-resource-manager-656fd4f6cf\" is progressing.\n\n"}
github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func2
	github.com/gardener/gardener/pkg/utils/flow/flow.go:251
2026-08-13T08:09:31.890Z	INFO	Finished	{"flow": "init"}
Error: 1 error occurred:
	* task "Waiting until gardener-resource-manager reports readiness" failed: 1 error occurred:
	* retry failed with context deadline exceeded, last error: ReplicaSet "gardener-resource-manager-656fd4f6cf" is progressing.
```

This is because the required cleanups are not performed. The init flow wrongly detects the existing Node object and its stale NetworkUnavailable condition. Later on, the init flow wrongly concludes that Pod network is already set up and tries to deploy GRM in the Pod network when the Pod network is not set up.
This will be fixed after performing the required cleanups in the follow-up PR.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardenadm restore` command now reuses and runs the bootstrap control plane and init flows of `gardenadm init`.
```
