### PR TITLE
Work with `events.k8s.io` in `event` controller

### DIFF
--- a/pkg/controllermanager/controller/event/add.go
+++ b/pkg/controllermanager/controller/event/add.go
@@ -5,7 +5,7 @@
 package event
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -31,7 +31,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	return builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
-		For(&corev1.Event{}, builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Create))).
+		For(&eventsv1.Event{}, builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Create))).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: ptr.Deref(r.Config.ConcurrentSyncs, 0),
 			ReconciliationTimeout:   controllerutils.DefaultReconciliationTimeout,

--- a/pkg/controllermanager/controller/event/reconciler.go
+++ b/pkg/controllermanager/controller/event/reconciler.go
@@ -7,8 +7,9 @@ package event
 import (
 	"context"
 	"fmt"
+	"time"
 
-	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/clock"
@@ -31,7 +32,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	event := &corev1.Event{}
+	event := &eventsv1.Event{}
 	if err := r.Client.Get(ctx, req.NamespacedName, event); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.V(1).Info("Object is gone, stop reconciling")
@@ -44,7 +45,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 
-	deleteAt := event.LastTimestamp.Add(r.Config.TTLNonShootEvents.Duration)
+	deleteAt := getLastTimestampOf(event).Add(r.Config.TTLNonShootEvents.Duration)
 	timeUntilDeletion := deleteAt.Sub(r.Clock.Now())
 	if timeUntilDeletion > 0 {
 		return reconcile.Result{RequeueAfter: timeUntilDeletion}, nil
@@ -53,12 +54,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return reconcile.Result{}, r.Client.Delete(ctx, event)
 }
 
-func isShootEvent(event *corev1.Event) bool {
-	if gv, err := schema.ParseGroupVersion(event.InvolvedObject.APIVersion); err != nil || gv.Group != gardencorev1beta1.GroupName {
+func isShootEvent(event *eventsv1.Event) bool {
+	if gv, err := schema.ParseGroupVersion(event.Regarding.APIVersion); err != nil || gv.Group != gardencorev1beta1.GroupName {
 		return false
 	}
-	if event.InvolvedObject.Kind == "Shoot" {
+	if event.Regarding.Kind == "Shoot" {
 		return true
 	}
 	return false
+}
+
+func getLastTimestampOf(event *eventsv1.Event) time.Time {
+	// for series, take the last observed time
+	if event.Series != nil && !event.Series.LastObservedTime.IsZero() {
+		return event.Series.LastObservedTime.Time
+	}
+	// for single-occurrence events, take the first observed time
+	if firstTimestamp := event.EventTime.Time; !firstTimestamp.IsZero() {
+		return firstTimestamp
+	}
+
+	// for events reported via the old corev1.Event API,
+	// respect the legacy timestamp field
+	return event.DeprecatedLastTimestamp.Time
 }

--- a/pkg/controllermanager/controller/event/reconciler_test.go
+++ b/pkg/controllermanager/controller/event/reconciler_test.go
@@ -5,7 +5,7 @@
 package event_test
 
 import (
-	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -25,183 +24,111 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
-var _ = Describe("eventReconciler", func() {
+var _ = Describe("event reconciler", func() {
+	const ttl = time.Hour
+
 	var (
-		ctx        context.Context
-		fakeClient client.Client
 		fakeClock  *testclock.FakeClock
+		fakeClient client.Client
+		reconciler reconcile.Reconciler
 
-		shootEventName                  = "shootEvent-test"
-		nonShootEventName               = "nonShootEvent-test"
-		eventWithoutInvolvedObjectName  = "eventWithoutInvolvedObject-test"
-		nonGardenerAPIGroupEventName    = "nonGardenerAPIGroupEvent-test"
-		eventTimeEventName              = "eventTimeEvent-test"
-		seriesLastObservedTimeEventName = "seriesLastObservedTimeEvent-test"
-
-		ttl = &metav1.Duration{Duration: 1 * time.Hour}
-
-		reconciler                  reconcile.Reconciler
-		shootEvent                  *eventsv1.Event
-		nonShootEvent               *eventsv1.Event
-		nonGardenerAPIGroupEvent    *eventsv1.Event
-		eventWithoutInvolvedObject  *eventsv1.Event
-		eventTimeEvent              *eventsv1.Event
-		seriesLastObservedTimeEvent *eventsv1.Event
-		cfg                         controllermanagerconfigv1alpha1.EventControllerConfiguration
+		event   *eventsv1.Event
+		request reconcile.Request
 	)
 
 	BeforeEach(func() {
-		ctx = context.TODO()
+		fakeClock = testclock.NewFakeClock(time.Date(2022, 0, 0, 0, 0, 0, 0, time.UTC))
 
-		fakeNow := time.Date(2022, 0, 0, 0, 0, 0, 0, time.UTC)
-		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
-		fakeClock = testclock.NewFakeClock(fakeNow)
-
-		shootEvent = &eventsv1.Event{
-			ObjectMeta:              metav1.ObjectMeta{Name: shootEventName},
-			DeprecatedLastTimestamp: metav1.Time{Time: fakeNow},
-			Regarding:               corev1.ObjectReference{Kind: "Shoot", APIVersion: "core.gardener.cloud/v1beta1"},
-		}
-		nonShootEvent = &eventsv1.Event{
-			ObjectMeta:              metav1.ObjectMeta{Name: nonShootEventName},
-			DeprecatedLastTimestamp: metav1.Time{Time: fakeNow},
-			Regarding:               corev1.ObjectReference{Kind: "Project", APIVersion: "core.gardener.cloud/v1beta1"},
-		}
-		eventWithoutInvolvedObject = &eventsv1.Event{
-			ObjectMeta:              metav1.ObjectMeta{Name: eventWithoutInvolvedObjectName},
-			DeprecatedLastTimestamp: metav1.Time{Time: fakeNow},
-		}
-		nonGardenerAPIGroupEvent = &eventsv1.Event{
-			ObjectMeta:              metav1.ObjectMeta{Name: nonGardenerAPIGroupEventName},
-			DeprecatedLastTimestamp: metav1.Time{Time: fakeNow},
-			Regarding:               corev1.ObjectReference{Kind: "Shoot", APIVersion: "v1"},
-		}
-
-		eventTimeEvent = &eventsv1.Event{
-			ObjectMeta: metav1.ObjectMeta{Name: eventTimeEventName},
-			EventTime:  metav1.MicroTime{Time: fakeNow},
+		event = &eventsv1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			EventTime:  metav1.MicroTime{Time: fakeClock.Now()},
 			Regarding:  corev1.ObjectReference{Kind: "Project", APIVersion: "core.gardener.cloud/v1beta1"},
 		}
-		seriesLastObservedTimeEvent = &eventsv1.Event{
-			ObjectMeta: metav1.ObjectMeta{Name: seriesLastObservedTimeEventName},
-			EventTime:  metav1.MicroTime{Time: fakeNow.Add(-2 * ttl.Duration)},
-			Series: &eventsv1.EventSeries{
-				LastObservedTime: metav1.MicroTime{Time: fakeNow},
+		request = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(event)}
+
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		reconciler = &Reconciler{
+			Clock:  fakeClock,
+			Client: fakeClient,
+			Config: controllermanagerconfigv1alpha1.EventControllerConfiguration{
+				TTLNonShootEvents: &metav1.Duration{Duration: ttl},
 			},
-			Regarding: corev1.ObjectReference{Kind: "Project", APIVersion: "core.gardener.cloud/v1beta1"},
 		}
-
-		cfg = controllermanagerconfigv1alpha1.EventControllerConfiguration{
-			TTLNonShootEvents: ttl,
-		}
-
-		reconciler = &Reconciler{Clock: fakeClock, Client: fakeClient, Config: cfg}
 	})
 
-	It("should return nil because object not found", func() {
-		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), &eventsv1.Event{})).To(BeNotFoundError())
-
-		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: nonShootEventName}})
-		Expect(result).To(Equal(reconcile.Result{}))
-		Expect(err).NotTo(HaveOccurred())
+	JustBeforeEach(func(ctx SpecContext) {
+		Expect(fakeClient.Create(ctx, event)).To(Succeed())
 	})
 
-	Context("shoot events", func() {
-		It("should ignore them", func() {
-			Expect(fakeClient.Create(ctx, shootEvent)).To(Succeed())
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(shootEvent), &eventsv1.Event{})).To(Succeed())
+	When("event is already gone", func() {
+		JustBeforeEach(func(ctx SpecContext) {
+			Expect(fakeClient.Delete(ctx, event)).To(Succeed())
+		})
 
-			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: shootEventName}})
-			Expect(result).To(Equal(reconcile.Result{}))
-			Expect(err).NotTo(HaveOccurred())
+		It("should ignore event", func(ctx SpecContext) {
+			Expect(reconciler.Reconcile(ctx, request)).To(BeZero())
 		})
 	})
 
-	Context("non-shoot events", func() {
-		Context("ttl is not yet reached", func() {
-			It("should requeue non-shoot events", func() {
-				Expect(fakeClient.Create(ctx, nonShootEvent)).To(Succeed())
-
-				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: nonShootEventName}})
-				Expect(result).To(Equal(reconcile.Result{RequeueAfter: ttl.Duration}))
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("should requeue events with an empty involvedObject", func() {
-				Expect(fakeClient.Create(ctx, eventWithoutInvolvedObject)).To(Succeed())
-
-				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: eventWithoutInvolvedObjectName}})
-				Expect(result).To(Equal(reconcile.Result{RequeueAfter: ttl.Duration}))
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("should requeue events with non Gardener APIGroup", func() {
-				Expect(fakeClient.Create(ctx, nonGardenerAPIGroupEvent)).To(Succeed())
-				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: nonGardenerAPIGroupEventName}})
-				Expect(result).To(Equal(reconcile.Result{RequeueAfter: ttl.Duration}))
-				Expect(err).NotTo(HaveOccurred())
-			})
+	When("event is for shoot", func() {
+		BeforeEach(func() {
+			event.Regarding.Kind = "Shoot"
 		})
 
-		Context("ttl is reached", func() {
+		It("should ignore event", func(ctx SpecContext) {
+			Expect(reconciler.Reconcile(ctx, request)).To(BeZero())
+			Expect(fakeClient.Get(ctx, request.NamespacedName, event)).To(Succeed())
+		})
+	})
+
+	DescribeTableSubtree("requeue and delete event",
+		func(fieldName string, mutate func()) {
 			BeforeEach(func() {
-				fakeClock.Step(ttl.Duration)
-				reconciler = &Reconciler{Clock: fakeClock, Client: fakeClient, Config: cfg}
-
-				Expect(fakeClient.Create(ctx, nonShootEvent)).To(Succeed())
+				if mutate != nil {
+					mutate()
+				}
 			})
 
-			It("should delete the event", func() {
-				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: nonShootEventName}})
-				Expect(result).To(Equal(reconcile.Result{}))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), &eventsv1.Event{})).To(BeNotFoundError())
+			It(fmt.Sprintf("should delete event after %s + TTL", fieldName), func(ctx SpecContext) {
+				Expect(reconciler.Reconcile(ctx, request)).To(Equal(reconcile.Result{RequeueAfter: ttl}))
+				Expect(fakeClient.Get(ctx, request.NamespacedName, event)).To(Succeed(), "event still exists")
+
+				fakeClock.Step(ttl)
+				Expect(reconciler.Reconcile(ctx, request)).To(BeZero())
+				Expect(fakeClient.Get(ctx, request.NamespacedName, event)).To(BeNotFoundError(), "event is deleted")
 			})
-		})
-	})
+		},
 
