### PR TITLE
Finalizer stuck shoot deletion

### DIFF
--- a/pkg/controller/reference/add.go
+++ b/pkg/controller/reference/add.go
@@ -26,6 +26,10 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, name string) error {
 		r.Client = mgr.GetClient()
 	}
 
+	if r.Recorder == nil {
+		r.Recorder = mgr.GetEventRecorder(name + controllerNameSuffix)
+	}
+
 	return builder.
 		ControllerManagedBy(mgr).
 		Named(name+controllerNameSuffix).

--- a/pkg/controller/reference/reconciler.go
+++ b/pkg/controller/reference/reconciler.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -39,6 +40,7 @@ type Reconciler struct {
 	GetReferencedConfigMapNames        func(client.Object) []string
 	GetReferencedWorkloadIdentityNames func(client.Object) []string
 	ReferenceChangedPredicate          func(oldObj, newObj client.Object) bool
+	Recorder                           events.EventRecorder
 }
 
 // Reconcile performs the check.
@@ -85,6 +87,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		if controllerutil.ContainsFinalizer(obj, v1beta1constants.ReferenceProtectionFinalizerName) {
 			log.Info("Removing finalizer")
 			if err := controllerutils.RemoveFinalizers(ctx, r.Client, obj, v1beta1constants.ReferenceProtectionFinalizerName); err != nil {
+				r.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
 				return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
 			}
 		}
@@ -123,6 +126,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	if !needsFinalizer && hasFinalizer {
 		log.Info("Removing finalizer")
 		if err := controllerutils.RemoveFinalizers(ctx, r.Client, obj, v1beta1constants.ReferenceProtectionFinalizerName); err != nil {
+			r.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
 			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
 		}
 	}
