### PR TITLE
[GEP-28] Eliminate static admin token for self-hosted shoots

### DIFF
--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -113,6 +113,7 @@ build:
             - pkg/component/gardener/apiserver
             - pkg/component/gardener/resourcemanager
             - pkg/component/gardener/resourcemanager/constants
+            - pkg/component/kubernetes/adminaccess
             - pkg/component/kubernetes/apiserver
             - pkg/component/kubernetes/apiserver/constants
             - pkg/component/kubernetes/apiserverexposure
@@ -350,6 +351,7 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail
             - pkg/component/extensions/operatingsystemconfig/utils
+            - pkg/component/kubernetes/adminaccess
             - pkg/component/observability/logging/vali/constants
             - pkg/component/observability/opentelemetry/collector/constants
             - pkg/controllerutils
@@ -464,6 +466,8 @@ build:
             - pkg/client/core/listers/core/v1beta1
             - pkg/client/kubernetes
             - pkg/client/kubernetes/cache
+            - pkg/component
+            - pkg/component/kubernetes/adminaccess
             - pkg/controller/tokenrequestor
             - pkg/controllerutils
             - pkg/controllerutils/predicate
@@ -505,15 +509,19 @@ build:
             - pkg/resourcemanager/webhook/systemcomponentsconfig
             - pkg/resourcemanager/webhook/vpainplaceupdates
             - pkg/utils
+            - pkg/utils/chart
             - pkg/utils/context
             - pkg/utils/errors
             - pkg/utils/flow
             - pkg/utils/gardener
+            - pkg/utils/imagevector
             - pkg/utils/istio
             - pkg/utils/kubernetes
             - pkg/utils/kubernetes/client
             - pkg/utils/kubernetes/health
             - pkg/utils/kubernetes/unstructured
+            - pkg/utils/managedresources
+            - pkg/utils/managedresources/builder
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/secrets/manager
@@ -649,6 +657,7 @@ build:
             - pkg/component/gardener/apiserver
             - pkg/component/gardener/resourcemanager
             - pkg/component/gardener/resourcemanager/constants
+            - pkg/component/kubernetes/adminaccess
             - pkg/component/kubernetes/apiserver
             - pkg/component/kubernetes/apiserver/constants
             - pkg/component/kubernetes/apiserverexposure

--- a/dev-setup/skaffold-operator.yaml
+++ b/dev-setup/skaffold-operator.yaml
@@ -307,6 +307,8 @@ build:
             - pkg/client/core/listers/core/v1beta1
             - pkg/client/kubernetes
             - pkg/client/kubernetes/cache
+            - pkg/component
+            - pkg/component/kubernetes/adminaccess
             - pkg/controller/tokenrequestor
             - pkg/controllerutils
             - pkg/controllerutils/predicate
@@ -348,15 +350,19 @@ build:
             - pkg/resourcemanager/webhook/systemcomponentsconfig
             - pkg/resourcemanager/webhook/vpainplaceupdates
             - pkg/utils
+            - pkg/utils/chart
             - pkg/utils/context
             - pkg/utils/errors
             - pkg/utils/flow
             - pkg/utils/gardener
+            - pkg/utils/imagevector
             - pkg/utils/istio
             - pkg/utils/kubernetes
             - pkg/utils/kubernetes/client
             - pkg/utils/kubernetes/health
             - pkg/utils/kubernetes/unstructured
+            - pkg/utils/managedresources
+            - pkg/utils/managedresources/builder
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/secrets/manager

--- a/dev-setup/skaffold-seed.yaml
+++ b/dev-setup/skaffold-seed.yaml
@@ -159,6 +159,7 @@ build:
             - pkg/component/gardener/apiserver
             - pkg/component/gardener/resourcemanager
             - pkg/component/gardener/resourcemanager/constants
+            - pkg/component/kubernetes/adminaccess
             - pkg/component/kubernetes/apiserver
             - pkg/component/kubernetes/apiserver/constants
             - pkg/component/kubernetes/apiserverexposure
@@ -402,6 +403,8 @@ build:
             - pkg/client/core/listers/core/v1beta1
             - pkg/client/kubernetes
             - pkg/client/kubernetes/cache
+            - pkg/component
+            - pkg/component/kubernetes/adminaccess
             - pkg/controller/tokenrequestor
             - pkg/controllerutils
             - pkg/controllerutils/predicate
@@ -443,15 +446,19 @@ build:
             - pkg/resourcemanager/webhook/systemcomponentsconfig
             - pkg/resourcemanager/webhook/vpainplaceupdates
             - pkg/utils
+            - pkg/utils/chart
             - pkg/utils/context
             - pkg/utils/errors
             - pkg/utils/flow
             - pkg/utils/gardener
+            - pkg/utils/imagevector
             - pkg/utils/istio
             - pkg/utils/kubernetes
             - pkg/utils/kubernetes/client
             - pkg/utils/kubernetes/health
             - pkg/utils/kubernetes/unstructured
+            - pkg/utils/managedresources
+            - pkg/utils/managedresources/builder
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/secrets/manager
@@ -538,6 +545,7 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail
             - pkg/component/extensions/operatingsystemconfig/utils
+            - pkg/component/kubernetes/adminaccess
             - pkg/component/observability/logging/vali/constants
             - pkg/component/observability/opentelemetry/collector/constants
             - pkg/controllerutils

--- a/docs/concepts/node-agent.md
+++ b/docs/concepts/node-agent.md
@@ -129,7 +129,11 @@ Whenever the `.data.token` field changes, it writes the new content to a file on
 This mechanism is used to download its own access token for the shoot cluster, but also the access tokens of other `systemd` components (e.g., `valitail`).
 Since the underlying client is based on `k8s.io/client-go` and the kubeconfig points to this token file, it is dynamically reloaded without the necessity of explicit configuration or code changes.
 This procedure ensures that the most up-to-date tokens are always present on the host and used by the `gardener-node-agent` and the other `systemd` components.
-The controller is also triggered via a source channel, which is done by the `Operating System Config` controller during an in-place service account key rotation.
+
+The controller is also triggered via a source channel by the `Operating System Config` controller in two situations:
+
+- **In-place service account key rotation**: all configured token sync secrets receive an event so their tokens are re-fetched with the new key.
+- **File deletion**: when the OSC reconciler deletes a file whose path matches a `syncConfigs[].path` entry, it immediately sends an event for the corresponding secret. This covers the race where a file is moved from the `OperatingSystemConfig` spec into a `TokenSecretSyncConfig`: the token controller may write the file before the OSC reconciler deletes it, so the resync ensures the file is restored after deletion.
 
 ### [Certificate Controller](../../pkg/nodeagent/controller/certificate)
 

--- a/docs/concepts/node-agent.md
+++ b/docs/concepts/node-agent.md
@@ -125,8 +125,9 @@ When serial reconciliation is enabled:
 ### [Token Controller](../../pkg/nodeagent/controller/token)
 
 This controller watches the access token `Secret`s in the `kube-system` namespace configured via the `gardener-node-agent`'s component configuration (`.controllers.token.syncConfigs[]` field).
-Whenever the `.data.token` field changes, it writes the new content to a file on the configured path on the host file system.
-This mechanism is used to download its own access token for the shoot cluster, but also the access tokens of other `systemd` components (e.g., `valitail`).
+Whenever the `.data.token` field changes, it writes the new content to a file on the configured path on the host file system with `0640` permissions.
+Token files are written with `0640` permissions (rather than `0600`) because static pods running as the control plane components use `FSGroup=0`, which adds group `0` as a supplemental group to the container process — making `root:root 0640` files readable by the container, while `0600` would break this since group membership does not help with owner-only files.
+This mechanism is used to download its own access token for the shoot cluster, but also the access tokens of other `systemd` components (e.g., `valitail`) and of control plane components running as static pods on self-hosted shoot nodes (e.g., `kube-apiserver`, `kube-controller-manager`, `kube-scheduler`).
 Since the underlying client is based on `k8s.io/client-go` and the kubeconfig points to this token file, it is dynamically reloaded without the necessity of explicit configuration or code changes.
 This procedure ensures that the most up-to-date tokens are always present on the host and used by the `gardener-node-agent` and the other `systemd` components.
 