-	Context("events reported via events.k8s.io API", func() {
-		Context("ttl is not yet reached", func() {
-			It("should requeue events with EventTime", func() {
-				Expect(fakeClient.Create(ctx, eventTimeEvent)).To(Succeed())
+		Entry("the event occurred only once", "EventTime", nil),
 
-				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: eventTimeEventName}})
-				Expect(result).To(Equal(reconcile.Result{RequeueAfter: ttl.Duration}))
-				Expect(err).NotTo(HaveOccurred())
-			})
+		Entry("the event occurred multiple times", "Series.LastObservedTime", func() {
+			event.EventTime.Time = fakeClock.Now().Add(-2 * ttl)
+			event.Series = &eventsv1.EventSeries{
+				Count:            2,
+				LastObservedTime: metav1.MicroTime{Time: fakeClock.Now()},
+			}
+		}),
 
-			It("should requeue events with Series.LastObservedTime", func() {
-				Expect(fakeClient.Create(ctx, seriesLastObservedTimeEvent)).To(Succeed())
+		Entry("no object is referenced", "EventTime", func() {
+			event.Regarding = corev1.ObjectReference{}
+		}),
 
-				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seriesLastObservedTimeEventName}})
-				Expect(result).To(Equal(reconcile.Result{RequeueAfter: ttl.Duration}))
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
+		Entry("a non-Gardener object is referenced", "EventTime", func() {
+			event.Regarding.APIVersion = "v1"
+			event.Regarding.Kind = "Namespace"
+		}),
 
