### PR TITLE
Renew `istio-client-certificate` 15 days before it expires

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/sni.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni.go
@@ -538,7 +538,7 @@ func (s *sni) reconcileIstioTLSSecrets(ctx context.Context, ownerNamespace *core
 		CertType:                    secretsutils.ClientCert,
 		SkipPublishingCACertificate: true,
 		Validity:                    new(time.Hour * 24 * 30),
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAFrontProxy), secretsmanager.Rotate(secretsmanager.InPlace))
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAFrontProxy), secretsmanager.Rotate(secretsmanager.InPlace), secretsmanager.RenewAfterValidityPercentage(50))
 	if err != nil {
 		return fmt.Errorf("failed to generate kube-apiserver client certificate for istio: %w", err)
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane robustness
/kind enhancement

**What this PR does / why we need it**:
When a shoot is in failed state its reconciliation is skipped. This means the `istio-client-certificate` which is used for communication between istio-ingressgateway and kube-apiserver when L7 LB is active is not renewed.
The certificate expires after 30 days and is renewed 10 days before it expires (the default secrets manager settings). This means that when a shoot is in state failed for more than 10 days, the certificate might expire and client certificate based authentication like kubelet is using does not work anymore. 

With this PR `istio-client-certificate` is renewed after 15 days (50% of lifetime). This prevents the certificate expiry when you follow the Gardener release train 🚂 because the shoot is reconciled at least when a new Gardener version is deployed.
It does not prevent the expiry entirely. However, shoots with important workload should be monitored that they do not stay in a failed state for such a long time anyway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`istio-client-certificate` is now renewed every 15 days.
```