--- a/hack/usage/generate-kubeconfig.sh
+++ b/hack/usage/generate-kubeconfig.sh
@@ -221,10 +221,7 @@ get_self_hosted_shoot_certs() {
   remote_kubectl -n kube-system get secret -l name=ca-client -o jsonpath='{..data.ca\.crt}' | base64 -d > "$client_ca_cert"
   remote_kubectl -n kube-system get secret -l name=ca-client -o jsonpath='{..data.ca\.key}' | base64 -d > "$client_ca_key"
 
-  local dns_domain
-  dns_domain=$(remote_kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' | sed 's|https://api\.||')
-
-  echo "${tmp_dir}:${dns_domain}"
+  echo "${tmp_dir}:${shoot_name}.${shoot_namespace}.external.local.gardener.cloud"
 }
 
 generate_client_cert_kubeconfig() {

--- a/pkg/component/extensions/operatingsystemconfig/mock/mocks.go
+++ b/pkg/component/extensions/operatingsystemconfig/mock/mocks.go
@@ -172,6 +172,18 @@ func (mr *MockInterfaceMockRecorder) SetSSHPublicKeys(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSSHPublicKeys", reflect.TypeOf((*MockInterface)(nil).SetSSHPublicKeys), arg0)
 }
 
+// SetSyncControlPlaneAuthTokens mocks base method.
+func (m *MockInterface) SetSyncControlPlaneAuthTokens(arg0 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSyncControlPlaneAuthTokens", arg0)
+}
+
+// SetSyncControlPlaneAuthTokens indicates an expected call of SetSyncControlPlaneAuthTokens.
+func (mr *MockInterfaceMockRecorder) SetSyncControlPlaneAuthTokens(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSyncControlPlaneAuthTokens", reflect.TypeOf((*MockInterface)(nil).SetSyncControlPlaneAuthTokens), arg0)
+}
+
 // Wait mocks base method.
 func (m *MockInterface) Wait(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -82,6 +82,8 @@ type Interface interface {
 	WorkerPoolNameToOperatingSystemConfigsMap() map[string]*OperatingSystemConfigs
 	// SetClusterDNSAddresses sets the cluster DNS addresses.
 	SetClusterDNSAddresses([]string)
+	// SetSyncControlPlaneAuthTokens sets the SyncControlPlaneAuthTokens field in the values.
+	SetSyncControlPlaneAuthTokens(bool)
 }
 
 // Values contains the values used to create an OperatingSystemConfig resource.
@@ -149,6 +151,10 @@ type OriginalValues struct {
 	KubeProxyConfig *gardencorev1beta1.KubeProxyConfig
 	// Region is the name of the region specified in the Shoot spec.
 	Region *string
+	// SyncControlPlaneAuthTokens indicates whether the shoot access secret tokens for the Kubernetes control
+	// plane components (running as static pods) should be included in gardener-node-agent's token controller config for
+	// getting synced to the host filesystem.
+	SyncControlPlaneAuthTokens bool
 }
 
 // New creates a new instance of Interface.
@@ -512,6 +518,10 @@ func (o *operatingSystemConfig) SetClusterDNSAddresses(clusterDNSAddresses []str
 	o.values.ClusterDNSAddresses = clusterDNSAddresses
 }
 
+func (o *operatingSystemConfig) SetSyncControlPlaneAuthTokens(sync bool) {
+	o.values.SyncControlPlaneAuthTokens = sync
+}
+
 func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSystemConfig, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) (deployer, error) {
 	criName := extensionsv1alpha1.CRINameContainerD
 	if worker.CRI != nil {
@@ -621,8 +631,9 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		primaryIPFamily:                         o.values.PrimaryIPFamily,
 		taints:                                  taints,
 		caRotationLastInitiationTime:            caRotationLastInitiationTime,
+		region:                                  o.values.Region,
+		syncControlPlaneAuthTokens:              o.values.SyncControlPlaneAuthTokens,
 		serviceAccountKeyRotationLastInitiationTime: serviceAccountKeyRotationLastInitiationTime,
-		region: o.values.Region,
 	}, nil
 }
 
@@ -696,6 +707,7 @@ type deployer struct {
 	caRotationLastInitiationTime                *metav1.Time
 	serviceAccountKeyRotationLastInitiationTime *metav1.Time
 	region                                      *string
+	syncControlPlaneAuthTokens                  bool
 }
 
 // exposed for testing
@@ -739,6 +751,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 		Sysctls:                                 d.worker.Sysctls,
 		PreferIPv6:                              d.primaryIPFamily == gardencorev1beta1.IPFamilyIPv6,
 		Taints:                                  d.taints,
+		SyncControlPlaneAuthTokens:              d.syncControlPlaneAuthTokens && d.worker.ControlPlane != nil,
 	}
 
 	switch d.purpose {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/components.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/components.go
@@ -48,4 +48,5 @@ type Context struct {
 	Sysctls                                 map[string]string
 	PreferIPv6                              bool
 	Taints                                  []corev1.Taint
+	SyncControlPlaneAuthTokens              bool
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -22,13 +22,16 @@ import (
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/nodeagent/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/valitail"
 	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	collectorconstants "github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector/constants"
 	"github.com/gardener/gardener/pkg/features"
+	"github.com/gardener/gardener/pkg/gardenadm/staticpod"
 	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // PathBinary is a constant for the path to the gardener-node-agent binary file on the VMs.
@@ -71,6 +74,15 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 			SecretName: valiconstants.ValitailTokenSecretName,
 			Path:       valitail.PathAuthToken,
 		})
+	}
+
+	if ctx.SyncControlPlaneAuthTokens {
+		for _, componentName := range []string{v1beta1constants.DeploymentNameKubeControllerManager, v1beta1constants.DeploymentNameKubeScheduler} {
+			additionalTokenSyncConfigs = append(additionalTokenSyncConfigs, nodeagentconfigv1alpha1.TokenSecretSyncConfig{
+				SecretName: gardenerutils.SecretNamePrefixShootAccess + componentName,
+				Path:       staticpod.FilePathForProjectedVolumeItem(componentName, "kubeconfig", resourcesv1alpha1.DataKeyToken),
+			})
+		}
 	}
 
 	files, err := Files(ComponentConfig(ctx.Key, ctx.KubernetesVersion, ctx.APIServerURL, additionalTokenSyncConfigs))

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/valitail"
+	"github.com/gardener/gardener/pkg/component/kubernetes/adminaccess"
 	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	collectorconstants "github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector/constants"
 	"github.com/gardener/gardener/pkg/features"
@@ -83,6 +84,11 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 				Path:       staticpod.FilePathForProjectedVolumeItem(componentName, "kubeconfig", resourcesv1alpha1.DataKeyToken),
 			})
 		}
+
+		additionalTokenSyncConfigs = append(additionalTokenSyncConfigs, nodeagentconfigv1alpha1.TokenSecretSyncConfig{
+			SecretName: gardenerutils.SecretNamePrefixShootAccess + adminaccess.ShootAccessSecretNameSuffix,
+			Path:       adminaccess.PathOnControlPlaneNodes,
+		})
 	}
 
 	files, err := Files(ComponentConfig(ctx.Key, ctx.KubernetesVersion, ctx.APIServerURL, additionalTokenSyncConfigs))

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
@@ -111,6 +111,10 @@ WantedBy=multi-user.target`),
 						SecretName: "shoot-access-kube-scheduler",
 						Path:       "/var/lib/static-pods/kube-scheduler/kubeconfig/token",
 					},
+					{
+						SecretName: "shoot-access-cluster-admin",
+						Path:       "/etc/kubernetes/admin-token",
+					},
 				}
 			)
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
@@ -98,6 +98,38 @@ WantedBy=multi-user.target`),
 				},
 			})))
 		})
+
+		It("should include control plane auth token sync configs when SyncControlPlaneAuthTokens is true", func() {
+			var (
+				key                  = "key"
+				expectedTokenConfigs = []nodeagentconfigv1alpha1.TokenSecretSyncConfig{
+					{
+						SecretName: "shoot-access-kube-controller-manager",
+						Path:       "/var/lib/static-pods/kube-controller-manager/kubeconfig/token",
+					},
+					{
+						SecretName: "shoot-access-kube-scheduler",
+						Path:       "/var/lib/static-pods/kube-scheduler/kubeconfig/token",
+					},
+				}
+			)
+
+			_, files, err := component.Config(components.Context{
+				Key:                        key,
+				KubernetesVersion:          kubernetesVersion,
+				APIServerURL:               apiServerURL,
+				CABundle:                   string(caBundle),
+				SyncControlPlaneAuthTokens: true,
+				Images:                     map[string]*imagevectorutils.Image{"gardener-node-agent": {Repository: new("gardener-node-agent"), Tag: new("v1")}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedConfigFiles, err := Files(ComponentConfig(key, kubernetesVersion, apiServerURL, expectedTokenConfigs))
+			Expect(err).NotTo(HaveOccurred())
+			for _, expected := range expectedConfigFiles {
+				Expect(files).To(ContainElement(expected), "Expected file to be included: "+expected.Path)
+			}
+		})
 	})
 
 	Describe("#UnitContent", func() {

--- a/pkg/component/kubernetes/adminaccess/access.go
+++ b/pkg/component/kubernetes/adminaccess/access.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package adminaccess
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+)
+
+const (
+	// ManagedResourceName is the name of the ManagedResource containing the resource specifications.
+	ManagedResourceName = "shoot-core-adminaccess"
+	// ShootAccessSecretNameSuffix is the suffix name of the shoot access secret.
+	ShootAccessSecretNameSuffix = "cluster-admin"
+	// PathOnControlPlaneNodes is the path on control plane nodes to which the token of this shoot access secret should
+	// be synced.
+	PathOnControlPlaneNodes = "/etc/kubernetes/admin-token"
+)
+
+// New creates a new instance of the deployer for AdminAccess.
+func New(client client.Client, namespace string) component.DeployWaiter {
+	return &adminAccess{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+type adminAccess struct {
+	client    client.Client
+	namespace string
+}
+
+func (a *adminAccess) Deploy(ctx context.Context) error {
+	shootAccessSecret := gardenerutils.NewShootAccessSecret(ShootAccessSecretNameSuffix, a.namespace)
+	if err := shootAccessSecret.Reconcile(ctx, a.client); err != nil {
+		return err
+	}
+
+	data, err := a.computeResourcesData(shootAccessSecret.ServiceAccountName)
+	if err != nil {
+		return err
+	}
+
+	return managedresources.CreateForShootWithLabels(ctx, a.client, a.namespace, ManagedResourceName, managedresources.LabelValueGardener, true, nil, data)
+}
+
+func (a *adminAccess) Destroy(ctx context.Context) error {
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: gardenerutils.SecretNamePrefixShootAccess + ShootAccessSecretNameSuffix, Namespace: a.namespace}}
+	if err := a.client.Delete(ctx, secret); client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("failed deleting secret %s: %w", client.ObjectKeyFromObject(secret), err)
+	}
+
+	return managedresources.DeleteForShoot(ctx, a.client, a.namespace, ManagedResourceName)
+}
+
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy or deleted.
+var TimeoutWaitForManagedResource = 2 * time.Minute
+
+func (a *adminAccess) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilHealthy(timeoutCtx, a.client, a.namespace, ManagedResourceName)
+}
+
+func (a *adminAccess) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilDeleted(timeoutCtx, a.client, a.namespace, ManagedResourceName)
+}
+
+func (a *adminAccess) computeResourcesData(serviceAccountName string) (map[string][]byte, error) {
+	var (
+		registry = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
+
+		gardenerSystemClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener.cloud:system:cluster-admin",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "cluster-admin",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      serviceAccountName,
+				Namespace: metav1.NamespaceSystem,
+			}},
+		}
+	)
+
+	return registry.AddAllAndSerialize(gardenerSystemClusterRoleBinding)
+}