-		Context("ttl is reached", func() {
-			BeforeEach(func() {
-				fakeClock.Step(ttl.Duration)
-				reconciler = &Reconciler{Clock: fakeClock, Client: fakeClient, Config: cfg}
-			})
+		Entry("events reported via corev1.Event API", "LastTimestamp", func() {
+			event = &eventsv1.Event{
+				// common fields for both APIs
+				ObjectMeta: event.ObjectMeta,
+				Regarding:  event.Regarding,
 
-			It("should delete events with EventTime", func() {
-				Expect(fakeClient.Create(ctx, eventTimeEvent)).To(Succeed())
-
-				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: eventTimeEventName}})
-				Expect(result).To(Equal(reconcile.Result{}))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(eventTimeEvent), &eventsv1.Event{})).To(BeNotFoundError())
-			})
-
-			It("should delete events with Series.LastObservedTime", func() {
-				Expect(fakeClient.Create(ctx, seriesLastObservedTimeEvent)).To(Succeed())
-
-				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seriesLastObservedTimeEventName}})
-				Expect(result).To(Equal(reconcile.Result{}))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(seriesLastObservedTimeEvent), &eventsv1.Event{})).To(BeNotFoundError())
-			})
-		})
-	})
+				// fields for events reported via corev1
+				DeprecatedFirstTimestamp: metav1.Time{Time: fakeClock.Now().Add(-2 * ttl)},
+				DeprecatedLastTimestamp:  metav1.Time{Time: fakeClock.Now()},
+				DeprecatedCount:          2,
+			}
+		}),
+	)
 })