@@ -183,6 +187,7 @@ func (r *Reconciler) releaseUnreferencedResources(
 			if controllerutil.ContainsFinalizer(obj, v1beta1constants.ReferenceProtectionFinalizerName) {
 				log.Info("Removing finalizer from object", "kind", obj.GetObjectKind().GroupVersionKind().Kind, "obj", client.ObjectKeyFromObject(obj))
 				if err := controllerutils.RemoveFinalizers(ctx, r.Client, obj, v1beta1constants.ReferenceProtectionFinalizerName); err != nil {
+					r.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
 					return fmt.Errorf("failed to remove finalizer from %s %s: %w", obj.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(obj), err)
 				}
 			}

--- a/pkg/controllermanager/controller/credentialsbinding/reconciler.go
+++ b/pkg/controllermanager/controller/credentialsbinding/reconciler.go
@@ -94,6 +94,7 @@ func (r *Reconciler) reconcile(ctx context.Context, credentialsBinding *security
 	if controllerutil.ContainsFinalizer(credential, gardencorev1beta1.ExternalGardenerName) {
 		log.Info("Removing finalizer", "finalizer", gardencorev1beta1.ExternalGardenerName, kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
 		if err := controllerutils.RemoveFinalizers(ctx, r.Client, credential, gardencorev1beta1.ExternalGardenerName); err != nil {
+			r.Recorder.Eventf(credential, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
 			return fmt.Errorf("could not remove finalizer from %s: %w", kind, err)
 		}
 	}
@@ -175,6 +176,7 @@ func (r *Reconciler) delete(ctx context.Context, credentialsBinding *securityv1a
 		if controllerutil.ContainsFinalizer(credential, gardencorev1beta1.ExternalGardenerName) {
 			log.Info("Removing finalizer", "finalizer", gardencorev1beta1.ExternalGardenerName, kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
 			if err := controllerutils.RemoveFinalizers(ctx, r.Client, credential, gardencorev1beta1.ExternalGardenerName); err != nil {
+				r.Recorder.Eventf(credential, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
 				return fmt.Errorf("failed to remove finalizer from %s: %w", kind, err)
 			}
 		}
@@ -221,6 +223,7 @@ func (r *Reconciler) delete(ctx context.Context, credentialsBinding *securityv1a
 		if controllerutil.ContainsFinalizer(credential, finalizerName) {
 			log.Info("Removing finalizer", "finalizer", finalizerName, kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
 			if err := controllerutils.RemoveFinalizers(ctx, r.Client, credential, finalizerName); err != nil {
+				r.Recorder.Eventf(credential, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
 				return fmt.Errorf("failed to remove finalizer from %s: %w", kind, err)
 			}
 		}
@@ -233,6 +236,7 @@ func (r *Reconciler) delete(ctx context.Context, credentialsBinding *securityv1a
 	// Remove finalizer from CredentialsBinding
 	log.Info("Removing finalizer")
 	if err := controllerutils.RemoveFinalizers(ctx, r.Client, credentialsBinding, gardencorev1beta1.GardenerName); err != nil {
+		r.Recorder.Eventf(credential, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
 		return fmt.Errorf("failed to remove finalizer: %w", err)
 	}
 

--- a/pkg/controllermanager/controller/credentialsbinding/reconciler.go
+++ b/pkg/controllermanager/controller/credentialsbinding/reconciler.go
@@ -236,7 +236,7 @@ func (r *Reconciler) delete(ctx context.Context, credentialsBinding *securityv1a
 	// Remove finalizer from CredentialsBinding
 	log.Info("Removing finalizer")
 	if err := controllerutils.RemoveFinalizers(ctx, r.Client, credentialsBinding, gardencorev1beta1.GardenerName); err != nil {
-		r.Recorder.Eventf(credential, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
+		r.Recorder.Eventf(credentialsBinding, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
 		return fmt.Errorf("failed to remove finalizer: %w", err)
 	}
 

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
@@ -69,6 +69,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			if controllerutil.ContainsFinalizer(namespacedCloudProfile, gardencorev1beta1.GardenerName) {
 				log.Info("Removing finalizer")
 				if err := controllerutils.RemoveFinalizers(ctx, r.Client, namespacedCloudProfile, gardencorev1beta1.GardenerName); err != nil {
+					r.Recorder.Eventf(namespacedCloudProfile, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
 					return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
 				}
 			}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -510,7 +510,9 @@ func (r *Reconciler) removeFinalizerFromShoot(ctx context.Context, log logr.Logg
 	if controllerutil.ContainsFinalizer(shoot, gardencorev1beta1.GardenerName) {
 		log.Info("Removing finalizer")
 		if err := controllerutils.RemoveFinalizers(ctx, r.GardenClient, shoot, gardencorev1beta1.GardenerName); err != nil {
-			return fmt.Errorf("failed to remove finalizer: %w", err)
+			updateErr := r.patchShootStatusOperationError(ctx, shoot, err.Error(), operationType, false, shoot.Status.LastErrors...)
+			r.Recorder.Eventf(shoot, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
+			return errorsutils.WithSuppressed(fmt.Errorf("failed to remove finalizer: %w", err), updateErr)
 		}
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -503,6 +503,7 @@ func (r *Reconciler) deleteClusterResourceFromSeed(ctx context.Context, shoot *g
 func (r *Reconciler) removeFinalizerFromShoot(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) error {
 	operationType := gardencorev1beta1.LastOperationTypeDelete
 
+	// this is necessary because the finalizerremoval admission plugin checks the status
 	if err := r.patchShootStatusOperationSuccess(ctx, shoot, operationType); err != nil {
 		return err
 	}
@@ -510,9 +511,8 @@ func (r *Reconciler) removeFinalizerFromShoot(ctx context.Context, log logr.Logg
 	if controllerutil.ContainsFinalizer(shoot, gardencorev1beta1.GardenerName) {
 		log.Info("Removing finalizer")
 		if err := controllerutils.RemoveFinalizers(ctx, r.GardenClient, shoot, gardencorev1beta1.GardenerName); err != nil {
-			updateErr := r.patchShootStatusOperationError(ctx, shoot, err.Error(), operationType, false, shoot.Status.LastErrors...)
 			r.Recorder.Eventf(shoot, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, "failed to remove finalizer: %v", err)
-			return errorsutils.WithSuppressed(fmt.Errorf("failed to remove finalizer: %w", err), updateErr)
+			return fmt.Errorf("failed to remove finalizer: %w", err)
 		}
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_test.go
@@ -6,16 +6,21 @@ package shoot
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -252,6 +257,57 @@ var _ = Describe("Reconciler", func() {
 			Expect(shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.UTC()).To(Equal(fakeClock.Now()))
 			Expect(shoot.Status.Credentials.Rotation.ServiceAccountKey.Phase).To(Equal(gardencorev1beta1.RotationPrepared))
 			Expect(shoot.Status.Credentials.Rotation.ServiceAccountKey.LastInitiationFinishedTime.UTC()).To(Equal(fakeClock.Now()))
+		})
+	})
+
+	Describe("#removeFinalizerFromShoot", func() {
+		BeforeEach(func() {
+			gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithStatusSubresource(&gardencorev1beta1.Shoot{}).Build()
+
+			seedClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+			seedClientSet = fakekubernetes.NewClientSetBuilder().WithClient(seedClient).Build()
+
+			fakeDateAndTime, _ := time.Parse(time.DateTime, "2024-05-14 19:59:39")
+			fakeClock = testclock.NewFakeClock(fakeDateAndTime)
+
+			reconciler = &Reconciler{
+				GardenClient:  gardenClient,
+				SeedClientSet: seedClientSet,
+				Clock:         fakeClock,
+			}
+
+			deletionTimestamp := metav1.NewTime(fakeClock.Now())
+			shoot.DeletionTimestamp = &deletionTimestamp
+			shoot.Finalizers = []string{gardencorev1beta1.GardenerName}
+		})
+
+		It("should emit an event and return the error if the finalizer removal fails", func() {
+			fakeRecorder := &events.FakeRecorder{Events: make(chan string, 1)}
+
+			gardenClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithStatusSubresource(&gardencorev1beta1.Shoot{}).
+				WithInterceptorFuncs(interceptor.Funcs{
+					// Let the status patch ('Delete Succeeded') through, but fail the subsequent finalizer removal
+					// (a merge patch on the Shoot's metadata) to exercise the failure path.
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if _, ok := obj.(*gardencorev1beta1.Shoot); ok && patch.Type() == types.MergePatchType {
+							return fmt.Errorf("fake patch error")
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			reconciler.GardenClient = gardenClient
+			reconciler.Recorder = fakeRecorder
+
+			Expect(gardenClient.Create(ctx, shoot)).To(Succeed())
+
+			err := reconciler.removeFinalizerFromShoot(ctx, logr.Discard(), shoot)
+			Expect(err).To(MatchError(ContainSubstring("failed to remove finalizer")))
+
+			Eventually(fakeRecorder.Events).Should(Receive(ContainSubstring("failed to remove finalizer")))
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
In the issue linked below, a shoot got stuck at 'Delete Succeeded (100%)' after a user removed a DNS secret during deletion.

`kubectl describe shoot` did not give any useful information about why it got stuck.

This PR improves error surfacing for shoots stuck in deletion while failing to remove finalizers.
- If the gardenlet fails to remove the `gardener` finalizer or the shoot reference controller fails to remove the `gardener.cloud/reference-protection` finalizer, we emit an event.

However, changing the shoot status from 'Delete Succeeded (100%)' to an error is not done in this PR, as it has some unintended consequences. First, there is currently no precedent for any other controller except the gardenlet changing the shoot status, thus e.g. for the shoot reference controller, we do not want to change the shoot status if finalizer removal fails. Secondly, a few places in the code currently depend on the status going to 'Delete Succeeded (100%)' right before finalizer removal, most notably the finalizerremoval admission plugin.

**Which issue(s) this PR fixes**:
Improves error surfacing for Issue #15465

**Special notes for your reviewer**:
Root cause of the problem (that users can delete finalizers) will be fixed in another PR.

There are quite a few places where failure to remove a finalizer does not lead to an event being emitted. Should that be done in general, or is it fine like this?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```