--- a/pkg/component/kubernetes/adminaccess/access_suite_test.go
+++ b/pkg/component/kubernetes/adminaccess/access_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package adminaccess_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAdminAccess(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component Kubernetes AdminAccess Suite")
+}

--- a/pkg/component/kubernetes/adminaccess/access_test.go
+++ b/pkg/component/kubernetes/adminaccess/access_test.go
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package adminaccess_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	. "github.com/gardener/gardener/pkg/component/kubernetes/adminaccess"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("AdminAccess", func() {
+	var (
+		fakeClient client.Client
+		access     component.DeployWaiter
+		consistOf  func(...client.Object) types.GomegaMatcher
+
+		ctx       = context.Background()
+		namespace = "shoot--foo--bar"
+
+		clusterAdminClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener.cloud:system:cluster-admin",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     "cluster-admin",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      "cluster-admin",
+				Namespace: "kube-system",
+			}},
+		}
+
+		shootAccessSecretName     = "shoot-access-cluster-admin"
+		managedResourceName       = "shoot-core-adminaccess"
+		managedResourceSecretName = "managedresource-shoot-core-adminaccess"
+		managedResourceSecret     *corev1.Secret
+
+		expectedShootAccessSecret *corev1.Secret
+		expectedManagedResource   *resourcesv1alpha1.ManagedResource
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(fakeClient)
+
+		access = New(fakeClient, namespace)
+
+		expectedShootAccessSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            shootAccessSecretName,
+				Namespace:       namespace,
+				ResourceVersion: "1",
+				Annotations: map[string]string{
+					"serviceaccount.resources.gardener.cloud/name":      "cluster-admin",
+					"serviceaccount.resources.gardener.cloud/namespace": "kube-system",
+				},
+				Labels: map[string]string{
+					"resources.gardener.cloud/purpose": "token-requestor",
+					"resources.gardener.cloud/class":   "shoot",
+				},
+			},
+			Type: corev1.SecretTypeOpaque,
+		}
+
+		managedResourceSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResourceSecretName,
+				Namespace: namespace,
+			},
+		}
+		expectedManagedResource = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            managedResourceName,
+				Namespace:       namespace,
+				ResourceVersion: "1",
+				Labels: map[string]string{
+					"origin": "gardener",
+				},
+			},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				SecretRefs:   []corev1.LocalObjectReference{},
+				InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
+				KeepObjects:  new(true),
+			},
+		}
+	})
+
+	AfterEach(func() {
+		Expect(fakeClient.Delete(ctx, expectedShootAccessSecret)).To(Or(Succeed(), BeNotFoundError()))
+		Expect(fakeClient.Delete(ctx, managedResourceSecret)).To(Or(Succeed(), BeNotFoundError()))
+		Expect(fakeClient.Delete(ctx, expectedManagedResource)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	Describe("#Deploy", func() {
+		It("should successfully deploy all resources", func() {
+			Expect(access.Deploy(ctx)).To(Succeed())
+
+			reconciledManagedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: namespace}}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(reconciledManagedResource), reconciledManagedResource)).To(Succeed())
+			expectedManagedResource.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: reconciledManagedResource.Spec.SecretRefs[0].Name}}
+			utilruntime.Must(references.InjectAnnotations(expectedManagedResource))
+			Expect(reconciledManagedResource).To(DeepEqual(expectedManagedResource))
+			Expect(reconciledManagedResource).To(consistOf(clusterAdminClusterRoleBinding))
+
+			reconciledShootAccessSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: shootAccessSecretName, Namespace: namespace}}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(reconciledShootAccessSecret), reconciledShootAccessSecret)).To(Succeed())
+			Expect(reconciledShootAccessSecret).To(DeepEqual(expectedShootAccessSecret))
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should successfully delete all the resources", func() {
+			expectedShootAccessSecret.ResourceVersion = ""
+			managedResourceSecret.ResourceVersion = ""
+			expectedManagedResource.ResourceVersion = ""
+
+			Expect(fakeClient.Create(ctx, expectedShootAccessSecret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceSecret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, expectedManagedResource)).To(Succeed())
+
+			Expect(access.Destroy(ctx)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expectedShootAccessSecret), expectedShootAccessSecret)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expectedManagedResource), expectedManagedResource)).To(BeNotFoundError())
+		})
+	})
+
+	Context("waiting functions", func() {
+		var (
+			fakeOps *retryfake.Ops
+		)
+
+		BeforeEach(func() {
+			fakeOps = &retryfake.Ops{MaxAttempts: 1}
+			DeferCleanup(test.WithVars(
+				&TimeoutWaitForManagedResource, 500*time.Millisecond,
+				&retry.Until, fakeOps.Until,
+				&retry.UntilTimeout, fakeOps.UntilTimeout,
+			))
+		})
+
+		Describe("#Wait", func() {
+			It("should fail because reading the ManagedResource fails", func() {
+				Expect(access.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+			})
+
+			It("should fail because the ManagedResource doesn't become healthy", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(access.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should successfully wait for the managed resource to become healthy", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(access.Wait(ctx)).To(Succeed())
+			})
+		})
+
+		Describe("#WaitCleanup", func() {
+			It("should fail when the wait for the managed resource deletion times out", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(access.Deploy(ctx)).To(Succeed())
+
+				Expect(access.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should not return an error when it's already removed", func() {
+				Expect(access.WaitCleanup(ctx)).To(Succeed())
+			})
+		})
+	})
+})

--- a/pkg/gardenadm/botanist/client.go
+++ b/pkg/gardenadm/botanist/client.go
@@ -36,6 +36,7 @@ func NewClientSetFromFile(kubeconfigPath string, scheme *runtime.Scheme) (kubern
 		kubernetes.WithClientOptions(client.Options{Scheme: scheme}),
 		kubernetes.WithClientConnectionOptions(componentbaseconfigv1alpha1.ClientConnectionConfiguration{QPS: 100, Burst: 130}),
 		kubernetes.WithDisabledCachedClient(),
+		kubernetes.WithAllowedUserFields([]string{kubernetes.AuthTokenFile}),
 	)
 }
 

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -37,11 +37,11 @@ import (
 // DeployOperatingSystemConfigSecretForBootstrap deploys the OperatingSystemConfig resource and adds its content into
 // a Secret so that gardener-node-agent can read it and reconcile its content.
 func (b *GardenadmBotanist) DeployOperatingSystemConfigSecretForBootstrap(ctx context.Context) error {
-	if err := b.DeployControlPlaneDeployments(ctx, true, b.BackupDataPath); err != nil {
+	if err := b.DeployControlPlaneDeployments(ctx, true, false, b.BackupDataPath); err != nil {
 		return fmt.Errorf("failed deploying control plane deployments: %w", err)
 	}
 
-	oscData, controlPlaneWorkerPoolName, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, true, b.BackupDataPath)
+	oscData, controlPlaneWorkerPoolName, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, true, false, b.BackupDataPath)
 	if err != nil {
 		return fmt.Errorf("failed deploying OperatingSystemConfig: %w", err)
 	}

--- a/pkg/gardenadm/staticpod/translator.go
+++ b/pkg/gardenadm/staticpod/translator.go
@@ -200,3 +200,8 @@ func StatefulSetVolumeClaimTemplateHostPath(volumeClaimTemplateName string) stri
 func HostPath(podName, volumeName string) string {
 	return filepath.Join(string(filepath.Separator), "var", "lib", "static-pods", podName, volumeName)
 }
+
+// FilePathForProjectedVolumeItem returns the file path for an item in a projected volume for the given pod.
+func FilePathForProjectedVolumeItem(podName, volumeName, itemPath string) string {
+	return filepath.Join(HostPath(podName, volumeName), string(filepath.Separator), itemPath)
+}

--- a/pkg/gardenadm/staticpod/translator.go
+++ b/pkg/gardenadm/staticpod/translator.go
@@ -63,17 +63,19 @@ func translatePodTemplate(ctx context.Context, c client.Client, objectMeta metav
 
 	translateSpec(&pod.Spec)
 
-	filesFromVolumes, err := translateVolumes(ctx, c, pod, objectMeta.Namespace)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed translating volumes for static pod %s: %w", client.ObjectKeyFromObject(pod), err)
-	}
-
 	if mutate != nil {
 		mutate(pod)
 	}
 
+	// Compute the hash before rewriting volumes to HostPaths so that changes to referenced Secret/ConfigMap names
+	// (which affect the on-disk content) are reflected in the hash and trigger a static pod rollout via GNA.
 	hash := utils.ComputeChecksum(pod)
 	metav1.SetMetaDataAnnotation(&pod.ObjectMeta, AnnotationKeyHash, hash)
+
+	filesFromVolumes, err := translateVolumes(ctx, c, pod, objectMeta.Namespace)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed translating volumes for static pod %s: %w", client.ObjectKeyFromObject(pod), err)
+	}
 
 	staticPodYAML, err := kubernetesutils.Serialize(pod, c.Scheme())
 	if err != nil {

--- a/pkg/gardenadm/staticpod/translator_test.go
+++ b/pkg/gardenadm/staticpod/translator_test.go
@@ -220,6 +220,35 @@ status: {}
 				Expect(Translate(ctx, fakeClient, deployment, nil)).Error().To(MatchError(ContainSubstring("failed reading Secret")))
 			})
 