--- a/pkg/controllermanager/controller/event/reconciler_test.go
+++ b/pkg/controllermanager/controller/event/reconciler_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	testclock "k8s.io/utils/clock/testing"
@@ -30,19 +31,23 @@ var _ = Describe("eventReconciler", func() {
 		fakeClient client.Client
 		fakeClock  *testclock.FakeClock
 
-		shootEventName                 = "shootEvent-test"
-		nonShootEventName              = "nonShootEvent-test"
-		eventWithoutInvolvedObjectName = "eventWithoutInvolvedObject-test"
-		nonGardenerAPIGroupEventName   = "nonGardenerAPIGroupEvent-test"
+		shootEventName                  = "shootEvent-test"
+		nonShootEventName               = "nonShootEvent-test"
+		eventWithoutInvolvedObjectName  = "eventWithoutInvolvedObject-test"
+		nonGardenerAPIGroupEventName    = "nonGardenerAPIGroupEvent-test"
+		eventTimeEventName              = "eventTimeEvent-test"
+		seriesLastObservedTimeEventName = "seriesLastObservedTimeEvent-test"
 
 		ttl = &metav1.Duration{Duration: 1 * time.Hour}
 
-		reconciler                 reconcile.Reconciler
-		shootEvent                 *corev1.Event
-		nonShootEvent              *corev1.Event
-		nonGardenerAPIGroupEvent   *corev1.Event
-		eventWithoutInvolvedObject *corev1.Event
-		cfg                        controllermanagerconfigv1alpha1.EventControllerConfiguration
+		reconciler                  reconcile.Reconciler
+		shootEvent                  *eventsv1.Event
+		nonShootEvent               *eventsv1.Event
+		nonGardenerAPIGroupEvent    *eventsv1.Event
+		eventWithoutInvolvedObject  *eventsv1.Event
+		eventTimeEvent              *eventsv1.Event
+		seriesLastObservedTimeEvent *eventsv1.Event
+		cfg                         controllermanagerconfigv1alpha1.EventControllerConfiguration
 	)
 
 	BeforeEach(func() {
@@ -52,24 +57,38 @@ var _ = Describe("eventReconciler", func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 		fakeClock = testclock.NewFakeClock(fakeNow)
 
-		shootEvent = &corev1.Event{
-			ObjectMeta:     metav1.ObjectMeta{Name: shootEventName},
-			LastTimestamp:  metav1.Time{Time: fakeNow},
-			InvolvedObject: corev1.ObjectReference{Kind: "Shoot", APIVersion: "core.gardener.cloud/v1beta1"},
+		shootEvent = &eventsv1.Event{
+			ObjectMeta:              metav1.ObjectMeta{Name: shootEventName},
+			DeprecatedLastTimestamp: metav1.Time{Time: fakeNow},
+			Regarding:               corev1.ObjectReference{Kind: "Shoot", APIVersion: "core.gardener.cloud/v1beta1"},
 		}
-		nonShootEvent = &corev1.Event{
-			ObjectMeta:     metav1.ObjectMeta{Name: nonShootEventName},
-			LastTimestamp:  metav1.Time{Time: fakeNow},
-			InvolvedObject: corev1.ObjectReference{Kind: "Project", APIVersion: "core.gardener.cloud/v1beta1"},
+		nonShootEvent = &eventsv1.Event{
+			ObjectMeta:              metav1.ObjectMeta{Name: nonShootEventName},
+			DeprecatedLastTimestamp: metav1.Time{Time: fakeNow},
+			Regarding:               corev1.ObjectReference{Kind: "Project", APIVersion: "core.gardener.cloud/v1beta1"},
 		}
-		eventWithoutInvolvedObject = &corev1.Event{
-			ObjectMeta:    metav1.ObjectMeta{Name: eventWithoutInvolvedObjectName},
-			LastTimestamp: metav1.Time{Time: fakeNow},
+		eventWithoutInvolvedObject = &eventsv1.Event{
+			ObjectMeta:              metav1.ObjectMeta{Name: eventWithoutInvolvedObjectName},
+			DeprecatedLastTimestamp: metav1.Time{Time: fakeNow},
 		}
-		nonGardenerAPIGroupEvent = &corev1.Event{
-			ObjectMeta:     metav1.ObjectMeta{Name: nonGardenerAPIGroupEventName},
-			LastTimestamp:  metav1.Time{Time: fakeNow},
-			InvolvedObject: corev1.ObjectReference{Kind: "Shoot", APIVersion: "v1"},
+		nonGardenerAPIGroupEvent = &eventsv1.Event{
+			ObjectMeta:              metav1.ObjectMeta{Name: nonGardenerAPIGroupEventName},
+			DeprecatedLastTimestamp: metav1.Time{Time: fakeNow},
+			Regarding:               corev1.ObjectReference{Kind: "Shoot", APIVersion: "v1"},
+		}
+
+		eventTimeEvent = &eventsv1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: eventTimeEventName},
+			EventTime:  metav1.MicroTime{Time: fakeNow},
+			Regarding:  corev1.ObjectReference{Kind: "Project", APIVersion: "core.gardener.cloud/v1beta1"},
+		}
+		seriesLastObservedTimeEvent = &eventsv1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: seriesLastObservedTimeEventName},
+			EventTime:  metav1.MicroTime{Time: fakeNow.Add(-2 * ttl.Duration)},
+			Series: &eventsv1.EventSeries{
+				LastObservedTime: metav1.MicroTime{Time: fakeNow},
+			},
+			Regarding: corev1.ObjectReference{Kind: "Project", APIVersion: "core.gardener.cloud/v1beta1"},
 		}
 
 		cfg = controllermanagerconfigv1alpha1.EventControllerConfiguration{
@@ -80,7 +99,7 @@ var _ = Describe("eventReconciler", func() {
 	})
 
 	It("should return nil because object not found", func() {
-		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), &corev1.Event{})).To(BeNotFoundError())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), &eventsv1.Event{})).To(BeNotFoundError())
 
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: nonShootEventName}})
 		Expect(result).To(Equal(reconcile.Result{}))
