### PR TITLE
Avoid billable GitHub Actions runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
       id-token: write
 
   tests:
-    runs-on: ${{ github.repository_owner == 'gardener' && 'ubuntu-latest-large' || 'ubuntu-latest' }}
+    runs-on: 'ubuntu-latest'
     if: github.event_name != 'pull_request'
     steps:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area cost
/kind enhancement

**What this PR does / why we need it**:

Soon™️, the [gardener](https://github.com/gardener) org will be transferred to the [NeoNephos Foundation](https://github.com/neonephos). With the new ownership, there'll be a monthly cap on billable usage. Today, the only billable usage that the org produces comes from paid GitHub Actions runners. Naturally, as the largest repository, it bears the largest share of these costs because it uses `ubuntu-latest-large`.

ℹ️ `ubuntu-latest-large` is configured with 16 CPUs and 64 GB of memory. `ubuntu-latest` has 4 CPUs and 16 GB of memory ([ref](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories)). Since we continue to run all of our tests on Prow, the runner "only" has to execute `make verify-extended`. This _might_ be a bit slower than before, but should not be a drastic disadvantage.

We could also experiment with running this on the free ARM runner to see whether that's faster.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

Similar to: https://github.com/gardener/gardener-landscape-kit/pull/500

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
