### PR TITLE
[renovate] Fix disabling of etcd-backup-restore image updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -492,6 +492,7 @@
       // Do not update etcd and etcd-backup-restore images since they have to be in sync with the etcd-druid version.
       matchDatasources: [
         'docker',
+        'github-releases',
       ],
       matchFileNames: [
         'imagevector/**',


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This is a follow-up to https://github.com/gardener/gardener/pull/15481, which attempted to disable Renovate version updates for the `etcd-backup-restore` image but did not work (Renovate kept creating update PRs, e.g. https://github.com/gardener/gardener/pull/15493).

The root cause is a datasource mismatch. The `imagevector` custom manager (gardener/ci-infra's [`config/renovate/imagevector.json5`](https://github.com/gardener/ci-infra/blob/master/config/renovate/imagevector.json5)) creates **two** dependencies for the `etcd-backup-restore` entry in `imagevector/containers.yaml`:
- a `github-releases` dependency with depName `gardener/etcd-backup-restore`, derived from the `sourceRepository: github.com/gardener/etcd-backup-restore` field, and
- a `docker` dependency derived from the `repository` field.

The rule added in #15481 only matched `matchDatasources: ['docker']`, but the update PRs are produced by the `github-releases` dependency (as seen in #15493: a `minor` update `v0.43.0` -> `v0.44.1` named `gardener/etcd-backup-restore` with GitHub Release Notes). The `docker` dependency is already suppressed by the existing rule for `europe-docker.pkg.dev/gardener-project/releases/...` images, so it was never the source of the PRs.

This PR fixes the rule by adding `github-releases` to `matchDatasources`, so the disable actually applies to the dependency that creates the update PRs.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/15481

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