@@ -90,7 +109,7 @@ var _ = Describe("eventReconciler", func() {
 	Context("shoot events", func() {
 		It("should ignore them", func() {
 			Expect(fakeClient.Create(ctx, shootEvent)).To(Succeed())
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(shootEvent), &corev1.Event{})).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(shootEvent), &eventsv1.Event{})).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: shootEventName}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -136,7 +155,52 @@ var _ = Describe("eventReconciler", func() {
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: nonShootEventName}})
 				Expect(result).To(Equal(reconcile.Result{}))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), &corev1.Event{})).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), &eventsv1.Event{})).To(BeNotFoundError())
+			})
+		})
+	})
+
+	Context("events reported via events.k8s.io API", func() {
+		Context("ttl is not yet reached", func() {
+			It("should requeue events with EventTime", func() {
+				Expect(fakeClient.Create(ctx, eventTimeEvent)).To(Succeed())
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: eventTimeEventName}})
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: ttl.Duration}))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should requeue events with Series.LastObservedTime", func() {
+				Expect(fakeClient.Create(ctx, seriesLastObservedTimeEvent)).To(Succeed())
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seriesLastObservedTimeEventName}})
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: ttl.Duration}))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("ttl is reached", func() {
+			BeforeEach(func() {
+				fakeClock.Step(ttl.Duration)
+				reconciler = &Reconciler{Clock: fakeClock, Client: fakeClient, Config: cfg}
+			})
+
+			It("should delete events with EventTime", func() {
+				Expect(fakeClient.Create(ctx, eventTimeEvent)).To(Succeed())
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: eventTimeEventName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(eventTimeEvent), &eventsv1.Event{})).To(BeNotFoundError())
+			})
+
+			It("should delete events with Series.LastObservedTime", func() {
+				Expect(fakeClient.Create(ctx, seriesLastObservedTimeEvent)).To(Succeed())
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seriesLastObservedTimeEventName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(seriesLastObservedTimeEvent), &eventsv1.Event{})).To(BeNotFoundError())
 			})
 		})
 	})

