### PR TITLE
Add `status` documentation for developers

### DIFF
--- a/charts/gardener/operator/files/crd-extensions.yaml
+++ b/charts/gardener/operator/files/crd-extensions.yaml
@@ -463,10 +463,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of an Extension's current state.
+                  of an Extension's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/charts/gardener/operator/files/crd-gardens.yaml
+++ b/charts/gardener/operator/files/crd-gardens.yaml
@@ -2110,10 +2110,10 @@ spec:
                   type: object
                 type: array
               conditions:
-                description: Conditions is a list of conditions.
+                description: Conditions is a list of conditions based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition
@@ -2158,7 +2158,7 @@ spec:
                   state that constraint some operations on it.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/docs/README.md
+++ b/docs/README.md
@@ -141,6 +141,7 @@
 * [Validation Guidelines](development/validation-guidelines.md)
 * [Logging Guidelines in Gardener Components](development/logging-guidelines.md)
 * [Changing the API](development/changing-the-api.md)
+* [Status Subresource in Gardener APIs](development/status.md)
 * [Secrets Management for Seed and Shoot Clusters](development/secrets_management.md)
 * [IPv6 in Gardener Clusters](development/ipv6.md)
 * [Releases, Features, Hotfixes](development/process.md)

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2388,7 +2388,7 @@ ClusterType defines the type of cluster.
 </p>
 
 <p>
-Condition holds the information about the state of a resource.
+Condition holds the information about the state of a resource based on health checks.
 </p>
 
 <table>
@@ -11684,7 +11684,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -13038,7 +13038,7 @@ ShootStatus holds the most recently observed status of the Shoot cluster.
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Shoots's current state.</p>
+<p>Conditions represents the latest available observations of a Shoots's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -13050,7 +13050,7 @@ ShootStatus holds the most recently observed status of the Shoot cluster.
 </td>
 <td>
 <em>(Optional)</em>
-<p>Constraints represents conditions of a Shoot's current state that constraint some operations on it.</p>
+<p>Constraints represents conditions of a Shoot's current state that constraint or are relevant for some operations.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -233,7 +233,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -516,7 +516,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -802,7 +802,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -1417,7 +1417,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -1834,7 +1834,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -2190,7 +2190,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -2458,7 +2458,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -2746,7 +2746,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -3457,7 +3457,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -3948,7 +3948,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -4331,7 +4331,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -4869,7 +4869,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -5723,7 +5723,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of a Seed's current state.</p>
+<p>Conditions represents the latest available observations of a Seed's current state based on health checks.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -1688,7 +1688,7 @@ Condition array
 </td>
 <td>
 <em>(Optional)</em>
-<p>Conditions represents the latest available observations of an Extension's current state.</p>
+<p>Conditions represents the latest available observations of an Extension's current state based on health checks.</p>
 </td>
 </tr>
 <tr>
@@ -1937,7 +1937,7 @@ Condition array
 </em>
 </td>
 <td>
-<p>Conditions is a list of conditions.</p>
+<p>Conditions is a list of conditions based on health checks.</p>
 </td>
 </tr>
 <tr>