+			It("should produce different hashes when Secret names change (same HostPath)", func() {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "secret-v1", Namespace: deployment.Namespace},
+					Data:       map[string][]byte{"token": []byte("old-token")},
+				}
+				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+				deployment.Spec.Template.Spec.Volumes = []corev1.Volume{
+					{Name: "token", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "secret-v1"}}},
+				}
+
+				_, hash1, err := Translate(ctx, fakeClient, deployment, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Rename the secret (simulates secrets-manager rotating to a new secret name).
+				secret2 := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "secret-v2", Namespace: deployment.Namespace},
+					Data:       map[string][]byte{"token": []byte("new-token")},
+				}
+				Expect(fakeClient.Create(ctx, secret2)).To(Succeed())
+
+				deployment.Spec.Template.Spec.Volumes[0].VolumeSource = corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "secret-v2"}}
+
+				_, hash2, err := Translate(ctx, fakeClient, deployment, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(hash1).NotTo(Equal(hash2), "hash must change when referenced Secret name changes so GNA triggers a static pod rollout")
+			})
+
 			It("should successfully translate a deployment w/ volumes", func() {
 				var (
 					configMap1 = &corev1.ConfigMap{

--- a/pkg/gardenadm/staticpod/translator_test.go
+++ b/pkg/gardenadm/staticpod/translator_test.go
@@ -960,6 +960,12 @@ kind: Config
 			Expect(StatefulSetVolumeClaimTemplateHostPath("foo")).To(Equal("/var/lib/foo/data"))
 		})
 	})
+
+	Describe("#FilePathForProjectedVolumeItem", func() {
+		It("should return the expected path", func() {
+			Expect(FilePathForProjectedVolumeItem("my-pod", "my-volume", "subdir/token")).To(Equal("/var/lib/static-pods/my-pod/my-volume/subdir/token"))
+		})
+	})
 })
 
 func foobarThePod(pod *corev1.Pod) {

--- a/pkg/gardenlet/operation/botanist/adminaccess.go
+++ b/pkg/gardenlet/operation/botanist/adminaccess.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/kubernetes/adminaccess"
+)
+
+// DefaultAdminAccess returns an instance of the Deployer which reconciles the resources so that a shoot access secret
+// with cluster-admin access gets created
+func (b *Botanist) DefaultAdminAccess() component.Deployer {
+	return adminaccess.New(
+		b.SeedClientSet.Client(),
+		b.Shoot.ControlPlaneNamespace,
+	)
+}

--- a/pkg/gardenlet/operation/botanist/components.go
+++ b/pkg/gardenlet/operation/botanist/components.go
@@ -217,6 +217,10 @@ func (b *Botanist) instantiateComponentsMisc() {
 	b.Shoot.Components.DependencyWatchdogAccess = b.DefaultDependencyWatchdogAccess()
 	b.Shoot.Components.GardenerAccess = b.DefaultGardenerAccess()
 	b.Shoot.Components.SourceBackupEntry = b.SourceBackupEntry()
+
+	if b.Shoot.IsSelfHosted() {
+		b.Shoot.Components.AdminAccess = b.DefaultAdminAccess()
+	}
 }
 
 func (b *Botanist) instantiateComponentsAddons() (err error) {

--- a/pkg/gardenlet/operation/botanist/export_test.go
+++ b/pkg/gardenlet/operation/botanist/export_test.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import "context"
+
+// Functions exported for testing.
+
+var UseShootAccessTokensForSelfHostedShootControlPlane = func(b *Botanist, ctx context.Context) (bool, error) {
+	return b.useShootAccessTokensForSelfHostedShootControlPlane(ctx)
+}

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -637,6 +637,12 @@ func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd boo
 			TaskGroupReconcileETCDs,
 		).SkipIf(!b.Shoot.IsSelfHosted())
 
