### PR TITLE
Update opentelemetry-operator to v0.158.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
-	github.com/open-telemetry/opentelemetry-operator/apis v0.156.0
+	github.com/open-telemetry/opentelemetry-operator/apis v0.158.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml v1.9.5
 	github.com/perses/perses-operator v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -621,8 +621,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.42.1 h1:iN1rCUX+44NZ1Dc97MPoeFYbFR0vh8zxoxMFwKdyZ6I=
 github.com/onsi/gomega v1.42.1/go.mod h1:REff/hsDsodHoKlWsP2mAPhu1+5/6hVYNf9rIEBpeSg=
-github.com/open-telemetry/opentelemetry-operator/apis v0.156.0 h1:DqoeCNW/s2OC5JspEwViLPGGQh9F0R3uFfw2KnvGlIQ=
-github.com/open-telemetry/opentelemetry-operator/apis v0.156.0/go.mod h1:zZwFm4H4qsZwkyGIWU/anvMYnQUnmSRjh0P0gT9hLtE=
+github.com/open-telemetry/opentelemetry-operator/apis v0.158.0 h1:8OZliZvvroBWO0XoH4TRGG1hEQAxSReza2WaxHKydhs=
+github.com/open-telemetry/opentelemetry-operator/apis v0.158.0/go.mod h1:4p95F2c41NbILsORGK9oE5Pufmp5b1uA0szR2ELzWKc=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -176,7 +176,7 @@ images:
   - name: opentelemetry-operator
     sourceRepository: github.com/open-telemetry/opentelemetry-operator
     repository: europe-docker.pkg.dev/gardener-project/releases/3rd/opentelemetry-operator/opentelemetry-operator
-    tag: "v0.156.0"
+    tag: "v0.158.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -401,6 +401,9 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 					DisablePrometheusAnnotations: true,
 				},
 			},