--- a/test/integration/controllermanager/event/event_test.go
+++ b/test/integration/controllermanager/event/event_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -17,104 +18,245 @@ import (
 )
 
 var _ = Describe("Event controller tests", func() {
-	var (
-		shootEvent, nonShootEvent *corev1.Event
+	// For testing purpose we are setting this variable to be more than TTLNonShootEvents, to have
+	// timeUntilDeletion value in controller to be less than 0. This is done to mock the deletion of non-shoot events
+	// on reaching TTL.
+	var ttl = &metav1.Duration{Duration: 45 * time.Minute}
 
-		// For testing purpose we are setting this variable to be more than TTLNonShootEvents, to have
-		// timeUntilDeletion value in controller to be less than 0. This is done to mock the deletion of non-shoot events
-		// on reaching TTL.
-		ttl = &metav1.Duration{Duration: 45 * time.Minute}
-	)
+	Context("events reported via corev1.Event API", func() {
+		var shootEvent, nonShootEvent *corev1.Event
 
-	BeforeEach(func() {
-		shootEvent = &corev1.Event{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: testID + "-",
-				Namespace:    testNamespace.Name,
-			},
-			InvolvedObject: corev1.ObjectReference{Kind: "Shoot", APIVersion: "core.gardener.cloud/v1beta1", Namespace: testNamespace.Name},
-		}
+		BeforeEach(func() {
+			shootEvent = &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: testID + "-",
+					Namespace:    testNamespace.Name,
+				},
+				InvolvedObject: corev1.ObjectReference{Kind: "Shoot", APIVersion: "core.gardener.cloud/v1beta1", Namespace: testNamespace.Name},
+			}
 
-		nonShootEvent = &corev1.Event{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: testID + "-",
-				Namespace:    testNamespace.Name,
-			},
-			InvolvedObject: corev1.ObjectReference{Kind: "Secret", APIVersion: "v1", Namespace: testNamespace.Name},
-		}
+			nonShootEvent = &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: testID + "-",
+					Namespace:    testNamespace.Name,
+				},
+				InvolvedObject: corev1.ObjectReference{Kind: "Secret", APIVersion: "v1", Namespace: testNamespace.Name},
+			}
+		})
+
+		Context("shoot events", func() {
+			JustBeforeEach(func() {
+				By("Create Shoot Event")
+				Expect(testClient.Create(ctx, shootEvent)).To(Succeed())
+				log.Info("Created Shoot Event for test", "shootEvent", client.ObjectKeyFromObject(shootEvent))
+
+				DeferCleanup(func() {
+					By("Delete Shoot Event")
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, shootEvent))).To(Succeed())
+				})
+			})
+
+			Describe("ttl not reached", func() {
+				BeforeEach(func() {
+					shootEvent.LastTimestamp = metav1.Time{Time: time.Now()}
+				})
+
+				It("should not remove the event", func() {
+					Consistently(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(shootEvent), shootEvent)
+					}).Should(Succeed())
+				})
+			})
+
+			Describe("ttl reached", func() {
+				BeforeEach(func() {
+					shootEvent.LastTimestamp = metav1.Time{Time: time.Now().Add(-ttl.Duration)}
+				})
+
+				It("should not remove the event as this is shoot event", func() {
+					Consistently(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(shootEvent), shootEvent)
+					}).Should(Succeed())
+				})
+			})
+		})
+
+		Context("non-shoot events", func() {
+			JustBeforeEach(func() {
+				By("Create Non-Shoot Event")
+				Expect(testClient.Create(ctx, nonShootEvent)).To(Succeed())
+				log.Info("Created non-shoot Event for test", "nonShootEvent", client.ObjectKeyFromObject(nonShootEvent))
+
+				DeferCleanup(func() {
+					By("Delete Non-Shoot Event")
+					Expect(testClient.Delete(ctx, nonShootEvent)).To(Or(Succeed(), BeNotFoundError()))
+				})
+			})
+
+			Describe("ttl not reached", func() {
+				BeforeEach(func() {
+					nonShootEvent.LastTimestamp = metav1.Time{Time: time.Now()}
+				})
+
+				It("should not remove the event", func() {
+					Consistently(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), nonShootEvent)
+					}).Should(Succeed())
+				})
+			})
+
+			Describe("ttl reached", func() {
+				BeforeEach(func() {
+					nonShootEvent.LastTimestamp = metav1.Time{Time: time.Now().Add(-ttl.Duration)}
+				})
+
+				It("should remove the non shoot event", func() {
+					Eventually(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), nonShootEvent)
+					}).Should(BeNotFoundError())
+				})
+			})
+		})
 	})
 
