### PR TITLE
Fix stale basic auth secret reference for verbatim secrets during credential rotation

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -549,6 +549,8 @@ const (
 	LabelBasicAuthSecretName = "reference.gardener.cloud/basic-auth-secret-name"
 	// LabelBasicAuthServerName is a constant for a label used on virtual services to associate them with a specific istio-basic-auth-server instance.
 	LabelBasicAuthServerName = "reference.gardener.cloud/basic-auth-server-name"
+	// LabelBasicAuthSecretManaged is a constant for a label used on virtual services to indicate whether the referenced basic-auth secret is managed by the secrets manager ("true") or used verbatim ("false").
+	LabelBasicAuthSecretManaged = "reference.gardener.cloud/basic-auth-secret-managed"
 
 	// LabelExtensionExtensionTypePrefix is used to prefix extension label for extension types.
 	LabelExtensionExtensionTypePrefix = "extensions.extensions.gardener.cloud/"

--- a/pkg/component/networking/istiobasicauthserver/istiobasicauthserver.go
+++ b/pkg/component/networking/istiobasicauthserver/istiobasicauthserver.go
@@ -66,6 +66,7 @@ type Values struct {
 
 type istioBasicAuthServer struct {
 	client         client.Client
+	apiReader      client.Reader
 	namespace      string
 	secretsManager secretsmanager.Interface
 	values         Values
@@ -74,12 +75,14 @@ type istioBasicAuthServer struct {
 // New creates a new instance of an istio-basic-auth-server deployer.
 func New(
 	client client.Client,
+	apiReader client.Reader,
 	namespace string,
 	secretsManager secretsmanager.Interface,
 	values Values,
 ) component.DeployWaiter {
 	return &istioBasicAuthServer{
 		client:         client,
+		apiReader:      apiReader,
 		namespace:      namespace,
 		secretsManager: secretsManager,
 		values:         values,
@@ -214,6 +217,15 @@ func (i *istioBasicAuthServer) calculateConfiguration(
 				return nil, nil, nil, fmt.Errorf("failed to find secret %q referenced by virtual service %q in the secrets manager", secretName, virtualService.Name)
 			}
 			secretName = secret.Name
+		} else {
+			// Use an uncached client to prevent race conditions between VirtualService updates by the GRM that reference
+			// secrets not managed by the secrets manager, and the istio-basic-auth-server deployer.
+			virtualServiceMetadata := &metav1.PartialObjectMetadata{}
+			virtualServiceMetadata.SetGroupVersionKind(istionetworkingv1beta1.SchemeGroupVersion.WithKind("VirtualService"))
+			if err := i.apiReader.Get(ctx, client.ObjectKeyFromObject(virtualService), virtualServiceMetadata); err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to get virtual service %q: %w", virtualService.Name, err)
+			}
+			secretName = virtualServiceMetadata.Labels[v1beta1constants.LabelBasicAuthSecretName]
 		}
 
 		for _, host := range virtualService.Spec.Hosts {

--- a/pkg/component/networking/istiobasicauthserver/istiobasicauthserver.go
+++ b/pkg/component/networking/istiobasicauthserver/istiobasicauthserver.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -203,7 +204,15 @@ func (i *istioBasicAuthServer) calculateConfiguration(
 
 	for _, virtualService := range virtualServiceList.Items {
 		secretName := virtualService.Labels[v1beta1constants.LabelBasicAuthSecretName]
-		if secret, found := i.secretsManager.Get(secretName); found {
+		secretManaged, err := strconv.ParseBool(virtualService.Labels[v1beta1constants.LabelBasicAuthSecretManaged])
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to parse label %q of virtual service %q: %w", v1beta1constants.LabelBasicAuthSecretManaged, virtualService.Name, err)
+		}
+		if secretManaged {
+			secret, found := i.secretsManager.Get(secretName)
+			if !found {
+				return nil, nil, nil, fmt.Errorf("failed to find secret %q referenced by virtual service %q in the secrets manager", secretName, virtualService.Name)
+			}
 			secretName = secret.Name
 		}
 
@@ -317,15 +326,16 @@ func (i *istioBasicAuthServer) getPrefix() string {
 }
 
 // BasicAuthLabels returns the labels that associate a VirtualService with its configuring istio-basic-auth-server.
-func BasicAuthLabels(isGardenCluster bool, secretName string) map[string]string {
+func BasicAuthLabels(isGardenCluster bool, secretName string, secretManaged bool) map[string]string {
 	basicAuthServerName := v1beta1constants.DeploymentNameIstioBasicAuthServer
 	if isGardenCluster {
 		basicAuthServerName = operatorv1alpha1.VirtualGardenNamePrefix + basicAuthServerName
 	}
 
 	return map[string]string{
-		v1beta1constants.LabelBasicAuthSecretName: secretName,
-		v1beta1constants.LabelBasicAuthServerName: basicAuthServerName,
+		v1beta1constants.LabelBasicAuthSecretName:    secretName,
+		v1beta1constants.LabelBasicAuthServerName:    basicAuthServerName,
+		v1beta1constants.LabelBasicAuthSecretManaged: strconv.FormatBool(secretManaged),
 	}
 }
 

--- a/pkg/component/networking/istiobasicauthserver/istiobasicauthserver_test.go
+++ b/pkg/component/networking/istiobasicauthserver/istiobasicauthserver_test.go
@@ -51,6 +51,7 @@ var _ = Describe("IstioBasicAuthServer", func() {
 		host3               = prefix3 + ".domain.name"
 
 		c                 client.Client
+		apiReader         client.Client
 		component         comp.DeployWaiter
 		fakeSecretManager secretsmanager.Interface
 		values            Values
@@ -360,6 +361,8 @@ status: {}
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-istio-basic-auth-server", Namespace: namespace}})).To(Succeed())
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-virtual-garden-istio-basic-auth-server", Namespace: namespace}})).To(Succeed())
 
+		apiReader = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
 		values = Values{
 			Image:                        image,
 			PriorityClassName:            priorityClassName,
@@ -367,7 +370,7 @@ status: {}
 			SigningCA:                    "ca-istio-basic-auth-server",
 			IstioIngressGatewayNamespace: "istio-ingress",
 		}
-		component = New(c, namespace, fakeSecretManager, values)
+		component = New(c, apiReader, namespace, fakeSecretManager, values)
 
 		managedResource = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
@@ -453,7 +456,7 @@ status: {}
 					values.IsGardenCluster = true
 					values.SigningCA = "ca-virtual-garden-istio-basic-auth-server"
 					values.IstioIngressGatewayNamespace = "virtual-garden-istio-ingress"
-					component = New(c, namespace, fakeSecretManager, values)
+					component = New(c, apiReader, namespace, fakeSecretManager, values)
 				})
 
 				It("should successfully deploy the resources", func() {
@@ -464,16 +467,17 @@ status: {}
 
 		Context("With secrets present", func() {
 			createVirtualServices := func(basicAuthServerName string) {
+				create := func(vs *istionetworkingv1beta1.VirtualService) {
+					vs.Labels["reference.gardener.cloud/basic-auth-server-name"] = basicAuthServerName
+					Expect(c.Create(ctx, vs.DeepCopy())).To(Succeed())
+					Expect(apiReader.Create(ctx, vs.DeepCopy())).To(Succeed())
+				}
+
 				Expect(c.Create(ctx, dummyVirtualService.DeepCopy())).To(Succeed())
 				Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secret1, Namespace: namespace}})).To(Succeed())
 
-				vs1 := virtualServiceWithManagedSecret.DeepCopy()
-				vs1.Labels["reference.gardener.cloud/basic-auth-server-name"] = basicAuthServerName
-				Expect(c.Create(ctx, vs1)).To(Succeed())
-
-				vs2 := virtualServiceWithVerbatimSecret.DeepCopy()
-				vs2.Labels["reference.gardener.cloud/basic-auth-server-name"] = basicAuthServerName
-				Expect(c.Create(ctx, vs2)).To(Succeed())
+				create(virtualServiceWithManagedSecret.DeepCopy())
+				create(virtualServiceWithVerbatimSecret.DeepCopy())
 			}
 
 			Context("Shoot or Seed", func() {
@@ -496,7 +500,7 @@ status: {}
 					values.IsGardenCluster = true
 					values.SigningCA = "ca-virtual-garden-istio-basic-auth-server"
 					values.IstioIngressGatewayNamespace = "virtual-garden-istio-ingress"
-					component = New(c, namespace, fakeSecretManager, values)
+					component = New(c, apiReader, namespace, fakeSecretManager, values)
 				})
 
 				It("should successfully deploy the resources", func() {
@@ -505,6 +509,54 @@ status: {}
 						{prefix2, secret2},
 						{prefix3, secret2},
 					}, host1, host2, host3)
+				})
+			})
+		})
+
+		Context("With stale secret references", func() {
+			Context("unmanaged secret", func() {
+				BeforeEach(func() {
+					staleVS := virtualServiceWithVerbatimSecret.DeepCopy()
+					staleVS.Labels["reference.gardener.cloud/basic-auth-server-name"] = "istio-basic-auth-server"
+					staleVS.Labels["reference.gardener.cloud/basic-auth-secret-name"] = "stale-secret"
+					Expect(c.Create(ctx, staleVS)).To(Succeed())
+
+					updatedVS := virtualServiceWithVerbatimSecret.DeepCopy()
+					updatedVS.Labels["reference.gardener.cloud/basic-auth-server-name"] = "istio-basic-auth-server"
+					updatedVS.Labels["reference.gardener.cloud/basic-auth-secret-name"] = "correct-secret-from-api-reader"
+					Expect(apiReader.Create(ctx, updatedVS)).To(Succeed())
+
+					component = New(c, apiReader, namespace, fakeSecretManager, values)
+				})
+
+				It("should resolve the secret name from the api reader instead of the stale cached label", func() {
+					testManifests(false, []prefixToSecretMapping{
+						{prefix2, "correct-secret-from-api-reader"},
+						{prefix3, "correct-secret-from-api-reader"},
+					}, host2, host3)
+				})
+			})
+
+			Context("managed secret", func() {
+				BeforeEach(func() {
+					Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secret1, Namespace: namespace}})).To(Succeed())
+
+					managedVS := virtualServiceWithManagedSecret.DeepCopy()
+					managedVS.Labels["reference.gardener.cloud/basic-auth-server-name"] = "istio-basic-auth-server"
+					Expect(c.Create(ctx, managedVS)).To(Succeed())
+
+					unmanagedVS := virtualServiceWithManagedSecret.DeepCopy()
+					unmanagedVS.Labels["reference.gardener.cloud/basic-auth-server-name"] = "istio-basic-auth-server"
+					unmanagedVS.Labels["reference.gardener.cloud/basic-auth-secret-name"] = "wrong-secret-from-api-reader"
+					Expect(apiReader.Create(ctx, unmanagedVS)).To(Succeed())
+
+					component = New(c, apiReader, namespace, fakeSecretManager, values)
+				})
+
+				It("should resolve the secret name from the secrets manager and ignore the api reader", func() {
+					testManifests(false, []prefixToSecretMapping{
+						{prefix1, secret1},
+					}, host1)
 				})
 			})
 		})
