### PR TITLE
Unset GOCACHEPROG for go tool -n

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -122,7 +122,9 @@ version_gomod = $(shell $(SET_GOWORK) go list $(MODFILE_TOOL_MOD) -f '{{ .Versio
 
 # Use this function to copy the tool binary built by Go to the location passed as arg.
 #   E.g., `$(call go_tool_copy,./path/to/tool)` will copy the tool binary built by Go to ./path/to/tool.
-go_tool_copy = $(shell cp $$( $(SET_GOWORK) go tool $(MODFILE_TOOL_MOD) -n $$(basename $(1))) $(1))
+# Set GOCACHEPROG to empty, this is required as `go tool -n` returns a wrong path when GOCACHEPROG is set.
+# https://github.com/golang/go/issues/72824
+go_tool_copy = $(shell cp $$( GOCACHEPROG= $(SET_GOWORK) go tool $(MODFILE_TOOL_MOD) -n $$(basename $(1))) $(1))
 
 # This target cleans up any previous version files for the given tool and creates the given version file.
 # This way, we can generically determine, which version was installed without calling each and every binary explicitly.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind bug

**What this PR does / why we need it**:

We use a go cache in repos which includes the gardener `hack/tools.mk` and run into problems while upgrading to g/g 1.146. This PR sets the `GOCACHEPROG` to empty for all `go tool -n` commands, to mitigate this problems.

With the PR #14861 tools like `mockgen` are installed with `go tools -n` instead of `go build`. If a go cache is used with `GOCACHEPROG` variable  `go tools -n` returns a wrong non existing path. There is also an upstream go issue https://github.com/golang/go/issues/72824 which is closed but there is also still an open PR linked, so I am not 100% sure what the current status is.

I can reproduce it locally with https://github.com/kaskabayev/gocacheprog and go 1.26.5:

```
❯ go version
go version go1.26.5 linux/amd64

❯ go tool -modfile go.mod -n mockgen
/home/maxgeberl/.cache/go-build/7b/7bba4d0bbf3224d9cf7858fa26797c9b7d963b2cb28d618aa9f9c753e743b281-d/mockgen
❯ ls /home/maxgeberl/.cache/go-build/7b/7bba4d0bbf3224d9cf7858fa26797c9b7d963b2cb28d618aa9f9c753e743b281-d/mockgen
 /home/maxgeberl/.cache/go-build/7b/7bba4d0bbf3224d9cf7858fa26797c9b7d963b2cb28d618aa9f9c753e743b281-d/mockgen

❯ GOCACHEPROG="/home/maxgeberl/go/bin/gocacheprog --cache-dir /tmp/go" go tool -modfile go.mod -n mockgen
2026/08/13 14:58:39 Cache directory is set to: /tmp/go
/tmp/go-build3486431029/b001/exe/mockgen
❯ ls /tmp/go-build3486431029/b001/exe/mockgen
"/tmp/go-build3486431029/b001/exe/mockgen": No such file or directory (os error 2)
```

It also can be reproduced without the change of this PR:

```
export GOCACHEPROG="/home/maxgeberl/go/bin/gocacheprog --cache-dir /tmp/go"
make clean-tools-bin
make generate
```

Parts of the ourput:
```
...
2026/08/13 15:55:36 Cache directory is set to: /tmp/go
2026/08/13 15:55:41 Cache directory is set to: /tmp/go
cp: Aufruf von stat für '/tmp/go-build150368840/b001/exe/crd-ref-docs' nicht möglich: Datei oder Verzeichnis nicht gefunden
2026/08/13 15:55:42 Cache directory is set to: /tmp/go
cp: Aufruf von stat für '/tmp/go-build708039281/b001/exe/goimports' nicht möglich: Datei oder Verzeichnis nicht gefunden
2026/08/13 15:55:43 Cache directory is set to: /tmp/go
cp: Aufruf von stat für '/tmp/go-build2971847005/b001/exe/go-to-protobuf' nicht möglich: Datei oder Verzeichnis nicht gefunden
...
```

With the change of this PR it is working,

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Set `GOCACHEPROG` to empty for all `go tool -n` commands.
```