-	Context("shoot events", func() {
-		JustBeforeEach(func() {
-			By("Create Shoot Event")
-			Expect(testClient.Create(ctx, shootEvent)).To(Succeed())
-			log.Info("Created Shoot Event for test", "shootEvent", client.ObjectKeyFromObject(shootEvent))
+	Context("events reported via events.k8s.io API", func() {
+		var shootEvent, nonShootEvent *eventsv1.Event
 
-			DeferCleanup(func() {
-				By("Delete Shoot Event")
-				Expect(client.IgnoreNotFound(testClient.Delete(ctx, shootEvent))).To(Succeed())
+		BeforeEach(func() {
+			shootEvent = &eventsv1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: testID + "-",
+					Namespace:    testNamespace.Name,
+				},
+				EventTime:           metav1.MicroTime{Time: time.Now()},
+				Type:                "Normal",
+				Reason:              "TestReason",
+				Note:                "Test message",
+				ReportingController: "test-controller",
+				ReportingInstance:   "test-instance",
+				Action:              "test-action",
+				Regarding:           corev1.ObjectReference{Kind: "Shoot", APIVersion: "core.gardener.cloud/v1beta1", Namespace: testNamespace.Name},
+			}
+
+			nonShootEvent = &eventsv1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: testID + "-",
+					Namespace:    testNamespace.Name,
+				},
+				EventTime:           metav1.MicroTime{Time: time.Now()},
+				Type:                "Normal",
+				Reason:              "TestReason",
+				Note:                "Test message",
+				ReportingController: "test-controller",
+				ReportingInstance:   "test-instance",
+				Action:              "test-action",
+				Regarding:           corev1.ObjectReference{Kind: "Secret", APIVersion: "v1", Namespace: testNamespace.Name},
+			}
+		})
+
+		Context("shoot events", func() {
+			JustBeforeEach(func() {
+				By("Create Shoot Event")
+				Expect(testClient.Create(ctx, shootEvent)).To(Succeed())
+				log.Info("Created Shoot Event for test", "shootEvent", client.ObjectKeyFromObject(shootEvent))
+
+				DeferCleanup(func() {
+					By("Delete Shoot Event")
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, shootEvent))).To(Succeed())
+				})
+			})
+
+			Describe("ttl not reached", func() {
+				BeforeEach(func() {
+					shootEvent.EventTime = metav1.MicroTime{Time: time.Now()}
+				})
+
+				It("should not remove the event", func() {
+					Consistently(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(shootEvent), shootEvent)
+					}).Should(Succeed())
+				})
+			})
+
+			Describe("ttl reached", func() {
+				BeforeEach(func() {
+					shootEvent.EventTime = metav1.MicroTime{Time: time.Now().Add(-ttl.Duration)}
+				})
+
+				It("should not remove the event as this is shoot event", func() {
+					Consistently(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(shootEvent), shootEvent)
+					}).Should(Succeed())
+				})
 			})
 		})
 