@@ -532,6 +584,14 @@ status: {}
 
 			Expect(component.Deploy(ctx)).To(MatchError(`failed to calculate configuration for istio-basic-auth-server: failed to find secret "nonexistent-secret" referenced by virtual service "vs-with-managed-secret" in the secrets manager`))
 		})
+
+		It("should fail when the secret is unmanaged but the virtual service is not found by the api reader", func() {
+			vs := virtualServiceWithVerbatimSecret.DeepCopy()
+			vs.Labels["reference.gardener.cloud/basic-auth-server-name"] = "istio-basic-auth-server"
+			Expect(c.Create(ctx, vs)).To(Succeed())
+
+			Expect(component.Deploy(ctx)).To(MatchError(`failed to calculate configuration for istio-basic-auth-server: failed to get virtual service "vs-with-verbatim-secret": virtualservices.networking.istio.io "vs-with-verbatim-secret" not found`))
+		})
 	})
 
 	Describe("#Destroy", func() {
@@ -553,7 +613,7 @@ status: {}
 		var fakeOps *retryfake.Ops
 
 		BeforeEach(func() {
-			component = New(c, namespace, fakeSecretManager, values)
+			component = New(c, apiReader, namespace, fakeSecretManager, values)
 			fakeOps = &retryfake.Ops{MaxAttempts: 1}
 			DeferCleanup(test.WithVars(
 				&retry.Until, fakeOps.Until,

--- a/pkg/component/networking/istiobasicauthserver/istiobasicauthserver_test.go
+++ b/pkg/component/networking/istiobasicauthserver/istiobasicauthserver_test.go
@@ -324,26 +324,28 @@ status: {}
 				Labels:    map[string]string{"app": "dummy"},
 			},
 		}
-		realVirtualService1 = &istionetworkingv1beta1.VirtualService{
+		virtualServiceWithManagedSecret = &istionetworkingv1beta1.VirtualService{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "real-virtual-service-1",
+				Name:      "vs-with-managed-secret",
 				Namespace: namespace,
 				Labels: map[string]string{
 					"app": "dummy",
-					"reference.gardener.cloud/basic-auth-secret-name": secret1,
+					"reference.gardener.cloud/basic-auth-secret-name":    secret1,
+					"reference.gardener.cloud/basic-auth-secret-managed": "true",
 				},
 			},
 			Spec: istioapinetworkingv1beta1.VirtualService{
 				Hosts: []string{host1},
 			},
 		}
-		realVirtualService2 = &istionetworkingv1beta1.VirtualService{
+		virtualServiceWithVerbatimSecret = &istionetworkingv1beta1.VirtualService{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "real-virtual-service-2",
+				Name:      "vs-with-verbatim-secret",
 				Namespace: namespace,
 				Labels: map[string]string{
 					"app": "dummy",
-					"reference.gardener.cloud/basic-auth-secret-name": secret2,
+					"reference.gardener.cloud/basic-auth-secret-name":    secret2,
+					"reference.gardener.cloud/basic-auth-secret-managed": "false",
 				},
 			},
 			Spec: istioapinetworkingv1beta1.VirtualService{
@@ -463,12 +465,13 @@ status: {}
 		Context("With secrets present", func() {
 			createVirtualServices := func(basicAuthServerName string) {
 				Expect(c.Create(ctx, dummyVirtualService.DeepCopy())).To(Succeed())
+				Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secret1, Namespace: namespace}})).To(Succeed())
 
-				vs1 := realVirtualService1.DeepCopy()
+				vs1 := virtualServiceWithManagedSecret.DeepCopy()
 				vs1.Labels["reference.gardener.cloud/basic-auth-server-name"] = basicAuthServerName
 				Expect(c.Create(ctx, vs1)).To(Succeed())
 
-				vs2 := realVirtualService2.DeepCopy()
+				vs2 := virtualServiceWithVerbatimSecret.DeepCopy()
 				vs2.Labels["reference.gardener.cloud/basic-auth-server-name"] = basicAuthServerName
 				Expect(c.Create(ctx, vs2)).To(Succeed())
 			}
@@ -504,6 +507,30 @@ status: {}
 					}, host1, host2, host3)
 				})
 			})
