### PR TITLE
Add `events.k8s.io/events` to etcd server override

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -3192,7 +3192,7 @@ kind: AuthorizationConfiguration
 						"--etcd-certfile=/srv/kubernetes/etcd/client/tls.crt",
 						"--etcd-keyfile=/srv/kubernetes/etcd/client/tls.key",
 						"--etcd-servers=https://etcd-main-client:2379",
-						"--etcd-servers-overrides=/events#https://etcd-events-client:2379",
+						"--etcd-servers-overrides=/events#https://etcd-events-client:2379,events.k8s.io/events#https://etcd-events-client:2379",
 						"--encryption-provider-config=/etc/kubernetes/etcd-encryption-secret/encryption-configuration.yaml",
 						"--event-ttl="+eventTTL.String(),
 						"--tls-min-version="+tlsMinVersion,
@@ -3707,7 +3707,7 @@ anonymous:
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
-						"--etcd-servers-overrides=networking.k8s.io/networkpolicies#https://etcd-events-client:2379,/events#https://etcd-events-client:2379,apps/daemonsets#https://etcd-events-client:2379",
+						"--etcd-servers-overrides=events.k8s.io/events#https://etcd-events-client:2379,networking.k8s.io/networkpolicies#https://etcd-events-client:2379,/events#https://etcd-events-client:2379,apps/daemonsets#https://etcd-events-client:2379",
 					))
 				})
 
@@ -3724,7 +3724,7 @@ anonymous:
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
 						"--etcd-servers=https://localhost:2379",
-						"--etcd-servers-overrides=/events#https://localhost:2382",
+						"--etcd-servers-overrides=/events#https://localhost:2382,events.k8s.io/events#https://localhost:2382",
 					))
 				})
 

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -489,8 +489,11 @@ func (k *kubeAPIServer) etcdServersOverrides() string {
 		hostName, port = "localhost", etcdconstants.StaticPodPortEtcdEventsClient
 	}
 
+	groupResources := addGroupResourceIfNotPresent(k.values.ResourcesToStoreInETCDEvents, schema.GroupResource{Group: "events.k8s.io", Resource: "events"})
+	groupResources = addGroupResourceIfNotPresent(groupResources, schema.GroupResource{Resource: "events"})
+
 	var overrides []string
-	for _, res := range addGroupResourceIfNotPresent(k.values.ResourcesToStoreInETCDEvents, schema.GroupResource{Resource: "events"}) {
+	for _, res := range groupResources {
 		overrides = append(overrides, fmt.Sprintf("%s/%s#https://%s:%d", res.Group, res.Resource, hostName, port))
 	}
 	return strings.Join(overrides, ",")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Adds the server override for `events.k8s.io/events` in addition to the `/events` API group.

This change is purely for completeness. The Kube API server already handles events from both API groups through a single /events override, so the previous configuration was not incorrect.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke @ialidzhikov @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `events.k8s.io/events` override for the `etcd-events` instance is now explicitly configured in Kube API server deployments, alongside the the already existing `/events` override.
```