--- a/docs/development/status.md
+++ b/docs/development/status.md
@@ -8,7 +8,7 @@ As a rule, only controllers that observe real-world state should write to `statu
 
 ## Statuses in Gardener APIs
 
-Most Gardener API types carry a `Status` struct that reports what a controller has observed about the resource. While the exact fields vary by resource, several fields appear across many types:
+Most Gardener API types carry a `Status` struct. It reports what a controller has observed about the resource. While the exact fields vary by resource, several fields appear across many types:
 
 | Field | Description |
 |---|---|
@@ -19,28 +19,26 @@ Most Gardener API types carry a `Status` struct that reports what a controller h
 
 ## Conditions
 
-Conditions represent the results of **health checks** — discrete observations about whether a specific aspect of the system is working correctly. Each condition has a `Type` (what is being checked), a `Status` (`True`, `False`, `Unknown`, or `Progressing`), a machine-readable `Reason`, and a human-readable `Message`.
+Conditions represent the results of **health checks** — discrete observations about whether a specific aspect of the system is working correctly.
 
-```go
-type Condition struct {
-    Type               ConditionType
-    Status             ConditionStatus
-    LastTransitionTime metav1.Time
-    LastUpdateTime     metav1.Time
-    Reason             string
-    Message            string
-    Codes              []ErrorCode
-}
-```
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `Type` | `ConditionType` | Yes | The identifier for this condition (e.g. `APIServerAvailable`) |
+| `Status` | `ConditionStatus` | Yes | Whether the condition is `True`, `False`, or `Unknown` |
+| `LastTransitionTime` | `metav1.Time` | Yes | When `Status` last changed |
+| `LastUpdateTime` | `metav1.Time` | Yes | When any field (reason, message, codes) last changed |
+| `Reason` | `string` | Yes | A short, machine-readable word describing why the condition has its current status |
+| `Message` | `string` | Yes | A human-readable description of the condition |
+| `Codes` | `[]ErrorCode` | No | Structured error codes (e.g. `ERR_INFRA_QUOTA_EXCEEDED`, `ERR_UNAUTHORIZED`) used for alerting and user-facing diagnostics |
 
-`LastTransitionTime` records when `Status` last changed. `LastUpdateTime` records when any field (reason, message, codes) last changed. The `Codes` field carries structured error codes (`ERR_INFRA_QUOTA_EXCEEDED`, `ERR_UNAUTHORIZED`, etc.) that Gardener uses for alerting and user-facing diagnostics.
+You can find the full type definition in [`pkg/apis/core/v1beta1/types_utils.go`](https://github.com/gardener/gardener/blob/master/pkg/apis/core/v1beta1/types_utils.go).
 
 ### Examples
 
 Shoot conditions:
 
 | Type | What it checks |
-|---|---|
+| --- | --- |
 | `APIServerAvailable` | Whether the shoot's kube-apiserver is reachable |
 | `ControlPlaneHealthy` | Health of control plane components (etcd, apiserver, controller-manager, scheduler) |
 | `ObservabilityComponentsHealthy` | Health of monitoring and logging components |
@@ -50,18 +48,18 @@ Shoot conditions:
 Seed conditions:
 
 | Type | What it checks |
-|---|---|
+| --- | --- |
 | `BackupBucketsReady` | Whether all backup buckets for the seed are healthy |
 | `ExtensionsReady` | Whether all extensions installed in the seed are ready |
 | `SeedSystemComponentsHealthy` | Health of system components running in the seed |
 
 ### Introducing New Condition Types
 
-Condition types are deliberately stable. Before introducing a new `ConditionType`, check whether an existing type can be reused — many health checks naturally fit under `SystemComponentsHealthy` or `ControlPlaneHealthy`. Fragmenting health checks into many narrow types makes the overall status harder to read. Also, the Gardener dashboard always displays all conditions, whereas constraints are only shown when relevant (`Status: False`).
+Condition types are deliberately stable. Before introducing a new `ConditionType`, check whether an existing type can be reused — many health checks naturally fit under `SystemComponentsHealthy` or `ControlPlaneHealthy`. Fragmenting health checks into many narrow types makes the overall status harder to read. Additionally, since the Gardener Dashboard always displays all conditions, having too many narrow types would clutter the cluster overview.
 
 ## Constraints
 
-Constraints use the same `Condition` type and struct as health check conditions but serve a different purpose: they carry **operational signals and informational state** that may gate or influence controller behavior, or that surface relevant cluster information to operators and users.
+Constraints use the same [`Condition` type and struct](https://github.com/gardener/gardener/blob/master/pkg/apis/core/v1beta1/types_utils.go) type and struct as health check conditions but serve a different purpose: they carry **operational signals and informational state** that may gate or influence controller behavior, or that surface relevant cluster information to operators and users.
 
 Unlike conditions, constraints are not limited to binary health checks. They can represent:
 
@@ -71,7 +69,7 @@ Unlike conditions, constraints are not limited to binary health checks. They can
 - **Pending user actions** — `ManualInPlaceWorkersUpdated` signals that a worker pool awaits manual intervention
 - **Informational signals** — `HasIgnoredManagedResources` or `CRDsWithProblematicConversionWebhooks` inform operators of configuration issues
 
-Also see the [shoot status documentation](../usage/shoot/shoot_status.md) for more information.
+See the [shoot status documentation](../usage/shoot/shoot_status.md) for more information.
 
 ### Introducing New Constraint Types
 
@@ -79,12 +77,15 @@ Introducing new constraint types is more common and generally more acceptable th
 
 ## Conditions and Constraints Status Convention
 
-Gardener's Dashboard and other consumers display conditions and constraints generically. To ensure a consistent visual representation, the following convention applies:
+The Gardener Dashboard and other consumers display conditions and constraints generically. To ensure a consistent visual representation, the following convention applies:
 
 - **Positive results** (everything is fine, the operation is possible) → `Status: True`
 - **Negative results** (something is wrong, an operation is blocked) → `Status: False`
 
 Even with this polarity rule, **avoid negating the `Type` name**. A type like `HibernationNotPossible` set to `Status: False` means "hibernation is not not possible" — a double negation that is hard to parse. Instead, use `HibernationPossible` with `Status: True` to express the same state clearly.
+
+> [!NOTE]
+> The Gardener Dashboard always displays all conditions, whereas constraints are only shown when relevant (`Status: False`).
 
 ## Using the Helper Functions
 
@@ -102,7 +103,7 @@ See [`pkg/gardenlet/operation/botanist/dualstackmigration.go`](https://github.co
 
 See [`pkg/controllermanager/controller/shoot/migration/reconciler.go`](https://github.com/gardener/gardener/blob/ad196442201a759ccb56ead63528b328f57d2638/pkg/controllermanager/controller/shoot/migration/reconciler.go#L104) for the builder being used to set a constraint.
 
-### Atomically rebuilding both slices
+### Atomically Rebuilding Both Slices
 
 `BuildConditions` removes a set of managed types from the existing slice and appends the freshly computed values, leaving any types owned by other controllers untouched. Use it when a reconciler refreshes all its conditions and constraints in one pass.
 

--- a/docs/development/status.md
+++ b/docs/development/status.md
@@ -1,0 +1,109 @@
+# Status Subresource in Gardener APIs
+
+## Overview
+
+Kubernetes resources are divided into two conceptually separate parts: **spec** (the desired state) and **status** (the observed state). The `status` subresource is a dedicated API endpoint (`/apis/<group>/<version>/<resource>/<name>/status`) that allows controllers to update the observed state independently of the spec.
+
+As a rule, only controllers that observe real-world state should write to `status`.
+
+## Statuses in Gardener APIs
+
+Most Gardener API types carry a `Status` struct that reports what a controller has observed about the resource. While the exact fields vary by resource, several fields appear across many types:
+
+| Field | Description |
+|---|---|
+| `Conditions` | Health check results (see [Conditions](#conditions)) |
+| `Constraints` | Operational signals and informational state (see [Constraints](#constraints)) |
+| `LastOperation` | The most recent reconciliation operation (type, state, progress, description) |
+| `ObservedGeneration` | The `.metadata.generation` last reconciled by the controller |
+
+## Conditions
+
+Conditions represent the results of **health checks** — discrete observations about whether a specific aspect of the system is working correctly. Each condition has a `Type` (what is being checked), a `Status` (`True`, `False`, `Unknown`, or `Progressing`), a machine-readable `Reason`, and a human-readable `Message`.
+
+```go
+type Condition struct {
+    Type               ConditionType
+    Status             ConditionStatus
+    LastTransitionTime metav1.Time
+    LastUpdateTime     metav1.Time
+    Reason             string
+    Message            string
+    Codes              []ErrorCode
+}
+```
+
+`LastTransitionTime` records when `Status` last changed. `LastUpdateTime` records when any field (reason, message, codes) last changed. The `Codes` field carries structured error codes (`ERR_INFRA_QUOTA_EXCEEDED`, `ERR_UNAUTHORIZED`, etc.) that Gardener uses for alerting and user-facing diagnostics.
+
+### Examples
+
+Shoot conditions:
+
+| Type | What it checks |
+|---|---|
+| `APIServerAvailable` | Whether the shoot's kube-apiserver is reachable |
+| `ControlPlaneHealthy` | Health of control plane components (etcd, apiserver, controller-manager, scheduler) |
+| `ObservabilityComponentsHealthy` | Health of monitoring and logging components |
+| `EveryNodeReady` | Whether all worker nodes are Ready |
+| `SystemComponentsHealthy` | Health of system components deployed to the shoot (coredns, vpn, etc.) |
+
+Seed conditions:
+
+| Type | What it checks |
+|---|---|
+| `BackupBucketsReady` | Whether all backup buckets for the seed are healthy |
+| `ExtensionsReady` | Whether all extensions installed in the seed are ready |
+| `SeedSystemComponentsHealthy` | Health of system components running in the seed |
+
+### Introducing New Condition Types
+
+Condition types are deliberately stable. Before introducing a new `ConditionType`, check whether an existing type can be reused — many health checks naturally fit under `SystemComponentsHealthy` or `ControlPlaneHealthy`. Fragmenting health checks into many narrow types makes the overall status harder to read. Also, the Gardener dashboard always displays all conditions, whereas constraints are only shown when relevant (`Status: False`).
+
+## Constraints
+
+Constraints use the same `Condition` type and struct as health check conditions but serve a different purpose: they carry **operational signals and informational state** that may gate or influence controller behavior, or that surface relevant cluster information to operators and users.
+
+Unlike conditions, constraints are not limited to binary health checks. They can represent:
+
+- **Prerequisites for operations** — `HibernationPossible` blocks hibernation when `Status: False`; `MaintenancePreconditionsSatisfied` gates maintenance
+- **Certificate and credential hygiene** — `CACertificateValiditiesAcceptable` signals when CA certificates are nearing expiry
+- **Migration readiness** — `ReadyForMigration` must be `True` before a control-plane migration can proceed
+- **Pending user actions** — `ManualInPlaceWorkersUpdated` signals that a worker pool awaits manual intervention
+- **Informational signals** — `HasIgnoredManagedResources` or `CRDsWithProblematicConversionWebhooks` inform operators of configuration issues
+
+Also see the [shoot status documentation](../usage/shoot/shoot_status.md) for more information.
+
+### Introducing New Constraint Types
+
+Introducing new constraint types is more common and generally more acceptable than introducing new condition types. Constraints are often specific to an operation or a lifecycle phase, and there is less risk of conflict with existing semantics. If you are implementing a new controller behavior that depends on cluster state, a new constraint type is the right place to surface that signal.
+
+## Conditions and Constraints Status Convention
+
+Gardener's Dashboard and other consumers display conditions and constraints generically. To ensure a consistent visual representation, the following convention applies:
+
+- **Positive results** (everything is fine, the operation is possible) → `Status: True`
+- **Negative results** (something is wrong, an operation is blocked) → `Status: False`
+
+Even with this polarity rule, **avoid negating the `Type` name**. A type like `HibernationNotPossible` set to `Status: False` means "hibernation is not not possible" — a double negation that is hard to parse. Instead, use `HibernationPossible` with `Status: True` to express the same state clearly.
+
+## Using the Helper Functions
+
+Never construct or compare `Condition` values by hand. Use the helpers in `pkg/api/core/v1beta1/helper/` to ensure timestamps are set correctly and updates are idempotent.
+
+### Functional Helpers (`condition.go`)
+
+`GetOrInitConditionWithClock`, `UpdatedConditionWithClock`, and `MergeConditions` are the most direct way to update a single condition. `UpdatedConditionWithClock` only advances `LastTransitionTime` when `Status` changes and `LastUpdateTime` when `Reason`, `Message`, or `Codes` change — stable inputs produce stable outputs.
+
+See [`pkg/gardenlet/operation/botanist/dualstackmigration.go`](https://github.com/gardener/gardener/blob/ad196442201a759ccb56ead63528b328f57d2638/pkg/gardenlet/operation/botanist/dualstackmigration.go#L77-L79) for a constraint being read, updated, and merged back.
+
+### Builder API (`condition_builder.go`)
+
+`NewConditionBuilder` provides a fluent API useful when the status, reason, and message come from different code paths. `Build()` returns a boolean `updated` that is `true` only when the resulting condition differs from the old one — use it to skip unnecessary status patch calls.
+
+See [`pkg/controllermanager/controller/shoot/migration/reconciler.go`](https://github.com/gardener/gardener/blob/ad196442201a759ccb56ead63528b328f57d2638/pkg/controllermanager/controller/shoot/migration/reconciler.go#L104) for the builder being used to set a constraint.
+
+### Atomically rebuilding both slices
+
+`BuildConditions` removes a set of managed types from the existing slice and appends the freshly computed values, leaving any types owned by other controllers untouched. Use it when a reconciler refreshes all its conditions and constraints in one pass.
+
+See [`pkg/gardenlet/controller/shoot/care/reconciler.go`](https://github.com/gardener/gardener/blob/ad196442201a759ccb56ead63528b328f57d2638/pkg/gardenlet/controller/shoot/care/reconciler.go#L250-L251) for both slices being rebuilt atomically.

--- a/example/operator/10-crd-operator.gardener.cloud_extensions.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_extensions.yaml
@@ -463,10 +463,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of an Extension's current state.
+                  of an Extension's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -2110,10 +2110,10 @@ spec:
                   type: object
                 type: array
               conditions:
-                description: Conditions is a list of conditions.
+                description: Conditions is a list of conditions based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition
@@ -2158,7 +2158,7 @@ spec:
                   state that constraint some operations on it.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -139,7 +139,7 @@ spec:
               conditions:
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_backupbuckets.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_backupbuckets.yaml
@@ -102,10 +102,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_backupentries.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_backupentries.yaml
@@ -117,10 +117,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
@@ -119,10 +119,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_containerruntimes.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_containerruntimes.yaml
@@ -147,10 +147,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
@@ -104,10 +104,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_dnsrecords.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_dnsrecords.yaml
@@ -130,10 +130,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_extensions.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_extensions.yaml
@@ -78,10 +78,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
@@ -108,10 +108,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_networks.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_networks.yaml
@@ -103,10 +103,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -411,10 +411,10 @@ spec:
                 type: object
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_selfhostedshootexposures.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_selfhostedshootexposures.yaml
@@ -176,10 +176,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -768,10 +768,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -139,7 +139,7 @@ spec:
               conditions:
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/apis/core/types_controllerinstallation.go
+++ b/pkg/apis/core/types_controllerinstallation.go
@@ -56,7 +56,7 @@ type ControllerInstallationSpec struct {
 
 // ControllerInstallationStatus is the status of a ControllerInstallation.
 type ControllerInstallationStatus struct {
-	// Conditions represents the latest available observations of a ControllerInstallations's current state.
+	// Conditions represents the latest available observations of a ControllerInstallations's current state based on health checks.
 	Conditions []Condition
 	// ProviderStatus contains type-specific status.
 	// +optional

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -83,7 +83,7 @@ type SeedStatus struct {
 	Gardener *Gardener
 	// KubernetesVersion is the Kubernetes version of the seed cluster.
 	KubernetesVersion *string
-	// Conditions represents the latest available observations of a Seed's current state.
+	// Conditions represents the latest available observations of a Seed's current state based on health checks.
 	Conditions []Condition
 	// ObservedGeneration is the most recent generation observed for this Seed. It corresponds to the
 	// Seed's generation, which is updated on mutation by the API Server.

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -124,9 +124,9 @@ type ShootSpec struct {
 
 // ShootStatus holds the most recently observed status of the Shoot cluster.
 type ShootStatus struct {
-	// Conditions represents the latest available observations of a Shoot's current state.
+	// Conditions represents the latest available observations of a Shoot's current state based on health checks.
 	Conditions []Condition
-	// Constraints represents conditions of a Shoot's current state that constraint some operations on it.
+	// Constraints represents conditions of a Shoot's current state that constraint or are relevant for some operations.
 	Constraints []Condition
 	// Gardener holds information about the Gardener which last acted on the Shoot.
 	Gardener Gardener

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -655,7 +655,7 @@ message ClusterAutoscalerOptions {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration maxNodeProvisionTime = 5;
 }
 
-// Condition holds the information about the state of a resource.
+// Condition holds the information about the state of a resource based on health checks.
 message Condition {
   // Type of the condition.
   optional string type = 1;
@@ -3275,7 +3275,7 @@ message SeedStatus {
   // +optional
   optional string kubernetesVersion = 2;
 
-  // Conditions represents the latest available observations of a Seed's current state.
+  // Conditions represents the latest available observations of a Seed's current state based on health checks.
   // +patchMergeKey=type
   // +patchStrategy=merge
   // +optional
@@ -3692,13 +3692,13 @@ message ShootStateSpec {
 
 // ShootStatus holds the most recently observed status of the Shoot cluster.
 message ShootStatus {
-  // Conditions represents the latest available observations of a Shoots's current state.
+  // Conditions represents the latest available observations of a Shoots's current state based on health checks.
   // +patchMergeKey=type
   // +patchStrategy=merge
   // +optional
   repeated Condition conditions = 1;
 
-  // Constraints represents conditions of a Shoot's current state that constraint some operations on it.
+  // Constraints represents conditions of a Shoot's current state that constraint or are relevant for some operations.
   // +patchMergeKey=type
   // +patchStrategy=merge
   // +optional

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -100,7 +100,7 @@ type SeedStatus struct {
 	// KubernetesVersion is the Kubernetes version of the seed cluster.
 	// +optional
 	KubernetesVersion *string `json:"kubernetesVersion,omitempty" protobuf:"bytes,2,opt,name=kubernetesVersion"`
-	// Conditions represents the latest available observations of a Seed's current state.
+	// Conditions represents the latest available observations of a Seed's current state based on health checks.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +optional

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -154,12 +154,12 @@ type ShootSpec struct {
 
 // ShootStatus holds the most recently observed status of the Shoot cluster.
 type ShootStatus struct {
-	// Conditions represents the latest available observations of a Shoots's current state.
+	// Conditions represents the latest available observations of a Shoots's current state based on health checks.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +optional
 	Conditions []Condition `json:"conditions,omitempty" patchMergeKey:"type" patchStrategy:"merge" protobuf:"bytes,1,rep,name=conditions"`
-	// Constraints represents conditions of a Shoot's current state that constraint some operations on it.
+	// Constraints represents conditions of a Shoot's current state that constraint or are relevant for some operations.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +optional

--- a/pkg/apis/core/v1beta1/types_utils.go
+++ b/pkg/apis/core/v1beta1/types_utils.go
@@ -21,7 +21,7 @@ type ConditionStatus string
 // ConditionType is a string alias.
 type ConditionType string
 
-// Condition holds the information about the state of a resource.
+// Condition holds the information about the state of a resource based on health checks.
 type Condition struct {
 	// Type of the condition.
 	Type ConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=ConditionType"`

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -63,7 +63,7 @@ type DefaultStatus struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	ProviderStatus *runtime.RawExtension `json:"providerStatus,omitempty"`
-	// Conditions represents the latest available observations of a Seed's current state.
+	// Conditions represents the latest available observations of a Seed's current state based on health checks.
 	// +optional
 	Conditions []gardencorev1beta1.Condition `json:"conditions,omitempty"`
 	// LastError holds information about the last occurred error during an operation.