+			NetworkPolicy: otelv1beta1.NetworkPolicy{
+				Enabled: new(false),
+			},
 			OpenTelemetryCommonFields: otelv1beta1.OpenTelemetryCommonFields{
 				Image:             o.values.Image,
 				Replicas:          new(o.values.Replicas),

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -290,6 +290,9 @@ var _ = Describe("OpenTelemetry Collector", func() {
 						DisablePrometheusAnnotations: true,
 					},
 				},
+				NetworkPolicy: otelv1beta1.NetworkPolicy{
+					Enabled: new(false),
+				},
 				Mode:            "deployment",
 				UpgradeStrategy: "none",
 				OpenTelemetryCommonFields: otelv1beta1.OpenTelemetryCommonFields{

--- a/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_opentelemetrycollectors.yaml
+++ b/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_opentelemetrycollectors.yaml
@@ -6052,6 +6052,29 @@ spec:
                   If not specified, it will default to "<name>-headless".
                   Note that the custom service name is not created by the operator.
                 type: string
+              sessionAffinity:
+                description: |-
+                  SessionAffinity specifies the session affinity type for the Service.
+                  This is only applicable to Service resources.
+                type: string
+              sessionAffinityConfig:
+                description: |-
+                  SessionAffinityConfig specifies the session affinity configurations for the Service.
+                  This is only applicable to Service resources.
+                properties:
+                  clientIP:
+                    description: clientIP contains the configurations of Client IP
+                      based session affinity.
+                    properties:
+                      timeoutSeconds:
+                        description: |-
+                          timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                          The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                          Default value is 10800(for 3 hours).
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
               shareProcessNamespace:
                 description: ShareProcessNamespace indicates if the pod's containers
                   should share process namespace.
@@ -7256,6 +7279,140 @@ spec:
                         description: Enabled indicates whether to enable mTLS between
                           the target allocator and the collector.
                         type: boolean
+                      tls:
+                        description: |-
+                          TLS references user-provided certificates used for mTLS. It allows managing
+                          the certificates outside of the operator (e.g. without cert-manager) and
+                          is only consulted when UseCertManager is set to false.
+                        properties:
+                          certificateAuthorityCertificate:
+                            description: |-
+                              CertificateAuthorityCertificate references the CA certificate used to verify the peer's
+                              certificate. Exactly one of secret or configMap must be set. It is required when
+                              UseCertManager is false.
+                            properties:
+                              configMap:
+                                description: ConfigMap sources the CA certificate
+                                  from a ConfigMap.
+                                properties:
+                                  key:
+                                    default: ca.crt
+                                    description: Key within the ConfigMap's data.
+                                      Defaults to ca.crt when omitted.
+                                    type: string
+                                  name:
+                                    description: Name of the ConfigMap, in the same
+                                      namespace as the workload.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              secret:
+                                description: Secret sources the CA certificate from
+                                  a Secret.
+                                properties:
+                                  key:
+                                    description: |-
+                                      Key within the Secret's data. When omitted, a role-specific default is applied: tls.crt for a
+                                      certificate, tls.key for a private key.
+                                    type: string
+                                  name:
+                                    description: Name of the Secret, in the same namespace
+                                      as the workload.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            type: object
+                          clientCertificate:
+                            description: |-
+                              ClientCertificate references the client certificate and key used by the collector when talking
+                              to the target allocator's HTTPS server.
+                            properties:
+                              certificateSecret:
+                                description: CertificateSecret selects the certificate.
+                                  Its key defaults to tls.crt.
+                                properties:
+                                  key:
+                                    description: |-
+                                      Key within the Secret's data. When omitted, a role-specific default is applied: tls.crt for a
+                                      certificate, tls.key for a private key.
+                                    type: string
+                                  name:
+                                    description: Name of the Secret, in the same namespace
+                                      as the workload.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              keySecret:
+                                description: KeySecret selects the private key. Its
+                                  key defaults to tls.key.
+                                properties:
+                                  key:
+                                    description: |-
+                                      Key within the Secret's data. When omitted, a role-specific default is applied: tls.crt for a
+                                      certificate, tls.key for a private key.
+                                    type: string
+                                  name:
+                                    description: Name of the Secret, in the same namespace
+                                      as the workload.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - certificateSecret
+                            - keySecret
+                            type: object
+                          serverCertificate:
+                            description: |-
+                              ServerCertificate references the server certificate and key used by the target allocator when
+                              exposing its HTTPS server.
+                            properties:
+                              certificateSecret:
+                                description: CertificateSecret selects the certificate.
+                                  Its key defaults to tls.crt.
+                                properties:
+                                  key:
+                                    description: |-
+                                      Key within the Secret's data. When omitted, a role-specific default is applied: tls.crt for a
+                                      certificate, tls.key for a private key.
+                                    type: string
+                                  name:
+                                    description: Name of the Secret, in the same namespace
+                                      as the workload.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              keySecret:
+                                description: KeySecret selects the private key. Its
+                                  key defaults to tls.key.
+                                properties:
+                                  key:
+                                    description: |-
+                                      Key within the Secret's data. When omitted, a role-specific default is applied: tls.crt for a
+                                      certificate, tls.key for a private key.
+                                    type: string
+                                  name:
+                                    description: Name of the Secret, in the same namespace
+                                      as the workload.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - certificateSecret
+                            - keySecret
+                            type: object
+                        type: object
                       useCertManager:
                         default: true
                         description: |-
@@ -8038,8 +8195,8 @@ spec:
                   replicas:
                     description: |-
                       Replicas is the number of pod instances for the underlying TargetAllocator. This should only be set to a value
-                      other than 1 if a strategy that allows for high availability is chosen. Currently, the only allocation strategy
-                      that can be run in a high availability mode is consistent-hashing.
+                      other than 1 if a strategy that allows for high availability is chosen. Currently, the allocation strategies
+                      that can be run in a high availability mode are consistent-hashing and per-node.
                     format: int32
                     type: integer
                   resources:

--- a/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_targetallocators.yaml
+++ b/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_targetallocators.yaml
@@ -4729,6 +4729,140 @@ spec:
                     description: Enabled indicates whether to enable mTLS between
                       the target allocator and the collector.
                     type: boolean
+                  tls:
+                    description: |-
+                      TLS references user-provided certificates used for mTLS. It allows managing
+                      the certificates outside of the operator (e.g. without cert-manager) and
+                      is only consulted when UseCertManager is set to false.
+                    properties:
+                      certificateAuthorityCertificate:
+                        description: |-
+                          CertificateAuthorityCertificate references the CA certificate used to verify the peer's
+                          certificate. Exactly one of secret or configMap must be set. It is required when
+                          UseCertManager is false.
+                        properties:
+                          configMap:
+                            description: ConfigMap sources the CA certificate from
+                              a ConfigMap.
+                            properties:
+                              key:
+                                default: ca.crt
+                                description: Key within the ConfigMap's data. Defaults
+                                  to ca.crt when omitted.
+                                type: string
+                              name:
+                                description: Name of the ConfigMap, in the same namespace
+                                  as the workload.
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          secret:
+                            description: Secret sources the CA certificate from a
+                              Secret.
+                            properties:
+                              key:
+                                description: |-
+                                  Key within the Secret's data. When omitted, a role-specific default is applied: tls.crt for a
+                                  certificate, tls.key for a private key.
+                                type: string
+                              name:
+                                description: Name of the Secret, in the same namespace
+                                  as the workload.
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      clientCertificate:
+                        description: |-
+                          ClientCertificate references the client certificate and key used by the collector when talking
+                          to the target allocator's HTTPS server.
+                        properties:
+                          certificateSecret:
+                            description: CertificateSecret selects the certificate.
+                              Its key defaults to tls.crt.
+                            properties:
+                              key:
+                                description: |-
+                                  Key within the Secret's data. When omitted, a role-specific default is applied: tls.crt for a
+                                  certificate, tls.key for a private key.
+                                type: string
+                              name:
+                                description: Name of the Secret, in the same namespace
+                                  as the workload.
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          keySecret:
+                            description: KeySecret selects the private key. Its key
+                              defaults to tls.key.
+                            properties:
+                              key:
+                                description: |-
+                                  Key within the Secret's data. When omitted, a role-specific default is applied: tls.crt for a
+                                  certificate, tls.key for a private key.
+                                type: string
+                              name:
+                                description: Name of the Secret, in the same namespace
+                                  as the workload.
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - certificateSecret
+                        - keySecret
+                        type: object
+                      serverCertificate:
+                        description: |-
+                          ServerCertificate references the server certificate and key used by the target allocator when
+                          exposing its HTTPS server.
+                        properties:
+                          certificateSecret:
+                            description: CertificateSecret selects the certificate.
+                              Its key defaults to tls.crt.
+                            properties:
+                              key:
+                                description: |-
+                                  Key within the Secret's data. When omitted, a role-specific default is applied: tls.crt for a
+                                  certificate, tls.key for a private key.
+                                type: string
+                              name:
+                                description: Name of the Secret, in the same namespace
+                                  as the workload.
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          keySecret:
+                            description: KeySecret selects the private key. Its key
+                              defaults to tls.key.
+                            properties:
+                              key:
+                                description: |-
+                                  Key within the Secret's data. When omitted, a role-specific default is applied: tls.crt for a
+                                  certificate, tls.key for a private key.
+                                type: string
+                              name:
+                                description: Name of the Secret, in the same namespace
+                                  as the workload.
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - certificateSecret
+                        - keySecret
+                        type: object
+                    type: object
                   useCertManager:
                     default: true
                     description: |-
@@ -6091,6 +6225,29 @@ spec:
                   ServiceAccount indicates the name of an existing service account to use with this instance. When set,
                   the operator will not automatically Create a ServiceAccount.
                 type: string
+              sessionAffinity:
+                description: |-
+                  SessionAffinity specifies the session affinity type for the Service.
+                  This is only applicable to Service resources.
+                type: string
+              sessionAffinityConfig:
+                description: |-
+                  SessionAffinityConfig specifies the session affinity configurations for the Service.
+                  This is only applicable to Service resources.
+                properties:
+                  clientIP:
+                    description: clientIP contains the configurations of Client IP
+                      based session affinity.
+                    properties:
+                      timeoutSeconds:
+                        description: |-
+                          timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                          The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                          Default value is 10800(for 3 hours).
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
               shareProcessNamespace:
                 description: ShareProcessNamespace indicates if the pod's containers
                   should share process namespace.

--- a/pkg/component/observability/opentelemetry/operator/operator.go
+++ b/pkg/component/observability/opentelemetry/operator/operator.go
@@ -334,6 +334,7 @@ func (o *openTelemetryOperator) deployment() *appsv1.Deployment {
 								"--enable-leader-election",
 								"--zap-log-level=info",
 								"--zap-time-encoding=rfc3339nano",
+								"--feature-gates=-operator.networkpolicy",
 							},
 							Env: []corev1.EnvVar{
 								{

--- a/pkg/component/observability/opentelemetry/operator/operator_test.go
+++ b/pkg/component/observability/opentelemetry/operator/operator_test.go
@@ -262,6 +262,7 @@ var _ = Describe("OpenTelemetry Operator", func() {
 									"--enable-leader-election",
 									"--zap-log-level=info",
 									"--zap-time-encoding=rfc3339nano",
+									"--feature-gates=-operator.networkpolicy",
 								},
 								Env: []corev1.EnvVar{
 									{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind cleanup

**What this PR does / why we need it**:
Extends the changes introduced by the robot in https://github.com/gardener/gardener/pull/15496 to adapt the codebase to the breaking changes introduced in OpenTelemetry Operator v0.158.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
