### PR TITLE
`coredns` fine tuning with regards to minimum memory requests and maximum amount of replicas

### DIFF
--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -104,6 +104,8 @@ type Values struct {
 	SearchPathRewriteCommonSuffixes []string
 	// IPFamilies specifies the IP protocol versions to use for core dns.
 	IPFamilies []gardencorev1beta1.IPFamily
+	// Zones specifies the number of availability zones of the shoot cluster.
+	Zones int32
 }
 
 // New creates a new instance of DeployWaiter for coredns.
@@ -727,7 +729,7 @@ import custom/*.server
 			},
 			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 				MinReplicas: new(int32(2)),
-				MaxReplicas: 5,
+				MaxReplicas: max(5, 2*c.values.Zones),
 				Metrics: []autoscalingv2.MetricSpec{{
 					Type: autoscalingv2.ResourceMetricSourceType,
 					Resource: &autoscalingv2.ResourceMetricSource{

--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -502,7 +502,7 @@ import custom/*.server
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("50m"),
-									corev1.ResourceMemory: resource.MustParse("15Mi"),
+									corev1.ResourceMemory: resource.MustParse("25Mi"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{

--- a/pkg/component/networking/coredns/coredns_test.go
+++ b/pkg/component/networking/coredns/coredns_test.go
@@ -6,6 +6,7 @@ package coredns_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"regexp"
 	"strings"
@@ -414,7 +415,8 @@ status:
   expectedPods: 0
 `
 
-		hpaYAML = `apiVersion: autoscaling/v2
+		hpaYAML = func(zones int) string {
+			return `apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
@@ -422,7 +424,7 @@ metadata:
   name: coredns
   namespace: kube-system
 spec:
-  maxReplicas: 5
+  maxReplicas: ` + fmt.Sprintf("%d", max(5, 2*zones)) + `
   metrics:
   - resource:
       name: cpu
@@ -439,6 +441,7 @@ status:
   currentMetrics: null
   desiredReplicas: 0
 `
+		}
 
 		cpasaYAML = `apiVersion: v1
 automountServiceAccountToken: false
@@ -801,7 +804,7 @@ status: {}
 				))
 			}
 			if !cpaEnabled {
-				Expect(manifests).To(ContainElement(hpaYAML))
+				Expect(manifests).To(ContainElement(hpaYAML(int(values.Zones))))
 			}
 
 			actualScrapeConfig := &monitoringv1alpha1.ScrapeConfig{}
@@ -905,6 +908,26 @@ status: {}
 				It("should successfully deploy all resources", func() {
 					Expect(manifests).To(ContainElement(serviceYAML(string(GetIPFamilyPolicy(values.IPFamilies, values.ClusterIPs)))))
 				})
+			})
+		})
+
+		Context("with single availability zone", func() {
+			BeforeEach(func() {
+				values.Zones = 1
+			})
+
+			It("should successfully deploy all resources", func() {
+				Expect(manifests).To(ContainElement(hpaYAML(int(values.Zones))))
+			})
+		})
+
+		Context("with three availability zones", func() {
+			BeforeEach(func() {
+				values.Zones = 3
+			})
+
+			It("should successfully deploy all resources", func() {
+				Expect(manifests).To(ContainElement(hpaYAML(int(values.Zones))))
 			})
 		})
 	})

--- a/pkg/component/networking/coredns/coredns_test.go
+++ b/pkg/component/networking/coredns/coredns_test.go
@@ -350,7 +350,7 @@ spec:
         resources:
           requests:
             cpu: 50m
-            memory: 15Mi
+            memory: 25Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/gardenlet/operation/botanist/coredns.go
+++ b/pkg/gardenlet/operation/botanist/coredns.go
@@ -13,6 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
@@ -36,6 +37,13 @@ func (b *Botanist) DefaultCoreDNS() (coredns.Interface, error) {
 		return nil, err
 	}
 
+	zones := sets.New[string]()
+	for _, pool := range b.Shoot.GetInfo().Spec.Provider.Workers {
+		if v1beta1helper.SystemComponentsAllowed(&pool) && pool.Maximum > 0 {
+			zones.Insert(pool.Zones...)
+		}
+	}
+
 	values := coredns.Values{
 		// resolve conformance test issue (https://github.com/kubernetes/kubernetes/blob/master/test/e2e/network/dns.go#L44)
 		// before changing
@@ -43,6 +51,7 @@ func (b *Botanist) DefaultCoreDNS() (coredns.Interface, error) {
 		Image:                           image.String(),
 		AutoscalingMode:                 gardencorev1beta1.CoreDNSAutoscalingModeHorizontal,
 		SearchPathRewriteCommonSuffixes: getCommonSuffixesForRewriting(b.Shoot.GetInfo().Spec.SystemComponents),
+		Zones:                           int32(len(zones)), // #nosec G115 -- `len(zones)` cannot be higher than max int32. Zones come from shoot spec and there is a validation that there cannot be more zones than worker.Maximum which is int32.
 		// Pod/node network CIDRs and cluster IPs are set on deployment to handle dynamic network CIDRs
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/area high-availability
/area networking
/area robustness
/kind enhancement

**What this PR does / why we need it**:

`coredns` and `go` as the language runtime have grown over the years so that the minimum memory requests for `coredns` are no longer realistic even for very small clusters without any load. This change increases the minimum memory requests slightly to be closer to reality (`15Mi` => `25Mi`).

Furthermore, the maximum number of replicas was set to `5` previously. This was mandated as we did not see even load distribution after the first few replicas.
However, this does not fit well to a multi-availability zone setup. For example, in a standard 3-availability-zone setup there will always be one zone without only a single `coredns` replica.
This change improves the situation by increasing the maximum to the higher one of twice of the number of usable availability zones or `5`. As a result, a 3-availability-zone setup will get up to `6` `coredns` replicas.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Minimum memory request for `coredns` was increased and the maximum amount of replica can now go beyond `5` to twice the number of availability zones.
```

/cc @axel7born