### PR TITLE
Remove separate `openapi-gen` step for model name file generation

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -445,9 +445,8 @@ openapi_definitions() {
       "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
   )
 
-  # First generate the openapi definitions for Gardener APIs only.
-  # This step is mainly required to generate the model name file (zz_generated.model_name.go).
-  # TODO(timuthy): Remove this separate step once https://github.com/kubernetes/kube-openapi/issues/571 is resolved.
+  # Generate openapi definitions for Gardener APIs along with required Kubernetes APIs.
+  # kube_apis packages are marked read-only so model name files are only written for Gardener APIs.
   "openapi-gen" \
     -v 1 \
     --output-file openapi_generated.go \
@@ -456,17 +455,7 @@ openapi_definitions() {
     --output-pkg "github.com/gardener/gardener/pkg/apiserver/openapi" \
     --report-filename "${PROJECT_ROOT}/pkg/apiserver/openapi/api_violations.report" \
     --output-model-name-file "zz_generated.model_name.go" \
-    "${gardener_apis[@]}"
-
-  # Now generate the openapi definitions for Gardener APIs along with required Kubernetes APIs.
-  # `output-model-name-file` must not be specified here, since it would lead to generation errors (see https://github.com/kubernetes/kube-openapi/issues/571).
-  "openapi-gen" \
-    -v 1 \
-    --output-file openapi_generated.go \
-    --go-header-file "${PROJECT_ROOT}/hack/LICENSE_BOILERPLATE.txt" \
-    --output-dir "${PROJECT_ROOT}/pkg/apiserver/openapi" \
-    --output-pkg "github.com/gardener/gardener/pkg/apiserver/openapi" \
-    --report-filename "${PROJECT_ROOT}/pkg/apiserver/openapi/api_violations.report" \
+    --readonly-pkg "$(IFS=,; echo "${kube_apis[*]}")" \
     "${gardener_apis[@]}" \
     "${kube_apis[@]}"
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Removes the separate `openapi-gen` invocation that existed solely to generate model name files for Gardener API packages. Now that https://github.com/kubernetes/kube-openapi/issues/571 is resolved, the new `--readonly-pkg` flag can be used to skip model name file generation for read-only Kubernetes dependency packages, allowing a single invocation to do everything.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
