### PR TITLE
Enhance VictoriaLogs pipeline in the OpenTelemetry collector

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -535,7 +535,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 						"otlphttp/victorialogs": map[string]any{
 							"logs_endpoint": "http://" + victorialogsconstants.ServiceName + ":" + strconv.Itoa(victorialogsconstants.VictoriaLogsPort) + victorialogsconstants.PushEndpoint,
 							"headers": map[string]any{
-								"VL-Stream-Fields": "host.name,k8s.node.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,k8s.deployment.name,k8s.daemonset.name,k8s.statefulset.name,severity,unit,origin",
+								"VL-Stream-Fields": "host.name,k8s.node.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,k8s.deployment.name,k8s.daemonset.name,k8s.statefulset.name,severity,unit,origin,service.name",
 							},
 						},
 					},

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -535,7 +535,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 						"otlphttp/victorialogs": map[string]any{
 							"logs_endpoint": "http://" + victorialogsconstants.ServiceName + ":" + strconv.Itoa(victorialogsconstants.VictoriaLogsPort) + victorialogsconstants.PushEndpoint,
 							"headers": map[string]any{
-								"VL-Stream-Fields": "host.name,k8s.node.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,k8s.deployment.name,k8s.daemonset.name,k8s.statefulset.name,severity,unit,origin,service.name",
+								"VL-Stream-Fields": "host.name,k8s.node.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,k8s.deployment.name,k8s.daemonset.name,k8s.statefulset.name,severity,unit,origin,service.name,job",
 							},
 						},
 					},

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -595,6 +595,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 				"otlp",
 			},
 			Processors: []string{
+				"memory_limiter",
 				"batch",
 			},
 		}

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -429,7 +429,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 							"otlphttp/victorialogs": map[string]any{
 								"logs_endpoint": "http://logging-vl:9428/insert/opentelemetry/v1/logs",
 								"headers": map[string]any{
-									"VL-Stream-Fields": "host.name,k8s.node.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,k8s.deployment.name,k8s.daemonset.name,k8s.statefulset.name,severity,unit,origin,service.name",
+									"VL-Stream-Fields": "host.name,k8s.node.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,k8s.deployment.name,k8s.daemonset.name,k8s.statefulset.name,severity,unit,origin,service.name,job",
 								},
 							},
 						},

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -755,7 +755,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			openTelemetryCollector.Spec.Config.Service.Pipelines["logs/victorialogs"] = &otelv1beta1.Pipeline{
 				Exporters:  []string{"otlphttp/victorialogs"},
 				Receivers:  []string{"otlp"},
-				Processors: []string{"batch"},
+				Processors: []string{"memory_limiter", "batch"},
 			}
 
 			Expect(customResourcesManagedResource).To(consistOf(

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -429,7 +429,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 							"otlphttp/victorialogs": map[string]any{
 								"logs_endpoint": "http://logging-vl:9428/insert/opentelemetry/v1/logs",
 								"headers": map[string]any{
-									"VL-Stream-Fields": "host.name,k8s.node.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,k8s.deployment.name,k8s.daemonset.name,k8s.statefulset.name,severity,unit,origin",
+									"VL-Stream-Fields": "host.name,k8s.node.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,k8s.deployment.name,k8s.daemonset.name,k8s.statefulset.name,severity,unit,origin,service.name",
 								},
 							},
 						},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Adding `service.name` seems like its worth it, because it is populated for systemd journal logs and groups per-unit logs into separate streams, improving compression and reducing stream churn on nodes. For the same reasons `job` is also added.

Adding `memory limiter` processor to the `VictoriaLogs` pipeline makes sure that it does not consume all available memory without setting a hard cgroup limit. In regards to the `VPA`, when the `memory limiter` is activated and starts dropping logs it reduces the resource consumption which will prevent the `VPA` from scaling it.  The `memory limiter` threshold is currently set to 3000 MiB - a value that is almost certainly never reached in practice.

**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardener/observability/issues/96
https://github.com/gardener/observability/issues/97

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add `memory limiter` processor to the `VictoriaLogs` pipeline.
Add `service.name` and `job` to the `VictoriaLogs` stream headers of the `OpenTelemetry` exporter.
```