+		})
+	})
+
+	Context("When secret references are misconfigured", func() {
+		BeforeEach(func() {
+			Expect(c.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})).To(Succeed())
+		})
+
+		It("should fail when the managed label has a non-boolean value", func() {
+			vs := virtualServiceWithManagedSecret.DeepCopy()
+			vs.Labels["reference.gardener.cloud/basic-auth-server-name"] = "istio-basic-auth-server"
+			vs.Labels["reference.gardener.cloud/basic-auth-secret-managed"] = "invalid"
+			Expect(c.Create(ctx, vs)).To(Succeed())
+
+			Expect(component.Deploy(ctx)).To(MatchError(`failed to calculate configuration for istio-basic-auth-server: failed to parse label "reference.gardener.cloud/basic-auth-secret-managed" of virtual service "vs-with-managed-secret": strconv.ParseBool: parsing "invalid": invalid syntax`))
+		})
+
+		It("should fail when the secret is managed but not found in the secrets manager", func() {
+			vs := virtualServiceWithManagedSecret.DeepCopy()
+			vs.Labels["reference.gardener.cloud/basic-auth-server-name"] = "istio-basic-auth-server"
+			vs.Labels["reference.gardener.cloud/basic-auth-secret-name"] = "nonexistent-secret"
+			Expect(c.Create(ctx, vs)).To(Succeed())
+
+			Expect(component.Deploy(ctx)).To(MatchError(`failed to calculate configuration for istio-basic-auth-server: failed to find secret "nonexistent-secret" referenced by virtual service "vs-with-managed-secret" in the secrets manager`))
 		})
 	})
 

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -362,8 +362,9 @@ var _ = Describe("Alertmanager", func() {
 					"component":    "alertmanager",
 					"role":         "monitoring",
 					"alertmanager": name,
-					"reference.gardener.cloud/basic-auth-secret-name": "foo",
-					"reference.gardener.cloud/basic-auth-server-name": "istio-basic-auth-server",
+					"reference.gardener.cloud/basic-auth-secret-name":    "foo",
+					"reference.gardener.cloud/basic-auth-server-name":    "istio-basic-auth-server",
+					"reference.gardener.cloud/basic-auth-secret-managed": "true",
 				},
 			},
 			Spec: istionetworkingv1alpha3.VirtualService{
@@ -534,6 +535,7 @@ var _ = Describe("Alertmanager", func() {
 				BeforeEach(func() {
 					values.ExternalExposure = &ExposureValues{
 						AuthSecretName:               ingressAuthSecretName,
+						AuthSecretManaged:            true,
 						Host:                         ingressHost,
 						WildcardCertSecretName:       &ingressWildcardSecretName,
 						IstioIngressGatewayNamespace: ingressNamespace,

--- a/pkg/component/observability/monitoring/alertmanager/component.go
+++ b/pkg/component/observability/monitoring/alertmanager/component.go
@@ -30,8 +30,8 @@ const (
 // Interface contains functions for an alertmanager deployer.
 type Interface interface {
 	component.DeployWaiter
-	// SetIngressAuthSecretName sets the ingress authentication secret name.
-	SetIngressAuthSecretName(string)
+	// SetIngressAuthSecret sets the ingress authentication secret name and whether it is managed by the secrets manager.
+	SetIngressAuthSecret(name string, managed bool)
 	// SetIngressWildcardCertSecret sets the ingress wildcard certificate secret name.
 	SetIngressWildcardCertSecret(*corev1.Secret)
 }
@@ -67,6 +67,8 @@ type Values struct {
 type ExposureValues struct {
 	// AuthSecretName is the name of the auth secret.
 	AuthSecretName string
+	// AuthSecretManaged indicates whether the auth secret is managed by the secrets manager.
+	AuthSecretManaged bool
 	// Host is the hostname under which the AlertManager instance should be exposed.
 	Host string
 	// IsGardenCluster specifies whether the cluster is garden cluster.
@@ -149,9 +151,10 @@ func (a *alertManager) WaitCleanup(ctx context.Context) error {
 	return managedresources.WaitUntilDeleted(timeoutCtx, a.client, a.namespace, a.name())
 }
 
-func (a *alertManager) SetIngressAuthSecretName(name string) {
+func (a *alertManager) SetIngressAuthSecret(name string, managed bool) {
 	if a.values.ExternalExposure != nil {
 		a.values.ExternalExposure.AuthSecretName = name
+		a.values.ExternalExposure.AuthSecretManaged = managed
 	}
 }
 

--- a/pkg/component/observability/monitoring/alertmanager/istio_resources.go
+++ b/pkg/component/observability/monitoring/alertmanager/istio_resources.go
@@ -88,7 +88,7 @@ func (a *alertManager) istioResources(ctx context.Context) ([]client.Object, err
 	virtualService := &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: a.namespace}}
 	if err := istio.VirtualServiceForTLSTermination(
 		virtualService,
-		utils.MergeStringMaps(a.getLabels(), istiobasicauthserver.BasicAuthLabels(a.values.ExternalExposure.IsGardenCluster, a.values.ExternalExposure.AuthSecretName)),
+		utils.MergeStringMaps(a.getLabels(), istiobasicauthserver.BasicAuthLabels(a.values.ExternalExposure.IsGardenCluster, a.values.ExternalExposure.AuthSecretName, a.values.ExternalExposure.AuthSecretManaged)),
 		[]string{a.values.ExternalExposure.IstioIngressGatewayNamespace},
 		[]string{a.values.ExternalExposure.Host},
 		gatewayName,

--- a/pkg/component/observability/monitoring/alertmanager/mock/mocks.go
+++ b/pkg/component/observability/monitoring/alertmanager/mock/mocks.go
@@ -69,16 +69,16 @@ func (mr *MockInterfaceMockRecorder) Destroy(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), ctx)
 }
 
-// SetIngressAuthSecretName mocks base method.
-func (m *MockInterface) SetIngressAuthSecretName(arg0 string) {
+// SetIngressAuthSecret mocks base method.
+func (m *MockInterface) SetIngressAuthSecret(name string, managed bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetIngressAuthSecretName", arg0)
+	m.ctrl.Call(m, "SetIngressAuthSecret", name, managed)
 }
 
-// SetIngressAuthSecretName indicates an expected call of SetIngressAuthSecretName.
-func (mr *MockInterfaceMockRecorder) SetIngressAuthSecretName(arg0 any) *gomock.Call {
+// SetIngressAuthSecret indicates an expected call of SetIngressAuthSecret.
+func (mr *MockInterfaceMockRecorder) SetIngressAuthSecret(name, managed any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIngressAuthSecretName", reflect.TypeOf((*MockInterface)(nil).SetIngressAuthSecretName), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIngressAuthSecret", reflect.TypeOf((*MockInterface)(nil).SetIngressAuthSecret), name, managed)
 }
 
 // SetIngressWildcardCertSecret mocks base method.

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -64,8 +64,8 @@ func ServicePorts() struct {
 // Interface contains functions for a Prometheus deployer.
 type Interface interface {
 	component.DeployWaiter
-	// SetIngressAuthSecretName sets the ingress authentication secret name.
-	SetIngressAuthSecretName(string)
+	// SetIngressAuthSecret sets the ingress authentication secret name and whether it is managed by the secrets manager.
+	SetIngressAuthSecret(name string, managed bool)
 	// SetIngressWildcardCertSecret sets the ingress wildcard certificate secret name.
 	SetIngressWildcardCertSecret(*corev1.Secret)
 	// SetCentralScrapeConfigs sets the central scrape configs.
@@ -183,6 +183,8 @@ type RemoteWriteValues struct {
 type IngressValues struct {
 	// AuthSecretName is the name of the auth secret.
 	AuthSecretName string
+	// AuthSecretManaged indicates whether the auth secret is managed by the secrets manager.
+	AuthSecretManaged bool
 	// Host is the hostname under which the Prometheus instance should be exposed.
 	Host string
 	// IsGardenCluster specifies whether the cluster is garden cluster.
@@ -349,9 +351,10 @@ func (p *prometheus) WaitCleanup(ctx context.Context) error {
 	return managedresources.WaitUntilDeleted(timeoutCtx, p.client, p.namespace, p.name())
 }
 
-func (p *prometheus) SetIngressAuthSecretName(name string) {
+func (p *prometheus) SetIngressAuthSecret(name string, managed bool) {
 	if p.values.Ingress != nil {
 		p.values.Ingress.AuthSecretName = name
+		p.values.Ingress.AuthSecretManaged = managed
 	}
 }
 

--- a/pkg/component/observability/monitoring/prometheus/istio_resources.go
+++ b/pkg/component/observability/monitoring/prometheus/istio_resources.go
@@ -93,7 +93,7 @@ func (p *prometheus) istioResources(ctx context.Context) ([]client.Object, error
 	virtualService := &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: p.namespace}}
 	if err := istio.VirtualServiceForTLSTermination(
 		virtualService,
-		utils.MergeStringMaps(p.getLabels(), istiobasicauthserver.BasicAuthLabels(p.values.Ingress.IsGardenCluster, p.values.Ingress.AuthSecretName)),
+		utils.MergeStringMaps(p.getLabels(), istiobasicauthserver.BasicAuthLabels(p.values.Ingress.IsGardenCluster, p.values.Ingress.AuthSecretName, p.values.Ingress.AuthSecretManaged)),
 		[]string{p.values.Ingress.IstioIngressGatewayNamespace},
 		[]string{p.values.Ingress.Host},
 		gatewayName,

--- a/pkg/component/observability/monitoring/prometheus/mock/mocks.go
+++ b/pkg/component/observability/monitoring/prometheus/mock/mocks.go
@@ -108,16 +108,16 @@ func (mr *MockInterfaceMockRecorder) SetCentralScrapeConfigs(arg0 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCentralScrapeConfigs", reflect.TypeOf((*MockInterface)(nil).SetCentralScrapeConfigs), arg0)
 }
 
-// SetIngressAuthSecretName mocks base method.
-func (m *MockInterface) SetIngressAuthSecretName(arg0 string) {
+// SetIngressAuthSecret mocks base method.
+func (m *MockInterface) SetIngressAuthSecret(name string, managed bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetIngressAuthSecretName", arg0)
+	m.ctrl.Call(m, "SetIngressAuthSecret", name, managed)
 }
 
-// SetIngressAuthSecretName indicates an expected call of SetIngressAuthSecretName.
-func (mr *MockInterfaceMockRecorder) SetIngressAuthSecretName(arg0 any) *gomock.Call {
+// SetIngressAuthSecret indicates an expected call of SetIngressAuthSecret.
+func (mr *MockInterfaceMockRecorder) SetIngressAuthSecret(name, managed any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIngressAuthSecretName", reflect.TypeOf((*MockInterface)(nil).SetIngressAuthSecretName), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIngressAuthSecret", reflect.TypeOf((*MockInterface)(nil).SetIngressAuthSecret), name, managed)
 }
 
 // SetIngressWildcardCertSecret mocks base method.

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -488,8 +488,9 @@ honor_labels: true`
 					"app":  "prometheus",
 					"role": "monitoring",
 					"name": name,
-					"reference.gardener.cloud/basic-auth-secret-name": "foo",
-					"reference.gardener.cloud/basic-auth-server-name": "istio-basic-auth-server",
+					"reference.gardener.cloud/basic-auth-secret-name":    "foo",
+					"reference.gardener.cloud/basic-auth-server-name":    "istio-basic-auth-server",
+					"reference.gardener.cloud/basic-auth-secret-managed": "true",
 				},
 			},
 			Spec: istionetworkingv1alpha3.VirtualService{
@@ -884,6 +885,7 @@ honor_labels: true`
 					BeforeEach(func() {
 						values.Ingress = &IngressValues{
 							AuthSecretName:               ingressAuthSecretName,
+							AuthSecretManaged:            true,
 							Host:                         ingressHost,
 							WildcardCertSecretName:       &ingressWildcardSecretName,
 							IstioIngressGatewayNamespace: ingressNamespace,
@@ -956,7 +958,7 @@ honor_labels: true`
 					BeforeEach(func() {
 						values.Ingress = &IngressValues{Host: ingressHost, IstioIngressGatewayNamespace: ingressNamespace}
 						deployer = New(logr.Discard(), fakeClient, namespace, values)
-						deployer.SetIngressAuthSecretName(ingressAuthSecretName)
+						deployer.SetIngressAuthSecret(ingressAuthSecretName, true)
 						deployer.SetIngressWildcardCertSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: ingressWildcardSecretName}})
 					})
 

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -791,19 +791,22 @@ func (p *plutono) refresherSidecar(what, label, folder string, volumeMount corev
 
 func (p *plutono) getIstioResources(ctx context.Context) ([]client.Object, error) {
 	var (
-		credentialsSecretName = p.values.AuthSecretName
-		caName                = v1beta1constants.SecretNameCASeed
-		gatewayName           = name
+		credentialsSecretName    = p.values.AuthSecretName
+		credentialsSecretManaged = false
+		caName                   = v1beta1constants.SecretNameCASeed
+		gatewayName              = name
 	)
 
 	if p.values.IsGardenCluster {
 		credentialsSecretName = v1beta1constants.SecretNameObservabilityIngress
+		credentialsSecretManaged = true
 		caName = operatorv1alpha1.SecretNameCARuntime
 		gatewayName = fmt.Sprintf("%s%s-%s", operatorv1alpha1.VirtualGardenNamePrefix, gatewayName, v1beta1constants.GardenNamespace)
 	}
 
 	if p.values.ClusterType == component.ClusterTypeShoot {
 		credentialsSecretName = v1beta1constants.SecretNameObservabilityIngressUsers
+		credentialsSecretManaged = true
 		caName = v1beta1constants.SecretNameCACluster
 		gatewayName = fmt.Sprintf("%s-%s", gatewayName, p.namespace)
 	}
@@ -862,7 +865,7 @@ func (p *plutono) getIstioResources(ctx context.Context) ([]client.Object, error
 	virtualService := &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: p.namespace}}
 	if err := istio.VirtualServiceForTLSTermination(
 		virtualService,
-		utils.MergeStringMaps(getLabels(), istiobasicauthserver.BasicAuthLabels(p.values.IsGardenCluster, credentialsSecretName)),
+		utils.MergeStringMaps(getLabels(), istiobasicauthserver.BasicAuthLabels(p.values.IsGardenCluster, credentialsSecretName, credentialsSecretManaged)),
 		[]string{p.values.IstioIngressGatewayNamespace},
 		[]string{p.values.IngressHost},
 		gatewayName,

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -564,6 +564,13 @@ kind: VirtualService
 metadata:
   labels:
     component: plutono
+    reference.gardener.cloud/basic-auth-secret-managed: `
+				if values.IsGardenCluster || values.ClusterType == comp.ClusterTypeShoot {
+					out += `"true"`
+				} else {
+					out += `"false"`
+				}
+				out += `
     reference.gardener.cloud/basic-auth-secret-name: `
 				secretName := values.AuthSecretName
 				if values.IsGardenCluster {

--- a/pkg/component/shared/istiobasicauthserver.go
+++ b/pkg/component/shared/istiobasicauthserver.go
@@ -16,6 +16,7 @@ import (
 // NewIstioBasicAuthServer instantiates a new `istio-basic-auth-server` component.
 func NewIstioBasicAuthServer(
 	c client.Client,
+	apiReader client.Reader,
 	namespace string,
 	secretsManager secretsmanager.Interface,
 	enabled bool,
@@ -35,6 +36,7 @@ func NewIstioBasicAuthServer(
 
 	deployer = istiobasicauthserver.New(
 		c,
+		apiReader,
 		namespace,
 		secretsManager,
 		istiobasicauthserver.Values{

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -546,6 +546,7 @@ func (r *Reconciler) newDependencyWatchdogs(seedSettings *gardencorev1beta1.Seed
 func (r *Reconciler) newIstioBasicAuthServer(secretsManager secretsmanager.Interface, istioDefaultNamespace string) (component.DeployWaiter, error) {
 	return sharedcomponent.NewIstioBasicAuthServer(
 		r.SeedClientSet.Client(),
+		r.SeedClientSet.APIReader(),
 		r.GardenNamespace,
 		secretsManager,
 		gardenlethelper.IsMonitoringEnabled(&r.Config),

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -798,9 +798,7 @@ func (r *Reconciler) newAggregatePrometheus(
 	}
 
 	if globalMonitoringSecret != nil {
-		// The global monitoring secret is a verbatim replica and not managed by the secrets manager.
 		values.Ingress.AuthSecretName = globalMonitoringSecret.Name
-		values.Ingress.AuthSecretManaged = false
 	}
 
 	if wildcardCertSecret != nil {

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -797,7 +797,9 @@ func (r *Reconciler) newAggregatePrometheus(
 	}
 
 	if globalMonitoringSecret != nil {
+		// The global monitoring secret is a verbatim replica and not managed by the secrets manager.
 		values.Ingress.AuthSecretName = globalMonitoringSecret.Name
+		values.Ingress.AuthSecretManaged = false
 	}
 
 	if wildcardCertSecret != nil {

--- a/pkg/gardenlet/operation/botanist/istiobasicauthserver.go
+++ b/pkg/gardenlet/operation/botanist/istiobasicauthserver.go
@@ -19,6 +19,7 @@ func (b *Botanist) DefaultIstioBasicAuthServer() (component.DeployWaiter, error)
 
 	return shared.NewIstioBasicAuthServer(
 		b.SeedClientSet.Client(),
+		b.SeedClientSet.APIReader(),
 		b.Shoot.ControlPlaneNamespace,
 		b.SecretsManager,
 		b.WantsObservabilityComponents(),

--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -64,7 +64,7 @@ func (b *Botanist) DeployAlertManager(ctx context.Context) error {
 		return b.Shoot.Components.ControlPlane.Alertmanager.Destroy(ctx)
 	}
 
-	b.Shoot.Components.ControlPlane.Alertmanager.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngressUsers)
+	b.Shoot.Components.ControlPlane.Alertmanager.SetIngressAuthSecret(v1beta1constants.SecretNameObservabilityIngressUsers, true)
 	b.Shoot.Components.ControlPlane.Alertmanager.SetIngressWildcardCertSecret(b.ControlPlaneWildcardCert)
 
 	return b.Shoot.Components.ControlPlane.Alertmanager.Deploy(ctx)
@@ -182,7 +182,7 @@ func (b *Botanist) DeployPrometheus(ctx context.Context) error {
 		return fmt.Errorf("failed reconciling access secret for prometheus: %w", err)
 	}
 
-	b.Shoot.Components.ControlPlane.Prometheus.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngressUsers)
+	b.Shoot.Components.ControlPlane.Prometheus.SetIngressAuthSecret(v1beta1constants.SecretNameObservabilityIngressUsers, true)
 	b.Shoot.Components.ControlPlane.Prometheus.SetIngressWildcardCertSecret(b.ControlPlaneWildcardCert)
 	b.Shoot.Components.ControlPlane.Prometheus.SetNamespaceUID(b.SeedNamespaceObject.UID)
 

--- a/pkg/gardenlet/operation/botanist/monitoring_test.go
+++ b/pkg/gardenlet/operation/botanist/monitoring_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Monitoring", func() {
 
 		Context("deployment", func() {
 			It("should successfully deploy", func() {
-				alertManager.EXPECT().SetIngressAuthSecretName(ingressAuthSecret.Name)
+				alertManager.EXPECT().SetIngressAuthSecret(ingressAuthSecret.Name, true)
 				alertManager.EXPECT().SetIngressWildcardCertSecret(gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(s *corev1.Secret) {
 					Expect(s.Name).To(Equal(ingressWildcardSecret.Name))
 				})

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1091,6 +1091,7 @@ func (r *Reconciler) newNginxIngressController(garden *operatorv1alpha1.Garden, 
 func (r *Reconciler) newIstioBasicAuthServer(secretsManager secretsmanager.Interface, ingressGatewayValues []istio.IngressGatewayValues) (component.DeployWaiter, error) {
 	return sharedcomponent.NewIstioBasicAuthServer(
 		r.RuntimeClientSet.Client(),
+		r.RuntimeClientSet.APIReader(),
 		r.GardenNamespace,
 		secretsManager,
 		true,

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -702,7 +702,7 @@ func (r *Reconciler) reconcile(
 		deployAlertmanager = g.Add(flow.Task{
 			Name: "Deploying Alertmanager",
 			Fn: func(ctx context.Context) error {
-				c.alertManager.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngress)
+				c.alertManager.SetIngressAuthSecret(v1beta1constants.SecretNameObservabilityIngress, true)
 				return c.alertManager.Deploy(ctx)
 			},
 			Dependencies: flow.NewTaskIDs(generateObservabilityIngressPassword),
@@ -1197,7 +1197,7 @@ func (r *Reconciler) deployGardenPrometheus(ctx context.Context, prometheus prom
 		return fmt.Errorf("failed reconciling access secret for garden prometheus: %w", err)
 	}
 
-	prometheus.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngress)
+	prometheus.SetIngressAuthSecret(v1beta1constants.SecretNameObservabilityIngress, true)
 
 	// fetch global monitoring secret for prometheus-aggregate scrape config
 	globalMonitoringSecretRuntime, err := r.getGlobalObservabilitySecret(ctx)
@@ -1361,7 +1361,7 @@ func (r *Reconciler) deployGardenerDashboard(ctx context.Context, dashboard gard
 }
 
 func (r *Reconciler) deployLongTermPrometheus(ctx context.Context, prometheus prometheus.Interface) error {
-	prometheus.SetIngressAuthSecretName(v1beta1constants.SecretNameObservabilityIngress)
+	prometheus.SetIngressAuthSecret(v1beta1constants.SecretNameObservabilityIngress, true)
 	return prometheus.Deploy(ctx)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR is a follow up of https://github.com/gardener/gardener/pull/15329, which fixed a race condition between the GRM and the `gardener-operator` or the `gardenlet`.

During observability secrets rotation, the GRM updates `VirtualServices` with basic authentication to reference the new generated secret. However, the `gardener-operator` or the `gardenlet` might miss this update during the deployment of the `istio-basic-auth-server` component due to a stale client cache. The original PR fixed this issue by using the secrets manager as a source of truth instead of the client cache. It changed the secret reference in the `VirtualService` from verbatim to the secret name as in the secrets manager, i.e., without the hash suffix. Secrets not managed by the secrets manager were still referenced by their verbatim name, but they were not affected by the race condition because they were never rotated.

However, https://github.com/gardener/gardener/pull/15284 introduced rotation for the global observability ingress secret. This secret in the seeds is not managed by the secrets manager since it is a copy of the original secret in the virtual garden cluster. During the development of that PR, we were aware that this could activate the race condition for this secret, but we could never reproduce it in development environments. In consequence, we opted to keep the original race condition fix intact, rather than providing a speculative fix, until we could confirm the issue in a productive setup.

Well, we should have trusted our hunch :)

This PR attempts to fix the race condition when `VirtualServices` reference secrets verbatim by using an uncached client that reads directly from the API server. Since uncached clients are discouraged, the fix only triggers an API call when strictly necessary. For that, this PR introduces a new `reference.gardener.cloud/basic-auth-secret-managed` label for `VirtualServices` that indicates whether the referenced secret is managed by the secrets manager or not:

- If it is, the secrets manager is used as the source of truth, just as the first fix did. The difference is that an error is now returned if the secret is not found. Previously, a missing secret would fall back to using it verbatim. This also resolves the concerns expressed in [this comment](https://github.com/gardener/gardener/pull/15329#discussion_r3630473159) from the first PR.
- If it is not, the API call is performed as a metadata-only request to reduce the bytes sent over the wire.

In practice, this results in two API calls per seed during seed reconciliation to read the Plutono and aggregate Prometheus `VirtualServices` referencing the global observability ingress secret. There are no other secrets used for basic authentication that need to be used verbatim.

This PR acknowledges the fix is specific to the credential rotation use case. For example, similar race conditions could occur in other situations if the `spec` of a `VirtualService` was updated, but such scenarios do not exist today. This makes these fixes arguably a workaround. The proper solution would probably be that the `istio-basic-auth-server` is deployed by the GRM as part of each `ManagedResource` that contains a `VirtualService` with basic authentication. But this would be wasteful, because it would require deploying multiple `istio-basic-auth-server` instances when a single one suffices. The fix proposed by this PR sits in between and is, in our opinion, an acceptable trade-off.

**Special notes for your reviewer**:

/cc @ScheererJ 

**Release note**:

```bugfix operator
A sporadic issue with stale secrets in the `istio-basic-auth-server` after rotation of verbatim secrets has been fixed.
```
