### PR TITLE
Fix duplicate `host.name` log attribute to prevent VictoriaLogs v1.52.0 from panic

### DIFF
--- a/pkg/component/observability/logging/fluentbit/lua/add_time_and_systemd_attr.lua
+++ b/pkg/component/observability/logging/fluentbit/lua/add_time_and_systemd_attr.lua
@@ -16,7 +16,6 @@ function add_time_and_systemd_attr(tag, timestamp, record)
   new_record["process.command"] = record["_EXE"]
   new_record["process.command_line"] = record["_CMDLINE"]
   new_record["process.pid"] = record["_PID"]
-  new_record["host.name"] = record["_HOSTNAME"]
   new_record["host.id"] = record["_MACHINE_ID"]
   new_record["service.name"] = record["_SYSTEMD_UNIT"]
   new_record["service.namespace"] = record["_SYSTEMD_SLICE"]

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -465,7 +465,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 								},
 								map[string]any{
 									"key":    "loki.resource.labels",
-									"value":  "job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role",
+									"value":  "job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role, host.name",
 									"action": "insert",
 								},
 								map[string]any{
@@ -499,7 +499,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 								},
 								map[string]any{
 									"key":    "loki.attribute.labels",
-									"value":  "priority, level, process.command, process.pid, host.name, host.id, service.name, service.namespace, job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role",
+									"value":  "priority, level, process.command, process.pid, host.id, service.name, service.namespace, job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role",
 									"action": "upsert",
 								},
 								map[string]any{

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -359,7 +359,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 									},
 									map[string]any{
 										"key":    "loki.resource.labels",
-										"value":  "job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role",
+										"value":  "job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role, host.name",
 										"action": "insert",
 									},
 									map[string]any{
@@ -393,7 +393,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 									},
 									map[string]any{
 										"key":    "loki.attribute.labels",
-										"value":  "priority, level, process.command, process.pid, host.name, host.id, service.name, service.namespace, job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role",
+										"value":  "priority, level, process.command, process.pid, host.id, service.name, service.namespace, job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role",
 										"action": "upsert",
 									},
 									map[string]any{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind bug

**What this PR does / why we need it**:
As stated in https://github.com/gardener/gardener/pull/15382, `VictoriaLogs` v1.52.0 changed its `OTLP `ingestion to scan both resource attributes and log record attributes when resolving `VL-Stream-Fields`. This exposed a pre-existing duplicate: `host.name` was arriving in both places on the systemd journal log path. The gardener fluent-bit output plugin already sets `host.name` as a resource attribute. The Lua copy is therefore redundant. 

Moving `host.name` from `loki.attribute.labels` to `loki.resource.labels` in the seed `OpenTelemetry` collector so `Vali` continues receiving it as a label, now correctly sourced from the resource attribute instead of the log record attribute.

**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardener/observability/issues/99

**Special notes for your reviewer**:
/cc @rrhubenov 
/cc @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
