### PR TITLE
Remove internal dns nil check

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -628,27 +628,7 @@ func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client, i
 			metav1.SetMetaDataLabel(&seed.ObjectMeta, v1beta1constants.LabelSelfHostedShootCluster, "true")
 		}
 
-		var (
-			internalDNS = seed.Spec.DNS.Internal
-			defaultDNS  = seed.Spec.DNS.Defaults
-		)
-
 		seed.Spec = g.config.SeedConfig.Spec
-
-		// TODO(dimityrmirchev): Remove this after 1.129 release
-		// Preserve current internal dns settings
-		// as these could have been already explicitly set by gardenlet itself
-		// and setting internal dns to nil is forbidden
-		if internalDNS != nil && g.config.SeedConfig.Spec.DNS.Internal == nil {
-			seed.Spec.DNS.Internal = internalDNS
-		}
-
-		// TODO(dimityrmirchev): Remove this after 1.131 release
-		// Preserve current defaults dns settings
-		// as these could have been already explicitly set by gardenlet itself
-		if defaultDNS != nil && g.config.SeedConfig.Spec.DNS.Defaults == nil {
-			seed.Spec.DNS.Defaults = defaultDNS
-		}
 
 		return nil
 	}); err != nil {
@@ -671,41 +651,6 @@ func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client, i
 		return true, nil
 	}); err != nil {
 		return err
-	}
-
-	// If the Seed config does not have spec.dns.internal set,
-	// set it automatically based on the global internal domain secret.
-	if g.config.SeedConfig.Spec.DNS.Internal == nil {
-		// TODO(dimityrmirchev): Require internal DNS settings and remove this logic after 1.129 release
-		secret, err := gardenerutils.ReadInternalDomainSecret(ctx, gardenClient, gardenerutils.ComputeGardenNamespace(g.config.SeedConfig.Name), true)
-		if err != nil {
-			return err
-		}
-
-		providerType, domain, zone, err := gardenerutils.GetDomainInfoFromAnnotations(secret.Annotations)
-		if err != nil {
-			return err
-		}
-
-		patch := client.MergeFrom(seed.DeepCopy())
-		seed.Spec.DNS.Internal = &gardencorev1beta1.SeedDNSProviderConfig{
-			Type:   providerType,
-			Domain: domain,
-		}
-		if len(zone) > 0 {
-			seed.Spec.DNS.Internal.Zone = &zone
-		}
-
-		seed.Spec.DNS.Internal.CredentialsRef = corev1.ObjectReference{
-			APIVersion: "v1",
-			Kind:       "Secret",
-			Namespace:  v1beta1constants.GardenNamespace, // explicitly set the garden namespace as the secret was originally copied from there to the seed namespace
-			Name:       secret.Name,
-		}
-
-		if err := gardenClient.Patch(ctx, seed, patch); err != nil {
-			return fmt.Errorf("could not patch internal dns settings for seed %q: %w", seed.Name, err)
-		}
 	}
 
 	// If the Seed config does not have spec.dns.defaults set,

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -445,9 +445,8 @@ openapi_definitions() {
       "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
   )
 
-  # First generate the openapi definitions for Gardener APIs only.
-  # This step is mainly required to generate the model name file (zz_generated.model_name.go).
-  # TODO(timuthy): Remove this separate step once https://github.com/kubernetes/kube-openapi/issues/571 is resolved.
+  # Generate openapi definitions for Gardener APIs along with required Kubernetes APIs.
+  # kube_apis packages are marked read-only so model name files are only written for Gardener APIs.
   "openapi-gen" \
     -v 1 \
     --output-file openapi_generated.go \
@@ -456,17 +455,7 @@ openapi_definitions() {
     --output-pkg "github.com/gardener/gardener/pkg/apiserver/openapi" \
     --report-filename "${PROJECT_ROOT}/pkg/apiserver/openapi/api_violations.report" \
     --output-model-name-file "zz_generated.model_name.go" \
-    "${gardener_apis[@]}"
-
-  # Now generate the openapi definitions for Gardener APIs along with required Kubernetes APIs.
-  # `output-model-name-file` must not be specified here, since it would lead to generation errors (see https://github.com/kubernetes/kube-openapi/issues/571).
-  "openapi-gen" \
-    -v 1 \
-    --output-file openapi_generated.go \
-    --go-header-file "${PROJECT_ROOT}/hack/LICENSE_BOILERPLATE.txt" \
-    --output-dir "${PROJECT_ROOT}/pkg/apiserver/openapi" \
-    --output-pkg "github.com/gardener/gardener/pkg/apiserver/openapi" \
-    --report-filename "${PROJECT_ROOT}/pkg/apiserver/openapi/api_violations.report" \
+    --readonly-pkg "$(IFS=,; echo "${kube_apis[*]}")" \
     "${gardener_apis[@]}" \
     "${kube_apis[@]}"
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
Removes backward-compatibility nil checks in gardenlet's registerSeed that were added to smooth the migration to spec.dns.internal being a required field.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