--- a/pkg/apis/operator/v1alpha1/types_extension.go
+++ b/pkg/apis/operator/v1alpha1/types_extension.go
@@ -135,7 +135,7 @@ type ExtensionStatus struct {
 	// ObservedGeneration is the most recent generation observed for this resource.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
-	// Conditions represents the latest available observations of an Extension's current state.
+	// Conditions represents the latest available observations of an Extension's current state based on health checks.
 	// +optional
 	Conditions []gardencorev1beta1.Condition `json:"conditions,omitempty" patchMergeKey:"type" patchStrategy:"merge"`
 	// ProviderStatus contains type-specific status.

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -847,7 +847,7 @@ type GardenStatus struct {
 	// Gardener holds information about the Gardener which last acted on the Garden.
 	// +optional
 	Gardener *gardencorev1beta1.Gardener `json:"gardener,omitempty"`
-	// Conditions is a list of conditions.
+	// Conditions is a list of conditions based on health checks.
 	Conditions []gardencorev1beta1.Condition `json:"conditions,omitempty"`
 	// Constraints represents conditions of a Garden's current state that constraint some operations on it.
 	// +patchMergeKey=type

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -2756,7 +2756,7 @@ func schema_pkg_apis_core_v1beta1_Condition(ref common.ReferenceCallback) common
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Condition holds the information about the state of a resource.",
+				Description: "Condition holds the information about the state of a resource based on health checks.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
@@ -9392,7 +9392,7 @@ func schema_pkg_apis_core_v1beta1_SeedStatus(ref common.ReferenceCallback) commo
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions represents the latest available observations of a Seed's current state.",
+							Description: "Conditions represents the latest available observations of a Seed's current state based on health checks.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -10422,7 +10422,7 @@ func schema_pkg_apis_core_v1beta1_ShootStatus(ref common.ReferenceCallback) comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Conditions represents the latest available observations of a Shoots's current state.",
+							Description: "Conditions represents the latest available observations of a Shoots's current state based on health checks.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -10441,7 +10441,7 @@ func schema_pkg_apis_core_v1beta1_ShootStatus(ref common.ReferenceCallback) comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Constraints represents conditions of a Shoot's current state that constraint some operations on it.",
+							Description: "Constraints represents conditions of a Shoot's current state that constraint or are relevant for some operations.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_backupbuckets.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_backupbuckets.yaml
@@ -104,10 +104,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_backupentries.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_backupentries.yaml
@@ -119,10 +119,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_bastions.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_bastions.yaml
@@ -121,10 +121,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_containerruntimes.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_containerruntimes.yaml
@@ -149,10 +149,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_controlplanes.yaml
@@ -106,10 +106,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_dnsrecords.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_dnsrecords.yaml
@@ -132,10 +132,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_extensions.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_extensions.yaml
@@ -80,10 +80,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_infrastructures.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_infrastructures.yaml
@@ -110,10 +110,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_networks.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_networks.yaml
@@ -105,10 +105,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -413,10 +413,10 @@ spec:
                 type: object
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_selfhostedshootexposures.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_selfhostedshootexposures.yaml
@@ -178,10 +178,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
@@ -770,10 +770,10 @@ spec:
             properties:
               conditions:
                 description: Conditions represents the latest available observations
-                  of a Seed's current state.
+                  of a Seed's current state based on health checks.
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition

--- a/pkg/component/gardener/resourcemanager/assets/crd-resources.gardener.cloud_managedresources.yaml
+++ b/pkg/component/gardener/resourcemanager/assets/crd-resources.gardener.cloud_managedresources.yaml
@@ -141,7 +141,7 @@ spec:
               conditions:
                 items:
                   description: Condition holds the information about the state of
-                    a resource.
+                    a resource based on health checks.
                   properties:
                     codes:
                       description: Well-defined error codes in case the condition


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Adds `status` documentation for developers, esp. to clarify the usage of conditions vs. constraints.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Output from discussions which happened in #15277 and #15023.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
A new documentation about the `status` in Gardener APIs has been added to `/docs/development/status.md`, containing general information and guidelines.
```
