### PR TITLE
Create alert for consistent NWPD-detected network issues on seeds

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
@@ -45,6 +45,10 @@ func init() {
 func CentralPrometheusRules(seedIsGarden bool) []*monitoringv1.PrometheusRule {
 	rules := []monitoringv1.Rule{
 		{
+			Record: "seed:nwpd_aggregated_observations_failing:count",
+			Expr:   intstr.FromString(`count(rate(nwpd_aggregated_observations{status="failed", jobid=~"tcp-[np]2[np]"}[5m]) > 0)`),
+		},
+		{
 			Alert: "PodStuckInPending",
 			Expr:  intstr.FromString(`sum_over_time(kube_pod_status_phase{phase="Pending"}[5m]) > 0`),
 			For:   new(monitoringv1.Duration("10m")),

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -19,6 +19,10 @@ var _ = ginkgo.Describe("PrometheusRules", func() {
 	ginkgo.Describe("#CentralPrometheusRules", func() {
 		rules := []monitoringv1.Rule{
 			{
+				Record: "seed:nwpd_aggregated_observations_failing:count",
+				Expr:   intstr.FromString(`count(rate(nwpd_aggregated_observations{status="failed", jobid=~"tcp-[np]2[np]"}[5m]) > 0)`),
+			},
+			{
 				Alert: "PodStuckInPending",
 				Expr:  intstr.FromString(`sum_over_time(kube_pod_status_phase{phase="Pending"}[5m]) > 0`),
 				For:   new(monitoringv1.Duration("10m")),

--- a/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
@@ -38,6 +38,7 @@ func CentralServiceMonitors() []*monitoringv1.ServiceMonitor {
 							`{__name__="kubeproxy_sync_proxy:quantile"}`,
 							`{__name__="kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu",container="kube-apiserver"}`,
 							`{__name__="container_cpu_usage_seconds_total",container="kube-apiserver"}`,
+							`{__name__="nwpd_aggregated_observations"}`,
 						},
 					},
 					Port: prometheus.ServicePorts().Web.Name,

--- a/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors_test.go
@@ -39,6 +39,7 @@ var _ = Describe("ServiceMonitors", func() {
 								`{__name__="kubeproxy_sync_proxy:quantile"}`,
 								`{__name__="kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_cpu",container="kube-apiserver"}`,
 								`{__name__="container_cpu_usage_seconds_total",container="kube-apiserver"}`,
+								`{__name__="nwpd_aggregated_observations"}`,
 							},
 						},
 						Port: "web",

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -385,3 +385,17 @@ spec:
           The seed {{$labels.name}} in {{$externalLabels.landscape}} has
           been in an Error state for its Reconcile operation for more than
           30 minutes. Gardenlet will keep retrying.
+
+    - alert: NWPDTCPConnectivityFailure
+      expr: |
+        seed:nwpd_aggregated_observations_failing:count > 2
+      for: 30m
+      labels:
+        severity: critical
+        topology: seed
+      annotations:
+        summary: "Nodes with persistent TCP connectivity failure for 30+ minutes"
+        description: >-
+          Seed {{$labels.seed}} in {{$externalLabels.landscape}} has more than 2 nodes
+          experiencing TCP connectivity failures between pods and nodes for over 30 minutes.
+          To identify affected nodes: count by (src) (rate(nwpd_aggregated_observations{status="failed", jobid=~"tcp-[np]2[np]"}[5m]) > 0)

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
@@ -213,3 +213,35 @@ tests:
 
 
               ALERTS{alertname="VerticalPodAutoscalerCappedRecommendation", type="seed"}
+
+  - name: NWPDTCPConnectivityFailure:fires
+    interval: 1m
+    input_series:
+      - series: 'seed:nwpd_aggregated_observations_failing:count{seed="seed-a"}'
+        values: "3x35"
+    external_labels:
+      landscape: landscape-unit-tests
+    alert_rule_test:
+      - alertname: NWPDTCPConnectivityFailure
+        eval_time: 31m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              topology: seed
+              seed: seed-a
+            exp_annotations:
+              summary: "Nodes with persistent TCP connectivity failure for 30+ minutes"
+              description: >-
+                Seed seed-a in landscape-unit-tests has more than 2 nodes
+                experiencing TCP connectivity failures between pods and nodes for over 30 minutes.
+                To identify affected nodes: count by (src) (rate(nwpd_aggregated_observations{status="failed", jobid=~"tcp-[np]2[np]"}[5m]) > 0)
+
+  - name: NWPDTCPConnectivityFailure:does_not_fire_with_two_nodes
+    interval: 1m
+    input_series:
+      - series: 'seed:nwpd_aggregated_observations_failing:count{seed="seed-a"}'
+        values: "2x35"
+    alert_rule_test:
+      - alertname: NWPDTCPConnectivityFailure
+        eval_time: 35m
+        exp_alerts: []


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Add an alert when NWPD consistently detects network issues on seeds in order to be proactively notified and able to investigate and potentially remediate seed network problems ASAP. 
We can improve the speed at which we detect network issues affecting seed nodes. Earlier detection enables faster investigation and remediation, reducing the impact on dependent services and improving overall system reliability.

What has been added to this pr:
- Added `nwpd_aggregated_observations` to the match[] federation params so the metric is pulled from each shoot prometheus into the aggregate prometheus.
- Added a recording rule that pre-aggregates per-seed failing node count
- Added alert NWPDTCPConnectivityFailure:
```
Expression: seed:nwpd_aggregated_observations_failing:count > 2
For: 30m
Severity: critical / topology: seed
Routing: automatically routed to VictorOps (matches severity=~"critical") and kubernetes-ops Slack/email (matches severity="critical" + topology=~"garden|seed")
```
- Added related unit test

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