-		Describe("ttl not reached", func() {
-			BeforeEach(func() {
-				shootEvent.LastTimestamp = metav1.Time{Time: time.Now()}
+		Context("non-shoot events", func() {
+			JustBeforeEach(func() {
+				By("Create Non-Shoot Event")
+				Expect(testClient.Create(ctx, nonShootEvent)).To(Succeed())
+				log.Info("Created non-shoot Event for test", "nonShootEvent", client.ObjectKeyFromObject(nonShootEvent))
+
+				DeferCleanup(func() {
+					By("Delete Non-Shoot Event")
+					Expect(testClient.Delete(ctx, nonShootEvent)).To(Or(Succeed(), BeNotFoundError()))
+				})
 			})
 
-			It("should not remove the event", func() {
-				Consistently(func() error {
-					return testClient.Get(ctx, client.ObjectKeyFromObject(shootEvent), shootEvent)
-				}).Should(Succeed())
-			})
-		})
+			Describe("ttl not reached", func() {
+				BeforeEach(func() {
+					nonShootEvent.EventTime = metav1.MicroTime{Time: time.Now()}
+				})
 
-		Describe("ttl reached", func() {
-			BeforeEach(func() {
-				shootEvent.LastTimestamp = metav1.Time{Time: time.Now().Add(-ttl.Duration)}
-			})
-
-			It("should not remove the event as this is shoot event", func() {
-				Consistently(func() error {
-					return testClient.Get(ctx, client.ObjectKeyFromObject(shootEvent), shootEvent)
-				}).Should(Succeed())
-			})
-		})
-
-	})
-
-	Context("non-shoot events", func() {
-		JustBeforeEach(func() {
-			By("Create Non-Shoot Event")
-			Expect(testClient.Create(ctx, nonShootEvent)).To(Succeed())
-			log.Info("Created non-shoot Event for test", "nonShootEvent", client.ObjectKeyFromObject(nonShootEvent))
-
-			DeferCleanup(func() {
-				By("Delete Non-Shoot Event")
-				Expect(testClient.Delete(ctx, nonShootEvent)).To(Or(Succeed(), BeNotFoundError()))
-			})
-		})
-
-		Describe("ttl not reached", func() {
-			BeforeEach(func() {
-				nonShootEvent.LastTimestamp = metav1.Time{Time: time.Now()}
+				It("should not remove the event", func() {
+					Consistently(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), nonShootEvent)
+					}).Should(Succeed())
+				})
 			})
 
-			It("should not remove the event", func() {
-				Consistently(func() error {
-					return testClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), nonShootEvent)
-				}).Should(Succeed())
-			})
-		})
+			Describe("ttl reached", func() {
+				BeforeEach(func() {
+					nonShootEvent.EventTime = metav1.MicroTime{Time: time.Now().Add(-ttl.Duration)}
+				})
 
-		Describe("ttl reached", func() {
-			BeforeEach(func() {
-				nonShootEvent.LastTimestamp = metav1.Time{Time: time.Now().Add(-ttl.Duration)}
+				It("should remove the non shoot event", func() {
+					Eventually(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), nonShootEvent)
+					}).Should(BeNotFoundError())
+				})
 			})
 
-			It("should remove the non shoot event", func() {
-				Eventually(func() error {
-					return testClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), nonShootEvent)
-				}).Should(BeNotFoundError())
+			Describe("series ttl not reached", func() {
+				BeforeEach(func() {
+					nonShootEvent.Series = &eventsv1.EventSeries{
+						Count:            2,
+						LastObservedTime: metav1.MicroTime{Time: time.Now()},
+					}
+				})
+
+				It("should not remove the event", func() {
+					Consistently(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), nonShootEvent)
+					}).Should(Succeed())
+				})
+			})
+
+			Describe("series ttl reached", func() {
+				BeforeEach(func() {
+					nonShootEvent.Series = &eventsv1.EventSeries{
+						Count:            2,
+						LastObservedTime: metav1.MicroTime{Time: time.Now().Add(-ttl.Duration)},
+					}
+					// Set EventTime to now to ensure Series.LastObservedTime takes precedence
+					nonShootEvent.EventTime = metav1.MicroTime{Time: time.Now()}
+				})
+
+				It("should remove the non shoot event", func() {
+					Eventually(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(nonShootEvent), nonShootEvent)
+					}).Should(BeNotFoundError())
+				})
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:

Switch the `event` controller to `events.k8s.io` while respecting the deprecated fields for events reported via the old corev1 API.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/15489

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Gardener no longer deletes `Events` in the virtual garden reported via the new `events.k8s.io` API.
```
