### PR TITLE
Collect metric for established TCP connections

### DIFF
--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
@@ -112,6 +112,7 @@ func (n *nodeExporter) Deploy(ctx context.Context) error {
 			"node_scrape_collector_success",
 			"process_max_fds",
 			"process_open_fds",
+			"node_netstat_Tcp_CurrEstab",
 		)
 		return nil
 	}); err != nil {
@@ -387,6 +388,7 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 									"--collector.filesystem.mount-points-exclude=^/(run|var)/.+$|^/(boot|dev|sys|usr)($|/.+$)",
 									"--collector.loadavg",
 									"--collector.meminfo",
+									"--collector.netstat",
 									"--collector.uname",
 									"--collector.stat",
 									"--collector.pressure",

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
@@ -112,7 +112,7 @@ var _ = Describe("NodeExporter", func() {
 				MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
 					SourceLabels: []monitoringv1.LabelName{"__name__"},
 					Action:       "keep",
-					Regex:        `^(node_boot_time_seconds|node_cpu_seconds_total|node_disk_read_bytes_total|node_disk_written_bytes_total|node_disk_io_time_weighted_seconds_total|node_disk_io_time_seconds_total|node_disk_write_time_seconds_total|node_disk_writes_completed_total|node_disk_read_time_seconds_total|node_disk_reads_completed_total|node_filesystem_avail_bytes|node_filesystem_files|node_filesystem_files_free|node_filesystem_free_bytes|node_filesystem_readonly|node_filesystem_size_bytes|node_load1|node_load15|node_load5|node_memory_.+|node_nf_conntrack_.+|node_scrape_collector_duration_seconds|node_scrape_collector_success|process_max_fds|process_open_fds)$`,
+					Regex:        `^(node_boot_time_seconds|node_cpu_seconds_total|node_disk_read_bytes_total|node_disk_written_bytes_total|node_disk_io_time_weighted_seconds_total|node_disk_io_time_seconds_total|node_disk_write_time_seconds_total|node_disk_writes_completed_total|node_disk_read_time_seconds_total|node_disk_reads_completed_total|node_filesystem_avail_bytes|node_filesystem_files|node_filesystem_files_free|node_filesystem_free_bytes|node_filesystem_readonly|node_filesystem_size_bytes|node_load1|node_load15|node_load5|node_memory_.+|node_nf_conntrack_.+|node_scrape_collector_duration_seconds|node_scrape_collector_success|process_max_fds|process_open_fds|node_netstat_Tcp_CurrEstab)$`,
 				}},
 			},
 		}
@@ -336,6 +336,7 @@ spec:
         - --collector.filesystem.mount-points-exclude=^/(run|var)/.+$|^/(boot|dev|sys|usr)($|/.+$)
         - --collector.loadavg
         - --collector.meminfo
+        - --collector.netstat
         - --collector.uname
         - --collector.stat
         - --collector.pressure


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Network functions on the underlying cloud infrastructures might have limits for the established TCP connections. This PR enables TCP connection tracking by adding the netstat collector and including the node_netstat_Tcp_CurrEstab metric in the monitoring stack to ease debugging when hitting such a limitation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vicwicker @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The metric for established TCP connections is now collected in the shoot observability stack.
```