+		_ = g.Add(flow.Task{
+			Name: "Reconciling cluster-admin access resources for kubeconfig on control plane nodes",
+			Fn: func(ctx context.Context) error {
+				return component.OpWait(b.Shoot.Components.AdminAccess).Deploy(ctx)
+			},
+		})
 		deployControlPlaneDeployments = g.Add(flow.Task{
 			Name: "Deploying control plane components as Deployments/StatefulSets and updating gardener-node-agent Secret",
 			Fn: func(ctx context.Context) error {

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -173,6 +173,12 @@ func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
 	}
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetClusterDNSAddresses(clusterDNSAddresses)
 
+	readyForStaticAuthTokenSync, err := b.useShootAccessTokensForSelfHostedShootControlPlane(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check whether static auth tokens for self-hosted shoot control plane components can be synced: %w", err)
+	}
+	b.Shoot.Components.Extensions.OperatingSystemConfig.SetSyncControlPlaneAuthTokens(readyForStaticAuthTokenSync)
+
 	if b.Shoot.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.OperatingSystemConfig.Restore(ctx, b.Shoot.GetShootState())
 	}

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -132,6 +132,7 @@ var _ = Describe("operatingsystemconfig", func() {
 				operatingSystemConfig.EXPECT().SetAPIServerURL(fmt.Sprintf("https://api.%s", shootDomain))
 				operatingSystemConfig.EXPECT().SetSSHPublicKeys(gomock.AssignableToTypeOf([]string{}))
 				operatingSystemConfig.EXPECT().SetClusterDNSAddresses(coreDNS)
+				operatingSystemConfig.EXPECT().SetSyncControlPlaneAuthTokens(false)
 			})
 
 			It("should deploy successfully (only CloudProfile CA)", func() {
@@ -195,6 +196,7 @@ var _ = Describe("operatingsystemconfig", func() {
 				operatingSystemConfig.EXPECT().SetAPIServerURL(fmt.Sprintf("https://api.%s", shootDomain))
 				operatingSystemConfig.EXPECT().SetSSHPublicKeys(gomock.AssignableToTypeOf([]string{}))
 				operatingSystemConfig.EXPECT().SetClusterDNSAddresses(coreDNS)
+				operatingSystemConfig.EXPECT().SetSyncControlPlaneAuthTokens(false)
 
 				shoot := botanist.Shoot.GetInfo()
 				shoot.Status = gardencorev1beta1.ShootStatus{

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -35,6 +35,7 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
 // PathKubeconfig is the path to a file on the control plane node containing an admin kubeconfig.
@@ -84,13 +85,28 @@ func (b *Botanist) deployETCD(role string, bootstrapEtcdBackupPath string) func(
 	}
 }
 
-func (b *Botanist) deployKubeAPIServer(ctx context.Context) error {
-	b.Shoot.Components.ControlPlane.KubeAPIServer.EnableStaticTokenKubeconfig()
+func (b *Botanist) deployKubeAPIServer(ctx context.Context, useShootAccessTokens bool) error {
+	if !useShootAccessTokens {
+		b.Shoot.Components.ControlPlane.KubeAPIServer.EnableStaticTokenKubeconfig()
+	} else {
+		// Usually, these secrets would be deleted by a `b.SecretsManager.Cleanup()` call. However, we don't run this
+		// call in gardenlet yet. Hence, for now, let's explicitly delete them.
+		// TODO(rfranzke): Remove this in favor of the `b.SecretsManager.Cleanup()` call at the end of the shoot
+		//  reconciliation (see TODO statement there).
+		if err := b.SeedClientSet.Client().DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(b.Shoot.ControlPlaneNamespace), client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(
+			utils.MustNewRequirement(secretsmanager.LabelKeyManagedBy, selection.Equals, secretsmanager.LabelValueSecretsManager),
+			utils.MustNewRequirement(secretsmanager.LabelKeyManagerIdentity, selection.Equals, b.SecretsManager.Identity()),
+			utils.MustNewRequirement(secretsmanager.LabelKeyName, selection.In, kubeapiserver.SecretNameUserKubeconfig),
+		)}); err != nil {
+			return fmt.Errorf("failed to cleanup static token kubeconfig and user kubeconfig secrets: %w", err)
+		}
+	}
+
 	b.Shoot.Components.ControlPlane.KubeAPIServer.SetAutoscalingReplicas(new(int32(0)))
 	return b.DeployKubeAPIServer(ctx)
 }
 
-func (b *Botanist) staticControlPlaneComponents(useBootstrapEtcd bool, bootstrapEtcdBackupPath string) []staticControlPlaneComponent {
+func (b *Botanist) staticControlPlaneComponents(useBootstrapEtcd, useShootAccessTokens bool, bootstrapEtcdBackupPath string) []staticControlPlaneComponent {
 	var (
 		components []staticControlPlaneComponent
 
@@ -118,7 +134,7 @@ func (b *Botanist) staticControlPlaneComponents(useBootstrapEtcd bool, bootstrap
 	}
 
 	return append(components,
-		staticControlPlaneComponent{b.deployKubeAPIServer, v1beta1constants.DeploymentNameKubeAPIServer, &appsv1.Deployment{}, nil},
+		staticControlPlaneComponent{func(ctx context.Context) error { return b.deployKubeAPIServer(ctx, useShootAccessTokens) }, v1beta1constants.DeploymentNameKubeAPIServer, &appsv1.Deployment{}, nil},
 		staticControlPlaneComponent{b.DeployKubeControllerManager, v1beta1constants.DeploymentNameKubeControllerManager, &appsv1.Deployment{}, nil},
 		staticControlPlaneComponent{b.Shoot.Components.ControlPlane.KubeScheduler.Deploy, v1beta1constants.DeploymentNameKubeScheduler, &appsv1.Deployment{}, nil},
 	)
@@ -155,7 +171,7 @@ func (b *Botanist) DeployStaticControlPlaneDeployments(ctx context.Context, useB
 
 // DeployControlPlaneDeployments runs the Deploy function of the control plane components.
 func (b *Botanist) DeployControlPlaneDeployments(ctx context.Context, useBootstrapEtcd, useShootAccessTokens bool, bootstrapEtcdBackupPath string) error {
-	for _, component := range b.staticControlPlaneComponents(useBootstrapEtcd, bootstrapEtcdBackupPath) {
+	for _, component := range b.staticControlPlaneComponents(useBootstrapEtcd, useShootAccessTokens, bootstrapEtcdBackupPath) {
 		if err := b.deployControlPlaneComponent(ctx, component.deploy, component.targetObject, component.name, useShootAccessTokens); err != nil {
 			return fmt.Errorf("failed deploying %q: %w", component.name, err)
 		}
@@ -224,9 +240,12 @@ func (b *Botanist) DeployOperatingSystemConfigWithStaticPods(ctx context.Context
 		return nil, "", fmt.Errorf("failed computing files for static control plane pods: %w", err)
 	}
 
-	files, err := b.appendAdminKubeconfigToFiles(pods.allFiles())
-	if err != nil {
-		return nil, "", fmt.Errorf("failed appending admin kubeconfig to list of files: %w", err)
+	files := pods.allFiles()
+	if !useShootAccessTokens {
+		files, err = b.appendAdminKubeconfigToFiles(files)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed appending admin kubeconfig to list of files: %w", err)
+		}
 	}
 
 	if err := b.DeployOperatingSystemConfig(ctx); err != nil {
@@ -292,7 +311,7 @@ func (s staticPods) allFiles() []extensionsv1alpha1.File {
 func (b *Botanist) staticControlPlanePods(ctx context.Context, useBootstrapEtcd, useShootAccessTokens bool, bootstrapEtcdBackupPath string) (staticPods, error) {
 	var pods staticPods
 
-	for _, component := range b.staticControlPlaneComponents(useBootstrapEtcd, bootstrapEtcdBackupPath) {
+	for _, component := range b.staticControlPlaneComponents(useBootstrapEtcd, useShootAccessTokens, bootstrapEtcdBackupPath) {
 		if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Name: component.name, Namespace: b.Shoot.ControlPlaneNamespace}, component.targetObject); err != nil {
 			return nil, fmt.Errorf("failed reading object for %q: %w", component.name, err)
 		}

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -407,8 +407,7 @@ func (b *Botanist) UpdateNodeAgentSecretNameLabelsOnNodes(ctx context.Context) e
 // instantiated the Botanist instance, it returns false, since only the shoot gardenlet is the only instance who should
 // take care to disable the static token after initialization of the cluster (gardenadm init).
 func (b *Botanist) useShootAccessTokensForSelfHostedShootControlPlane(ctx context.Context) (bool, error) {
-	if !b.Shoot.IsSelfHosted() ||
-		b.Shoot.GetInfo().Status.Gardener.Name == "gardenadm" {
+	if !b.Shoot.IsSelfHosted() || b.Shoot.GetInfo().Status.Gardener.Name == "gardenadm" {
 		return false, nil
 	}
 

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -16,7 +16,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
@@ -28,6 +31,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/etcd/bootstrap/backuprestore"
 	etcdconstants "github.com/gardener/gardener/pkg/component/etcd/etcd/constants"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig"
+	"github.com/gardener/gardener/pkg/component/kubernetes/adminaccess"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
 	"github.com/gardener/gardener/pkg/gardenadm/staticpod"
 	"github.com/gardener/gardener/pkg/utils"
@@ -240,12 +244,14 @@ func (b *Botanist) DeployOperatingSystemConfigWithStaticPods(ctx context.Context
 		return nil, "", fmt.Errorf("failed computing files for static control plane pods: %w", err)
 	}
 
-	files := pods.allFiles()
-	if !useShootAccessTokens {
-		files, err = b.appendAdminKubeconfigToFiles(files)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed appending admin kubeconfig to list of files: %w", err)
-		}
+	appendAdminKubeconfigFunc := b.appendStaticAdminKubeconfigToFiles
+	if useShootAccessTokens {
+		appendAdminKubeconfigFunc = b.appendDynamicAdminKubeconfigToFiles
+	}
+
+	files, err := appendAdminKubeconfigFunc(pods.allFiles())
+	if err != nil {
+		return nil, "", fmt.Errorf("failed appending admin kubeconfig to list of files: %w", err)
 	}
 
 	if err := b.DeployOperatingSystemConfig(ctx); err != nil {
@@ -280,7 +286,7 @@ func (b *Botanist) DeployOperatingSystemConfigWithStaticPods(ctx context.Context
 	return &oscData.Original, controlPlaneWorkerPool.Name, nil
 }
 
-func (b *Botanist) appendAdminKubeconfigToFiles(files []extensionsv1alpha1.File) ([]extensionsv1alpha1.File, error) {
+func (b *Botanist) appendStaticAdminKubeconfigToFiles(files []extensionsv1alpha1.File) ([]extensionsv1alpha1.File, error) {
 	userKubeconfigSecret, ok := b.SecretsManager.Get(kubeapiserver.SecretNameUserKubeconfig)
 	if !ok {
 		return nil, fmt.Errorf("failed fetching secret %q", kubeapiserver.SecretNameUserKubeconfig)
@@ -290,6 +296,31 @@ func (b *Botanist) appendAdminKubeconfigToFiles(files []extensionsv1alpha1.File)
 		Path:        PathKubeconfig,
 		Permissions: new(uint32(0600)),
 		Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(userKubeconfigSecret.Data[secretsutils.DataKeyKubeconfig])}},
+	}), nil
+}
+
+func (b *Botanist) appendDynamicAdminKubeconfigToFiles(files []extensionsv1alpha1.File) ([]extensionsv1alpha1.File, error) {
+	clusterCABundleSecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameCACluster)
+	if !found {
+		return nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
+	}
+
+	kubeconfig := kubernetesutils.NewKubeconfig(
+		b.Shoot.GetInfo().Status.TechnicalID,
+		clientcmdv1.Cluster{Server: "localhost", CertificateAuthorityData: clusterCABundleSecret.Data[secretsutils.DataKeyCertificateBundle]},
+		clientcmdv1.AuthInfo{TokenFile: adminaccess.PathOnControlPlaneNodes},
+	)
+	kubeconfig.Contexts[0].Context.Namespace = b.Shoot.ControlPlaneNamespace
+
+	rawKubeconfig, err := runtime.Encode(clientcmdlatest.Codec, kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed generating authorization webhook kubeconfig: %w", err)
+	}
+
+	return append(files, extensionsv1alpha1.File{
+		Path:        PathKubeconfig,
+		Permissions: new(uint32(0600)),
+		Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(rawKubeconfig)}},
 	}), nil
 }
 

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -323,3 +323,24 @@ func (b *Botanist) UpdateNodeAgentSecretNameLabelsOnNodes(ctx context.Context) e
 
 	return flow.Parallel(tasks...)(ctx)
 }
+
+// useShootAccessTokensForSelfHostedShootControlPlane returns true for self-hosted shoots whose
+// gardener-resource-manager deployment runs in the pod network. If the shoot status indicates that gardenadm
+// instantiated the Botanist instance, it returns false, since only the shoot gardenlet is the only instance who should
+// take care to disable the static token after initialization of the cluster (gardenadm init).
+func (b *Botanist) useShootAccessTokensForSelfHostedShootControlPlane(ctx context.Context) (bool, error) {
+	if !b.Shoot.IsSelfHosted() ||
+		b.Shoot.GetInfo().Status.Gardener.Name == "gardenadm" {
+		return false, nil
+	}
+
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameGardenerResourceManager, Namespace: b.Shoot.ControlPlaneNamespace}}
+	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKeyFromObject(deployment), deployment); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed fetching deployment %s: %w", client.ObjectKeyFromObject(deployment), err)
+		}
+		return false, nil
+	}
+
+	return !deployment.Spec.Template.Spec.HostNetwork, nil
+}

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,6 +23,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	bootstrapetcd "github.com/gardener/gardener/pkg/component/etcd/bootstrap"
 	"github.com/gardener/gardener/pkg/component/etcd/bootstrap/backuprestore"
 	etcdconstants "github.com/gardener/gardener/pkg/component/etcd/etcd/constants"
@@ -126,11 +128,16 @@ func (b *Botanist) staticControlPlaneComponents(useBootstrapEtcd bool, bootstrap
 // the OperatingSystemConfig, waits for it to be reconciled by the OS extension, and deploys the ManagedResource
 // containing the Secret with OperatingSystemConfig for gardener-node-agent.
 func (b *Botanist) DeployStaticControlPlaneDeployments(ctx context.Context, useBootstrapEtcd bool, bootstrapEtcdBackupPath string) error {
-	if err := b.DeployControlPlaneDeployments(ctx, useBootstrapEtcd, bootstrapEtcdBackupPath); err != nil {
+	useShootAccessTokens, err := b.useShootAccessTokensForSelfHostedShootControlPlane(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check whether static auth tokens for self-hosted shoot control plane components can be synced: %w", err)
+	}
+
+	if err := b.DeployControlPlaneDeployments(ctx, useBootstrapEtcd, useShootAccessTokens, bootstrapEtcdBackupPath); err != nil {
 		return fmt.Errorf("failed deploying control plane deployments: %w", err)
 	}
 
-	if _, _, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, useBootstrapEtcd, bootstrapEtcdBackupPath); err != nil {
+	if _, _, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, useBootstrapEtcd, useShootAccessTokens, bootstrapEtcdBackupPath); err != nil {
 		return fmt.Errorf("failed deploying OperatingSystemConfig: %w", err)
 	}
 
@@ -147,9 +154,9 @@ func (b *Botanist) DeployStaticControlPlaneDeployments(ctx context.Context, useB
 }
 
 // DeployControlPlaneDeployments runs the Deploy function of the control plane components.
-func (b *Botanist) DeployControlPlaneDeployments(ctx context.Context, useBootstrapEtcd bool, bootstrapEtcdBackupPath string) error {
+func (b *Botanist) DeployControlPlaneDeployments(ctx context.Context, useBootstrapEtcd, useShootAccessTokens bool, bootstrapEtcdBackupPath string) error {
 	for _, component := range b.staticControlPlaneComponents(useBootstrapEtcd, bootstrapEtcdBackupPath) {
-		if err := b.deployControlPlaneComponent(ctx, component.deploy, component.targetObject, component.name); err != nil {
+		if err := b.deployControlPlaneComponent(ctx, component.deploy, component.targetObject, component.name, useShootAccessTokens); err != nil {
 			return fmt.Errorf("failed deploying %q: %w", component.name, err)
 		}
 	}
@@ -157,13 +164,15 @@ func (b *Botanist) DeployControlPlaneDeployments(ctx context.Context, useBootstr
 	return nil
 }
 
-func (b *Botanist) deployControlPlaneComponent(ctx context.Context, deploy func(context.Context) error, targetObject client.Object, componentName string) error {
+func (b *Botanist) deployControlPlaneComponent(ctx context.Context, deploy func(context.Context) error, targetObject client.Object, componentName string, useShootAccessTokens bool) error {
 	if err := deploy(ctx); err != nil {
 		return fmt.Errorf("failed deploying component %q: %w", componentName, err)
 	}
 
-	if err := b.populateStaticAdminTokenToAccessTokenSecret(ctx, componentName); err != nil {
-		return fmt.Errorf("failed populating static admin token to access token secret for %q: %w", componentName, err)
+	if !useShootAccessTokens {
+		if err := b.populateStaticAdminTokenToAccessTokenSecret(ctx, componentName); err != nil {
+			return fmt.Errorf("failed populating static admin token to access token secret for %q: %w", componentName, err)
+		}
 	}
 
 	targetObject.SetName(componentName)
@@ -178,6 +187,10 @@ func (b *Botanist) populateStaticAdminTokenToAccessTokenSecret(ctx context.Conte
 			return nil
 		}
 		return fmt.Errorf("failed reading secret %s for %q: %w", client.ObjectKeyFromObject(secret), componentName, err)
+	}
+
+	if secret.Annotations[resourcesv1alpha1.ServiceAccountTokenRenewTimestamp] != "" {
+		return nil // Do not overwrite dynamic access token with static token.
 	}
 
 	secretStaticToken, found := b.SecretsManager.Get(kubeapiserver.SecretStaticTokenName)
@@ -205,8 +218,8 @@ func (b *Botanist) populateStaticAdminTokenToAccessTokenSecret(ctx context.Conte
 
 // DeployOperatingSystemConfigWithStaticPods deploys and waits for the OperatingSystemConfig containing the files for the control
 // plane components running as static pods.
-func (b *Botanist) DeployOperatingSystemConfigWithStaticPods(ctx context.Context, useBootstrapEtcd bool, bootstrapEtcdBackupPath string) (*operatingsystemconfig.Data, string, error) {
-	pods, err := b.staticControlPlanePods(ctx, useBootstrapEtcd, bootstrapEtcdBackupPath)
+func (b *Botanist) DeployOperatingSystemConfigWithStaticPods(ctx context.Context, useBootstrapEtcd, useShootAccessTokens bool, bootstrapEtcdBackupPath string) (*operatingsystemconfig.Data, string, error) {
+	pods, err := b.staticControlPlanePods(ctx, useBootstrapEtcd, useShootAccessTokens, bootstrapEtcdBackupPath)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed computing files for static control plane pods: %w", err)
 	}
@@ -276,7 +289,7 @@ func (s staticPods) allFiles() []extensionsv1alpha1.File {
 	return files
 }
 
-func (b *Botanist) staticControlPlanePods(ctx context.Context, useBootstrapEtcd bool, bootstrapEtcdBackupPath string) (staticPods, error) {
+func (b *Botanist) staticControlPlanePods(ctx context.Context, useBootstrapEtcd, useShootAccessTokens bool, bootstrapEtcdBackupPath string) (staticPods, error) {
 	var pods staticPods
 
 	for _, component := range b.staticControlPlaneComponents(useBootstrapEtcd, bootstrapEtcdBackupPath) {
@@ -287,6 +300,21 @@ func (b *Botanist) staticControlPlanePods(ctx context.Context, useBootstrapEtcd 
 		files, _, err := staticpod.Translate(ctx, b.SeedClientSet.Client(), component.targetObject, component.mutate)
 		if err != nil {
 			return nil, fmt.Errorf("failed translating object of type %T for %q: %w", component.targetObject, component.name, err)
+		}
+
+		if useShootAccessTokens {
+			// During bootstrapping we populate a static admin token to the shoot access token secrets used as volumes
+			// in the control plane component deployments. Later on, after bootstrapping is done, we don't need this
+			// anymore and can let gardener-resource-manager auto-rotate the shoot access tokens.
+			// We use the token-sync mechanism in gardener-node-agent which reads these shoot access token secrets from
+			// the cluster and writes them directly to the disk. Hence, we don't need another file in the
+			// OperatingSystemConfig containing the shoot access token (which just gets stale after GRM auto-rotates
+			// it).
+			// "Unfortunately", the static pod translator naively returns a file for the shoot access token secret
+			// volume in the pod spec. We drop this file here before returning it and persisting it in the OSC.
+			files = slices.DeleteFunc(files, func(file extensionsv1alpha1.File) bool {
+				return file.Path == staticpod.FilePathForProjectedVolumeItem(component.name, "kubeconfig", resourcesv1alpha1.DataKeyToken)
+			})
 		}
 
 		pods = append(pods, staticPod{

--- a/pkg/gardenlet/operation/botanist/staticpods_test.go
+++ b/pkg/gardenlet/operation/botanist/staticpods_test.go
@@ -10,11 +10,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
@@ -166,6 +168,79 @@ var _ = Describe("StaticPods", func() {
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(node2), node2)).To(Succeed())
 			Expect(node2.Labels[v1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName]).To(Equal(oscSecretName2))
+		})
+	})
+
+	Describe("#useShootAccessTokensForSelfHostedShootControlPlane", func() {
+		var controlPlaneNamespace = "kube-system"
+
+		selfHostedShoot := func(gardenerName string) *gardencorev1beta1.Shoot {
+			return &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Provider: gardencorev1beta1.Provider{
+						Workers: []gardencorev1beta1.Worker{{
+							ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+						}},
+					},
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					Gardener: gardencorev1beta1.Gardener{Name: gardenerName},
+				},
+			}
+		}
+
+		BeforeEach(func() {
+			botanist.Shoot.ControlPlaneNamespace = controlPlaneNamespace
+		})
+
+		It("should return false for a non-self-hosted shoot", func() {
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
+
+			result, err := UseShootAccessTokensForSelfHostedShootControlPlane(botanist, ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false when the shoot status indicates gardenadm", func() {
+			botanist.Shoot.SetInfo(selfHostedShoot("gardenadm"))
+
+			result, err := UseShootAccessTokensForSelfHostedShootControlPlane(botanist, ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false when gardener-resource-manager deployment does not exist", func() {
+			botanist.Shoot.SetInfo(selfHostedShoot("gardenlet"))
+
+			result, err := UseShootAccessTokensForSelfHostedShootControlPlane(botanist, ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false when gardener-resource-manager runs with host network (bootstrap phase)", func() {
+			botanist.Shoot.SetInfo(selfHostedShoot("gardenlet"))
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager", Namespace: controlPlaneNamespace},
+				Spec:       appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{HostNetwork: true}}},
+			}
+			Expect(seedClient.Create(ctx, deployment)).To(Succeed())
+
+			result, err := UseShootAccessTokensForSelfHostedShootControlPlane(botanist, ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return true when gardener-resource-manager runs in the pod network", func() {
+			botanist.Shoot.SetInfo(selfHostedShoot("gardenlet"))
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager", Namespace: controlPlaneNamespace},
+				Spec:       appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{HostNetwork: false}}},
+			}
+			Expect(seedClient.Create(ctx, deployment)).To(Succeed())
+
+			result, err := UseShootAccessTokensForSelfHostedShootControlPlane(botanist, ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
 		})
 	})
 })

--- a/pkg/gardenlet/operation/shoot/types.go
+++ b/pkg/gardenlet/operation/shoot/types.go
@@ -128,6 +128,7 @@ type Components struct {
 	Extensions               *Extensions
 	SystemComponents         *SystemComponents
 	Addons                   *Addons
+	AdminAccess              component.Deployer
 	GardenerAccess           component.Deployer
 	DependencyWatchdogAccess component.Deployer
 	Bastion                  *bastion.Bastion

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -551,12 +551,21 @@ func (r *Reconciler) removeDeletedFiles(log logr.Logger, changes *operatingSyste
 		}
 
 		log.Info("Successfully removed no longer needed file", "path", file.Path)
+		r.triggerTokenResyncForDeletedFile(log, file.Path)
 		if err := changes.completedFileDeleted(file.Path); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (r *Reconciler) triggerTokenResyncForDeletedFile(log logr.Logger, path string) {
+	for _, config := range r.TokenSecretSyncConfigs {
+		if config.Path == path {
+			r.triggerTokenResync(log, config.SecretName)
+		}
+	}
 }
 
 func (r *Reconciler) applyChangedUnits(ctx context.Context, log logr.Logger, changes *operatingSystemConfigChanges) error {
@@ -916,12 +925,16 @@ func (r *Reconciler) completeKubeletInPlaceUpdate(ctx context.Context, log logr.
 	return nil
 }
 
+func (r *Reconciler) triggerTokenResync(log logr.Logger, secretName string) {
+	r.Channel <- event.TypedGenericEvent[*corev1.Secret]{Object: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: metav1.NamespaceSystem}}}
+	log.Info("Triggered an event for the token controller", "secret", secretName)
+}
+
 func (r *Reconciler) performCredentialsRotationInPlace(ctx context.Context, log logr.Logger, oscChanges *operatingSystemConfigChanges, node *corev1.Node) error {
 	if oscChanges.InPlaceUpdates.ServiceAccountKeyRotation {
 		// Generate events for the token sync controller to update the SA tokens.
-		for _, tokenSyncConfig := range r.TokenSecretSyncConfigs {
-			r.Channel <- event.TypedGenericEvent[*corev1.Secret]{Object: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: tokenSyncConfig.SecretName, Namespace: metav1.NamespaceSystem}}}
-			log.Info("Triggered an event for the token controller", "secret", tokenSyncConfig.SecretName)
+		for _, config := range r.TokenSecretSyncConfigs {
+			r.triggerTokenResync(log, config.SecretName)
 		}
 
 		if err := oscChanges.completeSAKeyRotation(); err != nil {

--- a/pkg/nodeagent/controller/token/reconciler.go
+++ b/pkg/nodeagent/controller/token/reconciler.go
@@ -62,7 +62,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	if !bytes.Equal(currentToken, token) {
 		log.Info("Access token differs from the one currently stored on the disk, updating it", "path", path)
 
-		if err := r.FS.WriteFile(path, token, 0600); err != nil {
+		if err := r.FS.WriteFile(path, token, 0640); err != nil {
 			return reconcile.Result{}, fmt.Errorf("unable to write access token to %s: %w", path, err)
 		}
 

--- a/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer.go
+++ b/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer.go
@@ -31,7 +31,9 @@ import (
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/nodeagent/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/kubernetes/adminaccess"
 	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // NewAuthorizer returns a new authorizer for requests from gardener-node-agents. It never has an opinion on the request.
@@ -292,7 +294,13 @@ func (a *authorizer) authorizeSecret(ctx context.Context, log logr.Logger, machi
 		return auth.DecisionDeny, reason, nil
 	}
 
-	validSecrets := []string{valitailTokenSecretName, openTelemetryCollectorTokenSecretName}
+	validSecrets := []string{
+		valitailTokenSecretName,
+		openTelemetryCollectorTokenSecretName,
+		gardenerutils.SecretNamePrefixShootAccess + v1beta1constants.DeploymentNameKubeControllerManager,
+		gardenerutils.SecretNamePrefixShootAccess + v1beta1constants.DeploymentNameKubeScheduler,
+		gardenerutils.SecretNamePrefixShootAccess + adminaccess.ShootAccessSecretNameSuffix,
+	}
 
 	if a.machineNamespace != nil {
 		machine := &machinev1alpha1.Machine{}

--- a/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer_test.go
+++ b/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer_test.go
@@ -646,7 +646,7 @@ var _ = Describe("Authorizer", func() {
 					ResourceRequest: true,
 					Verb:            verb,
 				}
-				secretNames := []string{machineSecretName, "gardener-valitail"}
+				secretNames := []string{machineSecretName, "gardener-valitail", "shoot-access-kube-controller-manager", "shoot-access-kube-scheduler", "shoot-access-cluster-admin"}
 
 				for _, secretName := range secretNames {
 					attrs.Name = secretName
@@ -677,7 +677,7 @@ var _ = Describe("Authorizer", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(decision).To(Equal(auth.DecisionDeny))
-				Expect(reason).To(Equal(fmt.Sprintf("gardener-node-agent can only access secrets [gardener-valitail gardener-opentelemetry-collector %s] in \"kube-system\" namespace", machineSecretName)))
+				Expect(reason).To(Equal(fmt.Sprintf("gardener-node-agent can only access secrets [gardener-valitail gardener-opentelemetry-collector shoot-access-kube-controller-manager shoot-access-kube-scheduler shoot-access-cluster-admin %s] in \"kube-system\" namespace", machineSecretName)))
 			},
 				Entry("get", "get"),
 				Entry("list", "list"),
@@ -694,7 +694,7 @@ var _ = Describe("Authorizer", func() {
 					ResourceRequest: true,
 					Verb:            verb,
 				}
-				secretNames := []string{machineSecretName, "gardener-valitail"}
+				secretNames := []string{machineSecretName, "gardener-valitail", "shoot-access-kube-controller-manager", "shoot-access-kube-scheduler", "shoot-access-cluster-admin"}
 
 				for _, secretName := range secretNames {
 					attrs.Name = secretName
@@ -702,7 +702,7 @@ var _ = Describe("Authorizer", func() {
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(decision).To(Equal(auth.DecisionDeny))
-					Expect(reason).To(Equal(fmt.Sprintf("gardener-node-agent can only access secrets [gardener-valitail gardener-opentelemetry-collector %s] in \"kube-system\" namespace", machineSecretName)))
+					Expect(reason).To(Equal(fmt.Sprintf("gardener-node-agent can only access secrets [gardener-valitail gardener-opentelemetry-collector shoot-access-kube-controller-manager shoot-access-kube-scheduler shoot-access-cluster-admin %s] in \"kube-system\" namespace", machineSecretName)))
 				}
 			},
 				Entry("get", "get"),

--- a/pkg/utils/secrets/manager/fake/fake_manager.go
+++ b/pkg/utils/secrets/manager/fake/fake_manager.go
@@ -35,6 +35,10 @@ func New(client client.Client, namespace string) *fakeManager {
 	}
 }
 
+func (m *fakeManager) Identity() string {
+	return ManagerIdentity
+}
+
 func (m *fakeManager) Get(name string, opts ...secretsmanager.GetOption) (*corev1.Secret, bool) {
 	options := &secretsmanager.GetOptions{}
 	options.ApplyOptions(opts)

--- a/pkg/utils/secrets/manager/interface.go
+++ b/pkg/utils/secrets/manager/interface.go
@@ -29,6 +29,10 @@ type Interface interface {
 
 	Reader
 
+	// Identity returns the identity of this secrets manager instance. The identity is used as value for the
+	// LabelKeyManagerIdentity label on all managed secrets.
+	Identity() string
+
 	// Cleanup deletes no longer required secrets. No longer required secrets are those still existing in the system
 	// which weren't detected by prior Generate calls. Consequently, only call Cleanup after you have executed Generate
 	// calls for all desired secrets.

--- a/pkg/utils/secrets/manager/manager.go
+++ b/pkg/utils/secrets/manager/manager.go
@@ -144,6 +144,10 @@ func WithoutAutomaticSecretRenewal() NewOption {
 
 var _ Interface = &manager{}
 
+func (m *manager) Identity() string {
+	return m.identity
+}
+
 type secretClass string
 
 const (

--- a/pkg/utils/secrets/manager/manager_test.go
+++ b/pkg/utils/secrets/manager/manager_test.go
@@ -328,6 +328,14 @@ var _ = Describe("Manager", func() {
 				Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"secret1": "-100"}))
 			})
 		})
+
+		Describe("#Identity", func() {
+			It("should return the identity the manager was created with", func() {
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, WithNamespaces(namespace))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mgr.Identity()).To(Equal(identity))
+			})
+		})
 	})
 
 	Describe("#ObjectMeta", func() {

--- a/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
@@ -22,9 +22,12 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
@@ -38,7 +41,9 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/nodeagent"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	e2egardener "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/utils/access"
@@ -199,7 +204,28 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 			var (
 				gardenKomega                         Komega
 				gardenClusterKubeconfigPathOnMachine = "/tmp/virtual-garden-kubeconfig"
+
+				clusterAdminStaticToken string
 			)
+
+			It("should create a client for the self-hosted shoot API server", func(ctx SpecContext) {
+				initShootClientSet(ctx)
+			}, SpecTimeout(time.Minute))
+
+			It("should store the cluster-admin static token for later assertions", func(ctx SpecContext) {
+				secret, err := kubernetesutils.NewestObject(ctx, shootClientSet.Client(), &corev1.SecretList{}, nil, client.InNamespace(controlPlaneNamespace), client.MatchingLabels{
+					"managed-by": "secrets-manager",
+					"name":       "kube-apiserver-static-token",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(secret).NotTo(BeNil())
+
+				staticToken, err := secretsutils.LoadStaticTokenFromCSV("kube-apiserver-static-token", secret.(*corev1.Secret).Data[secretsutils.DataKeyStaticTokenCSV])
+				Expect(err).NotTo(HaveOccurred())
+				token, err := staticToken.GetTokenForUsername("system:cluster-admin")
+				Expect(err).NotTo(HaveOccurred())
+				clusterAdminStaticToken = token.Token
+			}, SpecTimeout(time.Minute))
 
 			It("should create a client for garden cluster", func(ctx SpecContext) {
 				initGardenClientSet(ctx)
@@ -310,8 +336,7 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 			Context("shoot gardenlet reconciles self-hosted shoot", func() {
 				var s *e2egardener.ShootContext
 
-				BeforeAll(func(ctx SpecContext) {
-					initShootClientSet(ctx)
+				BeforeAll(func() {
 					s = (&e2egardener.TestContext{
 						GardenClientSet: gardenClientSet,
 						GardenClient:    gardenClientSet.Client(),
@@ -349,6 +374,57 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 					By("Verifying ShootTaskUpdateGardenerNodeAgentSecretName task annotation has been removed")
 					Expect(controllerutils.HasTask(s.Shoot.Annotations, v1beta1constants.ShootTaskUpdateGardenerNodeAgentSecretName)).To(BeFalse())
 				}, SpecTimeout(30*time.Minute))
+
+				It("should ensure the static token secret only contains the health-check token (cluster-admin token eliminated)", func(ctx SpecContext) {
+					newestSecret, err := kubernetesutils.NewestObject(ctx, shootClientSet.Client(), &corev1.SecretList{}, nil, client.InNamespace(controlPlaneNamespace), client.MatchingLabels{
+						"managed-by": "secrets-manager",
+						"name":       "kube-apiserver-static-token",
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(newestSecret).NotTo(BeNil())
+
+					secret := newestSecret.(*corev1.Secret)
+					staticToken, err := secretsutils.LoadStaticTokenFromCSV("kube-apiserver-static-token", secret.Data[secretsutils.DataKeyStaticTokenCSV])
+					Expect(err).NotTo(HaveOccurred())
+					Expect(staticToken.Tokens).To(HaveLen(1))
+					Expect(staticToken.Tokens[0].Username).To(Equal("health-check"))
+
+					By("Verifying kube-apiserver no longer trusts the old cluster-admin static token")
+					unauthenticatedClient, err := client.New(&rest.Config{
+						Host:            shootClientSet.RESTConfig().Host,
+						TLSClientConfig: rest.TLSClientConfig{CAData: shootClientSet.RESTConfig().CAData},
+						BearerToken:     clusterAdminStaticToken,
+					}, client.Options{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(unauthenticatedClient.List(ctx, &corev1.NamespaceList{})).To(MatchError(apierrors.IsUnauthorized, "IsUnauthorized"))
+				}, SpecTimeout(time.Minute))
+
+				It("should ensure the new admin kubeconfig uses a dynamic token and the token files contain JWTs", func(ctx SpecContext) {
+					By("Verifying /etc/kubernetes/admin.conf uses tokenFile instead of an inline token")
+					stdOut, _, err := execute(ctx, 0, "cat", "/etc/kubernetes/admin.conf")
+					Expect(err).NotTo(HaveOccurred())
+
+					adminKubeconfig, err := clientcmd.Load(stdOut.Contents())
+					Expect(err).NotTo(HaveOccurred())
+					Expect(adminKubeconfig.AuthInfos).To(HaveLen(1))
+					for _, authInfo := range adminKubeconfig.AuthInfos {
+						Expect(authInfo.Token).To(BeEmpty(), "admin.conf should not contain an inline token")
+						Expect(authInfo.TokenFile).To(Equal("/etc/kubernetes/admin-token"))
+					}
+
+					By("Verifying /etc/kubernetes/admin-token contains a JWT")
+					stdOut, _, err = execute(ctx, 0, "cat", "/etc/kubernetes/admin-token")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(strings.Split(strings.TrimSpace(string(stdOut.Contents())), ".")).To(HaveLen(3), "admin-token should be a JWT (3 dot-separated parts)")
+
+					for _, component := range []string{"kube-controller-manager", "kube-scheduler"} {
+						By("Verifying " + component + " token file contains a JWT")
+						tokenPath := "/var/lib/static-pods/" + component + "/kubeconfig/token"
+						stdOut, _, err = execute(ctx, 0, "cat", tokenPath)
+						Expect(err).NotTo(HaveOccurred(), "failed to read token file for %s", component)
+						Expect(strings.Split(strings.TrimSpace(string(stdOut.Contents())), ".")).To(HaveLen(3), "%s token should be a JWT (3 dot-separated parts)", component)
+					}
+				}, SpecTimeout(time.Minute))
 
 				It("should ensure node labels and gardener-node-agent config reflect the correct OSC secret name", func(ctx SpecContext) {
 					By("Build map of worker pool -> newest original OSC name (the newest OSC is the one desired by gardenlet)")

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -159,7 +159,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			Expect(testClient.Delete(ctx, node)).To(Succeed())
 		})
 
-		channel = make(chan event.TypedGenericEvent[*corev1.Secret])
+		channel = make(chan event.TypedGenericEvent[*corev1.Secret], 10)
 		secretName1 = "test-secret-1"
 		secretName2 = "test-secret-2"
 
@@ -178,8 +178,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			Extractor: fakeregistry.NewExtractor(fakeFS, imageMountDirectory),
 			Channel:   channel,
 			TokenSecretSyncConfigs: []nodeagentconfigv1alpha1.TokenSecretSyncConfig{
-				{SecretName: secretName1},
-				{SecretName: secretName2},
+				{SecretName: secretName1, Path: "/another/file"},
+				{SecretName: secretName2, Path: "/no/such/file"},
 			},
 			CancelContext:    cancelFunc.cancel,
 			ContainerdClient: fakecontainerdclient.NewClient(),
@@ -711,6 +711,38 @@ units: {}
 
 		By("Assert that cancel func has not been called")
 		Expect(cancelFunc.called).To(BeFalse())
+	})
+
+	It("should trigger token resync for configs whose path matches a deleted file", func() {
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
+		waitForUpdatedNodeLabelKubernetesVersion(node, kubernetesVersion.String())
+
+		// Drain any events from the initial reconciliation.
+		for len(channel) > 0 {
+			<-channel
+		}
+
+		By("Update Operating System Config, removing file2 (/another/file)")
+		operatingSystemConfig.Status.ExtensionFiles = []extensionsv1alpha1.File{file4, file6, file7}
+
+		var err error
+		oscRaw, err = runtime.Encode(codec, operatingSystemConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Update Secret containing the operating system config")
+		patch := client.MergeFrom(oscSecret.DeepCopy())
+		oscSecret.Annotations["checksum/data-script"] = utils.ComputeSHA256Hex(oscRaw)
+		oscSecret.Data["osc.yaml"] = oscRaw
+		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
+
+		waitForUpdatedNodeAnnotationCloudConfig(node, oscSecret, utils.ComputeSHA256Hex(oscRaw))
+
+		By("Assert that only the token sync config whose path matches the deleted file received an event")
+		var received event.TypedGenericEvent[*corev1.Secret]
+		Eventually(channel).Should(Receive(&received))
+		Expect(received.Object.GetName()).To(Equal(secretName1))
+		Expect(received.Object.GetNamespace()).To(Equal("kube-system"))
+		Consistently(channel).ShouldNot(Receive())
 	})
 
 	It("should reconcile the configuration when the containerd registries change", func() {

--- a/test/integration/nodeagent/token/token_test.go
+++ b/test/integration/nodeagent/token/token_test.go
@@ -6,6 +6,7 @@ package token_test
 
 import (
 	"context"
+	"os"
 	"strings"
 	"time"
 
@@ -126,6 +127,18 @@ var _ = Describe("Token controller tests", func() {
 				token2OnDisk, err := afero.ReadFile(testFS, path2)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(token2OnDisk).To(Equal(accessToken2))
+			}).Should(Succeed())
+		})
+
+		It("should write the token files with 0640 permissions", func() {
+			Eventually(func(g Gomega) {
+				info1, err := testFS.Stat(path1)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(info1.Mode().Perm()).To(Equal(os.FileMode(0640)))
+
+				info2, err := testFS.Stat(path2)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(info2.Mode().Perm()).To(Equal(os.FileMode(0640)))
 			}).Should(Succeed())
 		})
 


### PR DESCRIPTION
> [!IMPORTANT]
> ✅ This pull request is based on #15502 which must be merged first. This PR remains in draft state until then.

**How to categorize this PR?**

/area os
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
During `gardenadm init`, a static admin token is written to the host filesystem for control plane components to authenticate — at this point, `gardener-resource-manager` is not yet running, so there is no runtime to manage auto-rotated tokens. Once gardenlet takes over shoot reconciliation (detected via `.status.gardener.name`), this static token must be eliminated and replaced with auto-rotated shoot access secrets managed by `gardener-resource-manager`.

This PR introduces a flow in gardenlet's shoot reconciliation that adds `TokenSecretSyncConfig` entries to the `gardener-node-agent` component config, causing GNA's existing token controller to sync shoot access secrets to disk as host files. It also disables the static token file and removes the stale token files previously injected by the static pod translator. Additionally, a new `adminaccess` component provides an auto-rotated admin kubeconfig on control plane nodes for post-reconciliation `gardenadm` invocations. A race fix ensures that when a file moves from the OSC spec into a `TokenSecretSyncConfig`, the token controller re-syncs immediately rather than racing with the OSC reconciler's deletion.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
The node-agent-authorizer allows reading the new access secrets unconditionally — they only exist for self-hosted shoots (for hosted shoots, they reside in the seed's control plane namespace, out of reach for `gardener-node-agent`).

File permissions for synced token files are `0640` (not `0600`) because static pods run with `FSGroup=0`, making group-readable files accessible via the supplemental group, while owner-only files would not be.

**Release note**:
```other developer
NONE
```