### PR TITLE
[GEP-28] Activate `Shoot` controller flow tasks for self-hosted shoots

### DIFF
--- a/dev-setup/gardenadm/resources/base/shoot.yaml
+++ b/dev-setup/gardenadm/resources/base/shoot.yaml
@@ -3,6 +3,8 @@ kind: Shoot
 metadata:
   name: root
   namespace: garden
+  annotations:
+    shoot.gardener.cloud/cloud-config-execution-max-delay-seconds: "0"
 spec:
   cloudProfile:
     kind: CloudProfile

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -72,6 +72,8 @@ var (
 		core.AlwaysVerify,
 	)
 	availableShootOperations = sets.New(
+		v1beta1constants.SeedOperationRenewGardenAccessSecrets,
+		v1beta1constants.SeedOperationRenewWorkloadIdentityTokens,
 		v1beta1constants.ShootOperationMaintain,
 		v1beta1constants.ShootOperationRetry,
 		v1beta1constants.ShootOperationForceInPlaceUpdate,
@@ -107,8 +109,11 @@ var (
 		v1beta1constants.OperationRotateETCDEncryptionKey,
 		v1beta1constants.OperationRotateETCDEncryptionKeyStart,
 	)
-	availableShootOperationsToRunInParallel = availableShootMaintenanceOperations
-	incompatibleShootOperations             = map[string][]string{
+	availableShootOperationsToRunInParallel = availableShootMaintenanceOperations.Union(sets.New(
+		v1beta1constants.SeedOperationRenewGardenAccessSecrets,
+		v1beta1constants.SeedOperationRenewWorkloadIdentityTokens,
+	))
+	incompatibleShootOperations = map[string][]string{
 		v1beta1constants.OperationRotateCredentialsStart: {
 			v1beta1constants.OperationRotateCAStartWithoutWorkersRollout,
 			v1beta1constants.OperationRotateServiceAccountKeyStartWithoutWorkersRollout,

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -411,6 +411,7 @@ const (
 	// name labels on nodes for self-hosted shoot clusters after the shoot gardenlet takes over reconciliation from
 	// gardenadm init.
 	ShootTaskUpdateGardenerNodeAgentSecretName = "updateGardenerNodeAgentSecretName"
+
 	// ShootOperationMaintain is a constant for an annotation on a Shoot indicating that the Shoot maintenance shall be
 	// executed as soon as possible.
 	ShootOperationMaintain = "maintain"

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -135,7 +135,9 @@ func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
 					v1beta1constants.OperationRotateETCDEncryptionKey,
 					v1beta1constants.OperationRotateETCDEncryptionKeyStart,
 					v1beta1constants.OperationRotateETCDEncryptionKeyComplete,
-					v1beta1constants.OperationRotateObservabilityCredentials:
+					v1beta1constants.OperationRotateObservabilityCredentials,
+					v1beta1constants.SeedOperationRenewGardenAccessSecrets,
+					v1beta1constants.SeedOperationRenewWorkloadIdentityTokens:
 					// We don't want to remove the annotation so that the gardenlet can pick it up and perform
 					// the rotation. It has to remove the annotation after it is done.
 					mustIncrease = true

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -880,9 +880,15 @@ func (e *etcd) Snapshot(ctx context.Context, httpClient rest.HTTPClient) error {
 		return fmt.Errorf("no backup is configured for this etcd, cannot make a snapshot")
 	}
 
-	url := fmt.Sprintf("https://%s%s.%s:%d/snapshot/full?final=true", e.values.NamePrefix, etcdconstants.ServiceName(e.values.Role), e.namespace, etcdconstants.PortBackupRestore)
+	address := fmt.Sprintf("%s%s.%s", e.values.NamePrefix, etcdconstants.ServiceName(e.values.Role), e.namespace)
+	if e.values.StaticPodConfig != nil {
+		if len(e.values.StaticPodConfig.ControlPlaneNodesIPAddresses) < 1 {
+			return fmt.Errorf("no static pod nodes IP addresses are configured for this etcd")
+		}
+		address = e.values.StaticPodConfig.ControlPlaneNodesIPAddresses[0].String()
+	}
 
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s:%d/snapshot/full?final=true", address, etcdconstants.PortBackupRestore), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -98,6 +99,10 @@ type Interface interface {
 	// RolloutPeerCA gets the peer CA and patches the
 	// related `etcd` resource to use this new CA for peer communication.
 	RolloutPeerCA(context.Context) error
+	// IsPeerCARolledOut checks if the Etcd resource was annotated with credentials.gardener.cloud/peer-ca-rolled-out.
+	IsPeerCARolledOut(context.Context) (bool, error)
+	// MarkAsPeerCARolloutCompleted annotates the Etcd resources with credentials.gardener.cloud/peer-ca-rolled-out=true.
+	MarkAsPeerCARolloutCompleted(context.Context) error
 	// GetValues returns the current configuration values of the deployer.
 	GetValues() Values
 	// GetReplicas gets the Replicas field in the Values.
@@ -979,6 +984,25 @@ func (e *etcd) RolloutPeerCA(ctx context.Context) error {
 	}
 
 	return e.Wait(ctx)
+}
+
+func (e *etcd) IsPeerCARolledOut(ctx context.Context) (bool, error) {
+	if err := e.client.Get(ctx, client.ObjectKeyFromObject(e.etcd), e.etcd); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+	return e.etcd.Annotations[secretsrotation.AnnotationKeyPeerCARolledOut] == "true", nil
+}
+
+func (e *etcd) MarkAsPeerCARolloutCompleted(ctx context.Context) error {
+	if err := e.client.Get(ctx, client.ObjectKeyFromObject(e.etcd), e.etcd); err != nil {
+		return err
+	}
+
+	patch := client.MergeFrom(e.etcd.DeepCopy())
+	metav1.SetMetaDataAnnotation(&e.etcd.ObjectMeta, secretsrotation.AnnotationKeyPeerCARolledOut, "true")
+	return e.client.Patch(ctx, e.etcd, patch)
 }
 
 func (e *etcd) GetValues() Values { return e.values }

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -43,6 +43,7 @@ import (
 	componenttest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/gardener/secretsrotation"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
@@ -2031,6 +2032,104 @@ var _ = Describe("Etcd", func() {
 			It("should fail because CA cannot be found", func() {
 				Expect(etcd.RolloutPeerCA(ctx)).To(MatchError("secret \"ca-etcd-peer\" not found"))
 			})
+		})
+	})
+
+	Describe("#IsPeerCARolledOut", func() {
+		It("should return false when the etcd resource does not exist", func() {
+			rolledOut, err := etcd.IsPeerCARolledOut(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rolledOut).To(BeFalse())
+		})
+
+		It("should return false when the annotation is absent", func() {
+			Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace}})).To(Succeed())
+
+			rolledOut, err := etcd.IsPeerCARolledOut(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rolledOut).To(BeFalse())
+		})
+
+		It("should return false when the annotation is set to a value other than \"true\"", func() {
+			Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{
+				Name:        etcdName,
+				Namespace:   testNamespace,
+				Annotations: map[string]string{secretsrotation.AnnotationKeyPeerCARolledOut: "false"},
+			}})).To(Succeed())
+
+			rolledOut, err := etcd.IsPeerCARolledOut(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rolledOut).To(BeFalse())
+		})
+
+		It("should return true when the annotation is set to \"true\"", func() {
+			Expect(c.Create(ctx, &druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{
+				Name:        etcdName,
+				Namespace:   testNamespace,
+				Annotations: map[string]string{secretsrotation.AnnotationKeyPeerCARolledOut: "true"},
+			}})).To(Succeed())
+
+			rolledOut, err := etcd.IsPeerCARolledOut(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rolledOut).To(BeTrue())
+		})
+
+		It("should return an error when the client Get fails", func() {
+			c = fakeclient.NewClientBuilder().WithScheme(c.Scheme()).WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return fakeErr
+				},
+			}).Build()
+			etcd = New(log, c, testNamespace, sm, Values{Role: role, Class: class, Replicas: replicas, PriorityClassName: priorityClassName})
+
+			_, err := etcd.IsPeerCARolledOut(ctx)
+			Expect(err).To(MatchError(fakeErr))
+		})
+	})
+
+	Describe("#MarkAsPeerCARolloutCompleted", func() {
+		It("should return a not-found error when the etcd resource does not exist", func() {
+			Expect(etcd.MarkAsPeerCARolloutCompleted(ctx)).To(BeNotFoundError())
+		})
+
+		It("should patch the annotation when the etcd resource exists and annotation is absent", func() {
+			existingEtcd := &druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace}}
+			Expect(c.Create(ctx, existingEtcd)).To(Succeed())
+
+			Expect(etcd.MarkAsPeerCARolloutCompleted(ctx)).To(Succeed())
+
+			updated := &druidcorev1alpha1.Etcd{}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(existingEtcd), updated)).To(Succeed())
+			Expect(updated.Annotations).To(HaveKeyWithValue(secretsrotation.AnnotationKeyPeerCARolledOut, "true"))
+		})
+
+		It("should be idempotent when annotation is already set to \"true\"", func() {
+			existingEtcd := &druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{
+				Name:        etcdName,
+				Namespace:   testNamespace,
+				Annotations: map[string]string{secretsrotation.AnnotationKeyPeerCARolledOut: "true"},
+			}}
+			Expect(c.Create(ctx, existingEtcd)).To(Succeed())
+
+			Expect(etcd.MarkAsPeerCARolloutCompleted(ctx)).To(Succeed())
+
+			updated := &druidcorev1alpha1.Etcd{}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(existingEtcd), updated)).To(Succeed())
+			Expect(updated.Annotations).To(HaveKeyWithValue(secretsrotation.AnnotationKeyPeerCARolledOut, "true"))
+		})
+
+		It("should return an error when the client Patch fails", func() {
+			existingEtcd := &druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: etcdName, Namespace: testNamespace}}
+			Expect(c.Create(ctx, existingEtcd)).To(Succeed())
+
+			c = fakeclient.NewClientBuilder().WithScheme(c.Scheme()).WithObjects(existingEtcd).WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+					return fakeErr
+				},
+			}).Build()
+			etcd = New(log, c, testNamespace, sm, Values{Role: role, Class: class, Replicas: replicas, PriorityClassName: priorityClassName})
+
+			Expect(etcd.MarkAsPeerCARolloutCompleted(ctx)).To(MatchError(fakeErr))
 		})
 	})
 

--- a/pkg/component/etcd/etcd/mock/mocks.go
+++ b/pkg/component/etcd/etcd/mock/mocks.go
@@ -115,6 +115,35 @@ func (mr *MockInterfaceMockRecorder) GetValues() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValues", reflect.TypeOf((*MockInterface)(nil).GetValues))
 }
 
+// IsPeerCARolledOut mocks base method.
+func (m *MockInterface) IsPeerCARolledOut(arg0 context.Context) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPeerCARolledOut", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsPeerCARolledOut indicates an expected call of IsPeerCARolledOut.
+func (mr *MockInterfaceMockRecorder) IsPeerCARolledOut(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPeerCARolledOut", reflect.TypeOf((*MockInterface)(nil).IsPeerCARolledOut), arg0)
+}
+
+// MarkAsPeerCARolloutCompleted mocks base method.
+func (m *MockInterface) MarkAsPeerCARolloutCompleted(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkAsPeerCARolloutCompleted", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MarkAsPeerCARolloutCompleted indicates an expected call of MarkAsPeerCARolloutCompleted.
+func (mr *MockInterfaceMockRecorder) MarkAsPeerCARolloutCompleted(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAsPeerCARolloutCompleted", reflect.TypeOf((*MockInterface)(nil).MarkAsPeerCARolloutCompleted), arg0)
+}
+
 // RolloutPeerCA mocks base method.
 func (m *MockInterface) RolloutPeerCA(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/pkg/component/shared/apiserver.go
+++ b/pkg/component/shared/apiserver.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component/apiserver"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
@@ -291,6 +292,16 @@ func handleETCDEncryptionKeyRotation(
 ) error {
 	switch etcdEncryptionKeyRotationPhase {
 	case gardencorev1beta1.RotationPreparing:
+		if isSelfHostedKubeAPIServer := runtimeNamespace == metav1.NamespaceSystem && deploymentName == v1beta1constants.DeploymentNameKubeAPIServer; isSelfHostedKubeAPIServer {
+			// For hosted shoots, changing the Deployment of the API server leads to a rollout of the pods. This is not
+			// true for self-hosted shoots: Here, we first have to translate the Deployment into a static pod, populate
+			// it via OperatingSystemConfig to the node, and wait for kubelet to restart it.
+			// Since all this is a bit more involved, we are performing these steps in the
+			// botanist.ReconcileStaticControlPlanePodsTaskGroup function as part of the flow (instead of doing it here
+			// like for hosted shoots).
+			return nil
+		}
+
 		if !etcdEncryptionConfig.EncryptWithCurrentKey {
 			if err := apiServer.Wait(ctx); err != nil {
 				return err
@@ -300,9 +311,7 @@ func handleETCDEncryptionKeyRotation(
 			// still use the old key for the encryption of ETCD data. Now we can mark this step as "completed" (via an
 			// annotation) and redeploy it with the option to use the current/new key for encryption, see
 			// https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#rotating-a-decryption-key for details.
-			if err := secretsrotation.PatchAPIServerDeploymentMeta(ctx, runtimeClient, runtimeNamespace, deploymentName, func(meta *metav1.PartialObjectMetadata) {
-				metav1.SetMetaDataAnnotation(&meta.ObjectMeta, secretsrotation.AnnotationKeyNewEncryptionKeyPopulated, "true")
-			}); err != nil {
+			if err := MarkAPIServerDeploymentAsReadyForEncryptionKeySwitch(ctx, runtimeClient, runtimeNamespace, deploymentName); err != nil {
 				return err
 			}
 
@@ -323,6 +332,15 @@ func handleETCDEncryptionKeyRotation(
 	}
 
 	return nil
+}
+
+// MarkAPIServerDeploymentAsReadyForEncryptionKeySwitch adds the credentials.gardener.cloud/new-encryption-key-populated
+// annotation to the deployment. This states that the new encryption key has been populated to all API server replicas
+// and that we are now ready to make switch it so that it's getting used for encrypting data.
+func MarkAPIServerDeploymentAsReadyForEncryptionKeySwitch(ctx context.Context, runtimeClient client.Client, runtimeNamespace string, deploymentName string) error {
+	return secretsrotation.PatchAPIServerDeploymentMeta(ctx, runtimeClient, runtimeNamespace, deploymentName, func(meta *metav1.PartialObjectMetadata) {
+		metav1.SetMetaDataAnnotation(&meta.ObjectMeta, secretsrotation.AnnotationKeyNewEncryptionKeyPopulated, "true")
+	})
 }
 
 // GetResourcesForEncryptionFromConfig returns the list of [schema.GroupResource] requiring encryption from the EncryptionConfig.

--- a/pkg/component/shared/apiserver.go
+++ b/pkg/component/shared/apiserver.go
@@ -336,7 +336,9 @@ func handleETCDEncryptionKeyRotation(
 
 // MarkAPIServerDeploymentAsReadyForEncryptionKeySwitch adds the credentials.gardener.cloud/new-encryption-key-populated
 // annotation to the deployment. This states that the new encryption key has been populated to all API server replicas
-// and that we are now ready to make switch it so that it's getting used for encrypting data.
+// as second key (usable for decryption). This means we are now ready to switch the order with the first (old key). Then
+// the new key is the first and gets used for encryption and decryption, and the old key is the second used for
+// decryption only.
 func MarkAPIServerDeploymentAsReadyForEncryptionKeySwitch(ctx context.Context, runtimeClient client.Client, runtimeNamespace string, deploymentName string) error {
 	return secretsrotation.PatchAPIServerDeploymentMeta(ctx, runtimeClient, runtimeNamespace, deploymentName, func(meta *metav1.PartialObjectMetadata) {
 		metav1.SetMetaDataAnnotation(&meta.ObjectMeta, secretsrotation.AnnotationKeyNewEncryptionKeyPopulated, "true")

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -536,15 +536,19 @@ func maintainAddons(shoot *gardencorev1beta1.Shoot) []string {
 }
 
 func maintainTasks(shoot *gardencorev1beta1.Shoot, config controllermanagerconfigv1alpha1.ShootMaintenanceControllerConfiguration) {
-	controllerutils.AddTasks(shoot.Annotations,
-		v1beta1constants.ShootTaskDeployInfrastructure,
-		v1beta1constants.ShootTaskDeployDNSRecordInternal,
-		v1beta1constants.ShootTaskDeployDNSRecordExternal,
-		v1beta1constants.ShootTaskDeployDNSRecordIngress,
-	)
+	if !v1beta1helper.IsShootSelfHosted(shoot.Spec.Provider.Workers) {
+		controllerutils.AddTasks(shoot.Annotations,
+			v1beta1constants.ShootTaskDeployInfrastructure,
+			v1beta1constants.ShootTaskDeployDNSRecordInternal,
+			v1beta1constants.ShootTaskDeployDNSRecordExternal,
+			v1beta1constants.ShootTaskDeployDNSRecordIngress,
+		)
 
-	if ptr.Deref(config.EnableShootControlPlaneRestarter, false) {
-		controllerutils.AddTasks(shoot.Annotations, v1beta1constants.ShootTaskRestartControlPlanePods)
+		if ptr.Deref(config.EnableShootControlPlaneRestarter, false) {
+			controllerutils.AddTasks(shoot.Annotations, v1beta1constants.ShootTaskRestartControlPlanePods)
+		}
+	} else if v1beta1helper.HasManagedInfrastructure(shoot) {
+		controllerutils.AddTasks(shoot.Annotations, v1beta1constants.ShootTaskDeployInfrastructure)
 	}
 
 	if ptr.Deref(config.EnableShootCoreAddonRestarter, false) {

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -112,7 +112,11 @@ func run(ctx context.Context, opts *Options) error {
 			Dependencies: flow.NewTaskIDs(deployNamespaces, initializeSecretsManagement),
 		})
 		_ = g.AddGroup(
-			b.ReconcileGardenerResourceManagerTaskGroup(true, false, false).
+			b.ReconcileRuntimeGardenerResourceManagerTaskGroup(true, false, false).
+				WithDependencies(deployPriorityClassCritical),
+		)
+		_ = g.AddGroup(
+			b.ReconcileGardenerResourceManagerTaskGroup(true, false).
 				WithDependencies(deployPriorityClassCritical),
 		)
 		_                             = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -119,6 +119,7 @@ func run(ctx context.Context, opts *Options) error {
 			b.ReconcileGardenerResourceManagerTaskGroup(true, false).
 				WithDependencies(deployPriorityClassCritical),
 		)
+		_                             = g.AddGroup(b.ReconcileReferencedResourcesTaskGroup())
 		_                             = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())
 		reconcileExtensionControllers = g.AddGroup(b.ReconcileExtensionControllersTaskGroup(true))
 		reconcileNetworkPolicies      = g.AddGroup(b.ReconcileNetworkPoliciesTaskGroup())

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -29,6 +30,7 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	bootstrapetcd "github.com/gardener/gardener/pkg/component/etcd/bootstrap"
+	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenadm/botanist"
@@ -303,6 +305,18 @@ func prepareGardenerResources(ctx context.Context, b *botanist.GardenadmBotanist
 
 	patch := client.MergeFrom(shoot.DeepCopy())
 	shoot.Status = b.Shoot.GetInfo().Status
+	// Initialize status.credentials.encryptionAtRest from the spec so that the gardenlet's first
+	// reconciliation correctly identifies the encryption state and skips the unnecessary rewrite tasks.
+	// gardenadm init already set up etcd with the provider configured in the spec, so spec == reality.
+	if shoot.Status.Credentials == nil {
+		shoot.Status.Credentials = &gardencorev1beta1.ShootCredentials{}
+	}
+	shoot.Status.Credentials.EncryptionAtRest = &gardencorev1beta1.EncryptionAtRest{
+		Provider: gardencorev1beta1.EncryptionProviderStatus{
+			Type: v1beta1helper.GetEncryptionProviderType(shoot.Spec.Kubernetes.KubeAPIServer),
+		},
+		Resources: sharedcomponent.StringifyGroupResources(sharedcomponent.GetResourcesForEncryptionFromConfig(shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig)),
+	}
 	if err := b.GardenClient.Status().Patch(ctx, shoot, patch); err != nil {
 		return fmt.Errorf("failed patching Shoot %s status in garden cluster: %w", client.ObjectKeyFromObject(b.Shoot.GetInfo()), err)
 	}

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -114,8 +114,12 @@ func RunInitFlow(ctx context.Context, b *gardenadmbotanist.GardenadmBotanist, op
 			Fn:           flow.TaskFn(b.ApproveNodeAgentCertificateSigningRequest).RetryUntilTimeout(2*time.Second, time.Minute),
 			Dependencies: flow.NewTaskIDs(activateGardenerNodeAgent),
 		})
+		reconcileRuntimeGardenerResourceManager = g.AddGroup(
+			b.ReconcileRuntimeGardenerResourceManagerTaskGroup(podNetworkAvailable, shootIsGarden, false).
+				WithDependencies(approveGardenerNodeAgentCSR),
+		)
 		reconcileGardenerResourceManager = g.AddGroup(
-			b.ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, shootIsGarden, false).
+			b.ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, false).
 				WithDependencies(approveGardenerNodeAgentCSR),
 		)
 		_                             = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())
@@ -131,8 +135,14 @@ func RunInitFlow(ctx context.Context, b *gardenadmbotanist.GardenadmBotanist, op
 				WithDependencies(gardenadmbotanist.TaskGroupReconcileNetworkPolicies),
 		)
 
+		reconcileRuntimeGardenerResourceManagerInPodNetwork = g.AddGroup(
+			b.ReconcileRuntimeGardenerResourceManagerTaskGroup(true, shootIsGarden, false).
+				WithID(botanist.TaskGroupReconcileRuntimeGardenerResourceManager + "InPodNetwork").
+				WithDependencies(reconcileSystemComponents).
+				SkipIf(podNetworkAvailable || opts.UseHostNetwork),
+		)
 		reconcileGardenerResourceManagerInPodNetwork = g.AddGroup(
-			b.ReconcileGardenerResourceManagerTaskGroup(true, shootIsGarden, false).
+			b.ReconcileGardenerResourceManagerTaskGroup(true, false).
 				WithID(botanist.TaskGroupReconcileGardenerResourceManager + "InPodNetwork").
 				WithDependencies(reconcileSystemComponents).
 				SkipIf(podNetworkAvailable || opts.UseHostNetwork),
@@ -149,6 +159,8 @@ func RunInitFlow(ctx context.Context, b *gardenadmbotanist.GardenadmBotanist, op
 		)
 		syncPointBootstrapped = flow.NewTaskIDs(
 			reconcileNetworkPolicies,
+			reconcileRuntimeGardenerResourceManager,
+			reconcileRuntimeGardenerResourceManagerInPodNetwork,
 			reconcileGardenerResourceManager,
 			reconcileGardenerResourceManagerInPodNetwork,
 			reconcileExtensionControllers,

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -122,6 +122,7 @@ func RunInitFlow(ctx context.Context, b *gardenadmbotanist.GardenadmBotanist, op
 			b.ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, false).
 				WithDependencies(approveGardenerNodeAgentCSR),
 		)
+		_                             = g.AddGroup(b.ReconcileReferencedResourcesTaskGroup())
 		_                             = g.AddGroup(b.ReconcileSystemResourcesTaskGroup())
 		reconcileExtensionControllers = g.AddGroup(b.ReconcileExtensionControllersTaskGroup(podNetworkAvailable))
 		reconcileNetworkPolicies      = g.AddGroup(b.ReconcileNetworkPoliciesTaskGroup())

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -103,7 +103,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	// the flow. However, when it's disabled then we check whether it is indeed available (and fail, otherwise).
 	if !vpaEnabled(seed.GetInfo().Spec.Settings) {
 		if _, err := r.SeedClientSet.Client().RESTMapper().RESTMapping(schema.GroupKind{Group: "autoscaling.k8s.io", Kind: "VerticalPodAutoscaler"}); err != nil {
-			return fmt.Errorf("VPA is required for seed cluster: %s", err)
+			return fmt.Errorf("VPA is required for seed cluster — if the seed is a self-hosted shoot, activate the VPA in the ShootSpec: %s", err)
 		}
 	}
 
@@ -440,7 +440,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Name:         "Reconciling Kubernetes vertical pod autoscaler",
 			Fn:           c.verticalPodAutoscaler.Deploy,
 			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
-			SkipIf:       seedIsGarden,
+			SkipIf:       seedIsGarden || seedIsSelfHostedShoot,
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying PVC Autoscaler",

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -730,7 +730,7 @@ func (h *Health) CheckClusterNodes(
 		return nil, err
 	}
 
-	workerPoolToCloudConfigSecretMeta, err := botanist.WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx, shootClient.Client(), v1beta1constants.GardenRoleOperatingSystemConfig)
+	workerPoolToCloudConfigSecretMeta, err := botanist.WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx, shootClient.Client())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -255,7 +255,8 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			b.InitializeSecretsManagementTaskGroup().
 				WithDependencies(reconcileIstioInternalLoadbalancingConfigMap),
 		)
-		initialValiDeployment = g.Add(flow.Task{
+		waitUntilRuntimeGardenerResourceManagerReady = g.AddGroup(b.ReconcileRuntimeGardenerResourceManagerTaskGroup(true, shootIsGarden, flowCtx.skipReadiness))
+		initialValiDeployment                        = g.Add(flow.Task{
 			Name:         "Deploying initial shoot logging stack in Seed",
 			Fn:           flow.TaskFn(b.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       flowCtx.isHibernatingShootWithWorkers || b.Shoot.IsSelfHosted(),
@@ -265,7 +266,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Name:         "Deploying referenced resources",
 			Fn:           flow.TaskFn(b.DeployReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployNamespace),
+			Dependencies: flow.NewTaskIDs(deployNamespace, waitUntilRuntimeGardenerResourceManagerReady),
 		})
 		waitUntilInfrastructureReady = g.AddGroup(
 			b.ReconcileInfrastructureTaskGroup(flowCtx.skipReadiness).
@@ -441,7 +442,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Dependencies: flow.NewTaskIDs(scaleEtcdAfterRestore),
 		})
 		waitUntilGardenerResourceManagerReady = g.AddGroup(
-			b.ReconcileGardenerResourceManagerTaskGroup(true, shootIsGarden, flowCtx.skipReadiness).
+			b.ReconcileGardenerResourceManagerTaskGroup(true, flowCtx.skipReadiness).
 				WithDependencies(waitUntilKubeAPIServerIsReady),
 		)
 		_ = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -541,6 +541,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		})
 		reconcileVPNComponents    = g.AddGroup(b.ReconcileVPNComponentsTaskGroup(flowCtx.skipReadiness).WithDependencies(syncPointReadyForSystemComponents))
 		reconcileSystemComponents = g.AddGroup(b.ReconcileSystemComponentsTaskGroup(flowCtx.kubeProxyEnabled, flowCtx.skipReadiness).WithDependencies(
+			ensureShootClusterIdentity,
 			initializeShootClients,
 			deployKubeScheduler,
 		))

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -504,9 +504,11 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			waitUntilGardenerResourceManagerReady,
 		)
 		deployManagedResourceForGardenerNodeAgent = g.Add(flow.Task{
-			Name:         "Deploying gardener-node-agent's OperatingSystemConfig secrets and RBAC resources",
-			Fn:           flow.TaskFn(b.DeployManagedResourceForGardenerNodeAgent).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
+			Name: "Deploying gardener-node-agent's OperatingSystemConfig secrets and RBAC resources",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return b.DeployManagedResourceForGardenerNodeAgent(ctx, false)
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
 		})
 		waitUntilShootNamespacesReady = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
@@ -594,9 +596,9 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		_ = g.Add(flow.Task{
 			Name: "Waiting until all shoot worker nodes have updated the operating system config",
 			Fn: func(ctx context.Context) error {
-				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)
+				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false, false)
 			},
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady, waitUntilTunnelConnectionExists),
 		})
 		deployAlertmanager = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -230,26 +230,21 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 	var (
 		deployNamespace            = g.AddGroup(b.DeployNamespacesTaskGroup())
 		ensureShootClusterIdentity = g.Add(flow.Task{
-			Name:         "Ensuring Shoot cluster identity",
-			Fn:           flow.TaskFn(b.EnsureShootClusterIdentity).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployNamespace),
+			Name: "Ensuring Shoot cluster identity",
+			Fn:   flow.TaskFn(b.EnsureShootClusterIdentity).RetryUntilTimeout(defaultInterval, defaultTimeout),
 		})
-		deployCloudProviderSecret                    = g.AddGroup(b.DeployCloudProviderSecretTaskGroup())
-		reconcileIstioInternalLoadbalancingConfigMap = g.Add(flow.Task{
+		reconcileIstioInternalLoadBalancingConfigMap = g.Add(flow.Task{
 			Name:         "Reconcile Istio internal load balancing ConfigMap",
 			Fn:           flow.TaskFn(b.ReconcileIstioInternalLoadBalancingConfigMap).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
+		deployCloudProviderSecret   = g.AddGroup(b.DeployCloudProviderSecretTaskGroup())
 		_                           = g.AddGroup(b.ReconcileCustomResourceDefinitionsTaskGroup())
 		_                           = g.AddGroup(b.ReconcileClusterResourceTaskGroup())
-		initializeSecretsManagement = g.AddGroup(
-			b.InitializeSecretsManagementTaskGroup().
-				WithDependencies(reconcileIstioInternalLoadbalancingConfigMap),
-		)
-		_                     = g.AddGroup(b.ReconcileRuntimeGardenerResourceManagerTaskGroup(true, shootIsGarden, flowCtx.skipReadiness))
-		initialValiDeployment = g.Add(flow.Task{
+		initializeSecretsManagement = g.AddGroup(b.InitializeSecretsManagementTaskGroup().WithDependencies(reconcileIstioInternalLoadBalancingConfigMap))
+		_                           = g.AddGroup(b.ReconcileRuntimeGardenerResourceManagerTaskGroup(true, shootIsGarden, flowCtx.skipReadiness))
+		initialValiDeployment       = g.Add(flow.Task{
 			Name:         "Deploying initial shoot logging stack in Seed",
 			Fn:           flow.TaskFn(b.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       flowCtx.isHibernatingShootWithWorkers || b.Shoot.IsSelfHosted(),
@@ -275,13 +270,9 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilKubeAPIServerServiceIsReady),
 		})
-		reconcileDNSRecords = g.AddGroup(b.ReconcileDNSRecordsTaskGroup().WithDependencies(
-			waitUntilKubeAPIServerServiceIsReady,
-		))
+		reconcileDNSRecords      = g.AddGroup(b.ReconcileDNSRecordsTaskGroup().WithDependencies(waitUntilKubeAPIServerServiceIsReady))
 		reconcileBackupResources = g.AddGroup(b.ReconcileBackupResourcesTaskGroup(flowCtx.allowBackup, flowCtx.isCopyOfBackupsRequired, flowCtx.skipReadiness))
-		waitUntilEtcdReady       = g.AddGroup(b.ReconcileETCDsTaskGroup(shootIsGarden, flowCtx.isRestoringHAControlPlane, flowCtx.skipReadiness).WithDependencies(
-			reconcileBackupResources,
-		))
+		waitUntilEtcdReady       = g.AddGroup(b.ReconcileETCDsTaskGroup(shootIsGarden, flowCtx.isRestoringHAControlPlane, flowCtx.skipReadiness).WithDependencies(reconcileBackupResources))
 		destroySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Destroying source backup entry",
 			Fn:           b.DestroySourceBackupEntry,
@@ -334,15 +325,12 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		})
 		waitUntilEtcdScaledAfterRestore = g.Add(flow.Task{
 			Name:         "Waiting until main and events etcd scaled up after kube-apiserver is ready",
-			Fn:           flow.TaskFn(b.WaitUntilEtcdsReady),
+			Fn:           b.WaitUntilEtcdsReady,
 			SkipIf:       !flowCtx.isRestoringHAControlPlane || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(scaleEtcdAfterRestore),
 		})
-		waitUntilGardenerResourceManagerReady = g.AddGroup(
-			b.ReconcileGardenerResourceManagerTaskGroup(true, flowCtx.skipReadiness).
-				WithDependencies(waitUntilKubeAPIServerIsReady),
-		)
-		_ = g.Add(flow.Task{
+		waitUntilGardenerResourceManagerReady = g.AddGroup(b.ReconcileGardenerResourceManagerTaskGroup(true, flowCtx.skipReadiness).WithDependencies(waitUntilKubeAPIServerIsReady))
+		_                                     = g.Add(flow.Task{
 			Name: "Renewing shoot access secrets after creation of new ServiceAccount signing key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return tokenrequest.RenewAccessSecrets(ctx, b.SeedClientSet.Client(),
@@ -357,11 +345,9 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
 		waitUntilControlPlaneReady      = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
-		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false).WithDependencies(
-			waitUntilExtensionResourcesBeforeKAPIReady,
-		))
-		waitUntilShootNamespacesReady = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
-		deployGardenerAccess          = g.Add(flow.Task{
+		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false).WithDependencies(waitUntilExtensionResourcesBeforeKAPIReady))
+		waitUntilShootNamespacesReady   = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
+		deployGardenerAccess            = g.Add(flow.Task{
 			Name:         "Deploying Gardener shoot access resources",
 			Fn:           flow.TaskFn(b.Shoot.Components.GardenerAccess.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsSelfHosted(),
@@ -476,7 +462,6 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilGardenerResourceManagerReady),
 		})
-
 		waitUntilKubeControllerManagerReady = g.Add(flow.Task{
 			Name:         "Waiting until kube-controller-manager reports readiness",
 			Fn:           b.Shoot.Components.ControlPlane.KubeControllerManager.Wait,
@@ -511,11 +496,9 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			SkipIf:       flowCtx.shootSSHAccessEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady),
 		})
-		waitUntilExtensionResourcesAfterKAPIReady = g.AddGroup(b.ReconcileExtensionsAfterKubeAPIServerTaskGroup(flowCtx.skipReadiness).WithDependencies(
-			initializeShootClients,
-		))
-		_                                   = g.AddGroup(b.ReconcileContainerRuntimeTaskGroup(flowCtx.skipReadiness))
-		waitUntilOperatingSystemConfigReady = g.AddGroup(b.ReconcileOperatingSystemConfigTaskGroup(flowCtx.skipReadiness).WithDependencies(
+		waitUntilExtensionResourcesAfterKAPIReady = g.AddGroup(b.ReconcileExtensionsAfterKubeAPIServerTaskGroup(flowCtx.skipReadiness).WithDependencies(initializeShootClients))
+		_                                         = g.AddGroup(b.ReconcileContainerRuntimeTaskGroup(flowCtx.skipReadiness))
+		waitUntilOperatingSystemConfigReady       = g.AddGroup(b.ReconcileOperatingSystemConfigTaskGroup(flowCtx.skipReadiness).WithDependencies(
 			waitUntilInfrastructureReady,
 			waitUntilControlPlaneReady,
 			deleteBastions,

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -255,24 +255,16 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			b.InitializeSecretsManagementTaskGroup().
 				WithDependencies(reconcileIstioInternalLoadbalancingConfigMap),
 		)
-		waitUntilRuntimeGardenerResourceManagerReady = g.AddGroup(b.ReconcileRuntimeGardenerResourceManagerTaskGroup(true, shootIsGarden, flowCtx.skipReadiness))
-		initialValiDeployment                        = g.Add(flow.Task{
+		_                     = g.AddGroup(b.ReconcileRuntimeGardenerResourceManagerTaskGroup(true, shootIsGarden, flowCtx.skipReadiness))
+		initialValiDeployment = g.Add(flow.Task{
 			Name:         "Deploying initial shoot logging stack in Seed",
 			Fn:           flow.TaskFn(b.DeployLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       flowCtx.isHibernatingShootWithWorkers || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployNamespace, initializeSecretsManagement),
 		})
-		deployReferencedResources = g.Add(flow.Task{
-			Name:         "Deploying referenced resources",
-			Fn:           flow.TaskFn(b.DeployReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployNamespace, waitUntilRuntimeGardenerResourceManagerReady),
-		})
-		waitUntilInfrastructureReady = g.AddGroup(
-			b.ReconcileInfrastructureTaskGroup(flowCtx.skipReadiness).
-				WithDependencies(deployReferencedResources),
-		)
-		deployKubeAPIServerService = g.Add(flow.Task{
+		deployReferencedResources    = g.AddGroup(b.ReconcileReferencedResourcesTaskGroup())
+		waitUntilInfrastructureReady = g.AddGroup(b.ReconcileInfrastructureTaskGroup(flowCtx.skipReadiness))
+		deployKubeAPIServerService   = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes API server service in the Seed cluster",
 			Fn:           flow.TaskFn(b.Shoot.Components.ControlPlane.KubeAPIServerService.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsSelfHosted(),
@@ -459,9 +451,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)) || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
-		waitUntilControlPlaneReady = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness).WithDependencies(
-			deployReferencedResources,
-		))
+		waitUntilControlPlaneReady    = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
 		waitUntilShootNamespacesReady = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
 		deployVPNSeedServer           = g.Add(flow.Task{
 			Name:         "Deploying vpn-seed-server",
@@ -632,14 +622,12 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterKAPI),
 		})
 		waitUntilOperatingSystemConfigReady = g.AddGroup(b.ReconcileOperatingSystemConfigTaskGroup(flowCtx.skipReadiness).WithDependencies(
-			deployReferencedResources,
 			waitUntilInfrastructureReady,
 			waitUntilControlPlaneReady,
 			deleteBastions,
 			waitUntilExtensionResourcesAfterKAPIReady,
 		))
 		deployShootSystemResources = g.AddGroup(b.ReconcileSystemResourcesTaskGroup().WithDependencies(
-			deployReferencedResources,
 			waitUntilOperatingSystemConfigReady,
 			waitUntilControlPlaneReady,
 			waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -361,13 +361,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			waitUntilExtensionResourcesBeforeKAPIReady,
 		))
 		waitUntilShootNamespacesReady = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
-		deployVPNSeedServer           = g.Add(flow.Task{
-			Name:         "Deploying vpn-seed-server",
-			Fn:           flow.TaskFn(b.DeployVPNServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployNamespace, waitUntilGardenerResourceManagerReady),
-		})
-		deployGardenerAccess = g.Add(flow.Task{
+		deployGardenerAccess          = g.Add(flow.Task{
 			Name:         "Deploying Gardener shoot access resources",
 			Fn:           flow.TaskFn(b.Shoot.Components.GardenerAccess.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsSelfHosted(),
@@ -527,35 +521,22 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			deleteBastions,
 			waitUntilExtensionResourcesAfterKAPIReady,
 		))
-		deployShootSystemResources = g.AddGroup(b.ReconcileSystemResourcesTaskGroup().WithDependencies(
+		syncPointReadyForSystemComponents = flow.NewTaskIDs(
+			initializeShootClients,
 			waitUntilOperatingSystemConfigReady,
 			waitUntilControlPlaneReady,
 			waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 			waitUntilGardenerResourceManagerReady,
-			initializeShootClients,
-			waitUntilOperatingSystemConfigReady,
-		))
-		_ = g.Add(flow.Task{
+		)
+
+		deployShootSystemResources = g.AddGroup(b.ReconcileSystemResourcesTaskGroup().WithDependencies(syncPointReadyForSystemComponents))
+		_                          = g.Add(flow.Task{
 			Name:         "Populating static manifests from seed to shoot",
 			Fn:           flow.TaskFn(b.PopulateStaticManifestsFromSeedToShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, waitUntilShootNamespacesReady),
 		})
-		deployVPNShoot = g.Add(flow.Task{
-			Name:   "Deploying vpn-shoot system component",
-			Fn:     flow.TaskFn(b.DeployVPNShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				waitUntilGardenerResourceManagerReady, waitUntilGardenerResourceManagerReady, deployKubeScheduler, deployVPNSeedServer, waitUntilShootNamespacesReady),
-		})
-		waitUntilVPNShootReady = g.Add(flow.Task{
-			Name: "Waiting until vpn-shoot system component is ready",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.SystemComponents.VPNShoot.Wait(ctx)
-			}),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted() || flowCtx.skipReadiness,
-			Dependencies: flow.NewTaskIDs(deployVPNShoot),
-		})
+		reconcileVPNComponents    = g.AddGroup(b.ReconcileVPNComponentsTaskGroup(flowCtx.skipReadiness).WithDependencies(syncPointReadyForSystemComponents))
 		reconcileSystemComponents = g.AddGroup(b.ReconcileSystemComponentsTaskGroup(flowCtx.kubeProxyEnabled, flowCtx.skipReadiness).WithDependencies(
 			waitUntilControlPlaneReady,
 			waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
@@ -563,25 +544,16 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			ensureShootClusterIdentity,
 			deployKubeScheduler,
 		))
-		deployAPIServerProxy = g.Add(flow.Task{
-			Name:   "Deploying apiserver-proxy",
-			Fn:     flow.TaskFn(b.DeployAPIServerProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
-		})
 		deployManagedResourceForGardenerNodeAgent = g.Add(flow.Task{
 			Name:         "Deploying managed resources for the gardener-node-agent",
 			Fn:           flow.TaskFn(b.DeployManagedResourceForGardenerNodeAgent).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
-
 		syncPointAllSystemComponentsDeployed = flow.NewTaskIDs(
 			reconcileSystemComponents,
-			deployAPIServerProxy,
 			deployShootSystemResources,
-			waitUntilVPNShootReady,
+			reconcileVPNComponents,
 		)
 
 		scaleClusterAutoscalerToZero = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -378,19 +378,8 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			SkipIf:       !flowCtx.allowBackup || flowCtx.skipReadiness || !b.Shoot.IsRestorePhase() || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(destroySourceBackupEntry),
 		})
-		deployExtensionResourcesBeforeKAPI = g.Add(flow.Task{
-			Name:         "Deploying extension resources before kube-apiserver",
-			Fn:           flow.TaskFn(b.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, deployReferencedResources, waitUntilInfrastructureReady),
-		})
-		waitUntilExtensionResourcesBeforeKAPIReady = g.Add(flow.Task{
-			Name:         "Waiting until extension resources handled before kube-apiserver are ready",
-			Fn:           b.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
-			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployExtensionResourcesBeforeKAPI),
-		})
-		deployKubeAPIServer = g.Add(flow.Task{
+		waitUntilExtensionResourcesBeforeKAPIReady = g.AddGroup(b.ReconcileExtensionsBeforeKubeAPIServerTaskGroup(flowCtx.skipReadiness))
+		deployKubeAPIServer                        = g.Add(flow.Task{
 			Name: "Deploying Kubernetes API server",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.DeployKubeAPIServer(ctx)
@@ -451,7 +440,10 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)) || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
-		waitUntilControlPlaneReady    = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
+		waitUntilControlPlaneReady      = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
+		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false).WithDependencies(
+			waitUntilExtensionResourcesBeforeKAPIReady,
+		))
 		waitUntilShootNamespacesReady = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
 		deployVPNSeedServer           = g.Add(flow.Task{
 			Name:         "Deploying vpn-seed-server",
@@ -744,7 +736,6 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			deployKubernetesDashboard,
 			deployNginxIngressAddon,
 		)
-		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false))
 
 		scaleClusterAutoscalerToZero = g.Add(flow.Task{
 			Name:         "Scaling down cluster autoscaler",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -278,67 +278,9 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		reconcileDNSRecords = g.AddGroup(b.ReconcileDNSRecordsTaskGroup().WithDependencies(
 			waitUntilKubeAPIServerServiceIsReady,
 		))
-		deploySourceBackupEntry = g.Add(flow.Task{
-			Name:         "Deploying source backup entry",
-			Fn:           b.DeploySourceBackupEntry,
-			SkipIf:       !flowCtx.isCopyOfBackupsRequired || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployNamespace),
-		})
-		waitUntilSourceBackupEntryInGardenReconciled = g.Add(flow.Task{
-			Name:         "Waiting until the source backup entry has been reconciled",
-			Fn:           b.Shoot.Components.SourceBackupEntry.Wait,
-			SkipIf:       flowCtx.skipReadiness || !flowCtx.isCopyOfBackupsRequired || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deploySourceBackupEntry),
-		})
-		deployBackupBucketInGarden = g.Add(flow.Task{
-			Name: "Deploying BackupBucket for ETCD data",
-			Fn: func(ctx context.Context) error {
-				return b.Shoot.Components.BackupBucket.Deploy(ctx)
-			},
-			SkipIf:       !flowCtx.allowBackup || !b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployNamespace),
-		})
-		waitUntilBackupBucketInGardenReconciled = g.Add(flow.Task{
-			Name: "Waiting until the BackupBucket for ETCD data has been reconciled",
-			Fn: func(ctx context.Context) error {
-				return b.Shoot.Components.BackupBucket.Wait(ctx)
-			},
-			SkipIf:       flowCtx.skipReadiness || !flowCtx.allowBackup || !b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployBackupBucketInGarden),
-		})
-		deployBackupEntryInGarden = g.Add(flow.Task{
-			Name:         "Deploying BackupEntry for ETCD data",
-			Fn:           b.DeployBackupEntry,
-			SkipIf:       !flowCtx.allowBackup,
-			Dependencies: flow.NewTaskIDs(deployNamespace, waitUntilSourceBackupEntryInGardenReconciled, waitUntilBackupBucketInGardenReconciled),
-		})
-		waitUntilBackupEntryInGardenReconciled = g.Add(flow.Task{
-			Name:         "Waiting until the BackupEntry for ETCD data has been reconciled",
-			Fn:           b.Shoot.Components.BackupEntry.Wait,
-			SkipIf:       flowCtx.skipReadiness || !flowCtx.allowBackup,
-			Dependencies: flow.NewTaskIDs(deployBackupEntryInGarden),
-		})
-		copyEtcdBackups = g.Add(flow.Task{
-			Name:         "Copying etcd backups to new seed's backup bucket",
-			Fn:           b.DeployEtcdCopyBackupsTask,
-			SkipIf:       !flowCtx.isCopyOfBackupsRequired,
-			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilBackupEntryInGardenReconciled, waitUntilSourceBackupEntryInGardenReconciled),
-		})
-		waitUntilEtcdBackupsCopied = g.Add(flow.Task{
-			Name:         "Waiting until etcd backups are copied",
-			Fn:           b.Shoot.Components.ControlPlane.EtcdCopyBackupsTask.Wait,
-			SkipIf:       flowCtx.skipReadiness || !flowCtx.isCopyOfBackupsRequired,
-			Dependencies: flow.NewTaskIDs(copyEtcdBackups),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Destroying copy etcd backups task resource",
-			Fn:           b.Shoot.Components.ControlPlane.EtcdCopyBackupsTask.Destroy,
-			SkipIf:       !flowCtx.isCopyOfBackupsRequired,
-			Dependencies: flow.NewTaskIDs(waitUntilEtcdBackupsCopied),
-		})
-		waitUntilEtcdReady = g.AddGroup(b.ReconcileETCDsTaskGroup(shootIsGarden, flowCtx.isRestoringHAControlPlane, flowCtx.skipReadiness).WithDependencies(
-			waitUntilBackupEntryInGardenReconciled,
-			waitUntilEtcdBackupsCopied,
+		reconcileBackupResources = g.AddGroup(b.ReconcileBackupResourcesTaskGroup(flowCtx.allowBackup, flowCtx.isCopyOfBackupsRequired, flowCtx.skipReadiness))
+		waitUntilEtcdReady       = g.AddGroup(b.ReconcileETCDsTaskGroup(shootIsGarden, flowCtx.isRestoringHAControlPlane, flowCtx.skipReadiness).WithDependencies(
+			reconcileBackupResources,
 		))
 		destroySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Destroying source backup entry",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -740,6 +740,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			waitUntilKubeRootCAConfigMapsUpdated,
 			waitUntilOperatingSystemConfigReady,
 		))
+		_ = g.AddGroup(b.ReconcileExtensionsAfterWorkerTaskGroup(flowCtx.skipReadiness))
 		_ = g.Add(flow.Task{
 			Name:         "Checking if we have dual-stack pod CIDRs in nodes",
 			Fn:           b.CheckPodCIDRsInNodes,

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -7,6 +7,8 @@ package shoot
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -350,7 +352,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 				}
 				return removeShootOperationAnnotation(ctx, b.GardenClient, b.Shoot, v1beta1constants.SeedOperationRenewGardenAccessSecrets)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       !b.Shoot.IsSelfHosted() || b.Shoot.GetInfo().Annotations[v1beta1constants.GardenerOperation] != v1beta1constants.SeedOperationRenewGardenAccessSecrets,
+			SkipIf:       !b.Shoot.IsSelfHosted() || !slices.Contains(v1beta1helper.GetShootGardenerOperations(b.Shoot.GetInfo().Annotations), v1beta1constants.SeedOperationRenewGardenAccessSecrets),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
 		_ = g.Add(flow.Task{
@@ -361,7 +363,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 				}
 				return removeShootOperationAnnotation(ctx, b.GardenClient, b.Shoot, v1beta1constants.SeedOperationRenewWorkloadIdentityTokens)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       !b.Shoot.IsSelfHosted() || b.Shoot.GetInfo().Annotations[v1beta1constants.GardenerOperation] != v1beta1constants.SeedOperationRenewWorkloadIdentityTokens,
+			SkipIf:       !b.Shoot.IsSelfHosted() || !slices.Contains(v1beta1helper.GetShootGardenerOperations(b.Shoot.GetInfo().Annotations), v1beta1constants.SeedOperationRenewWorkloadIdentityTokens),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
 		deployGardenerAccess = g.Add(flow.Task{
@@ -515,6 +517,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		waitUntilExtensionResourcesAfterKAPIReady = g.AddGroup(b.ReconcileExtensionsAfterKubeAPIServerTaskGroup(flowCtx.skipReadiness).WithDependencies(initializeShootClients))
 		_                                         = g.AddGroup(b.ReconcileContainerRuntimeTaskGroup(flowCtx.skipReadiness))
 		waitUntilOperatingSystemConfigReady       = g.AddGroup(b.ReconcileOperatingSystemConfigTaskGroup(flowCtx.skipReadiness).WithDependencies(deleteBastions))
+		waitUntilShootNamespacesReady             = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
 		syncPointReadyForSystemComponents         = flow.NewTaskIDs(
 			initializeShootClients,
 			waitUntilOperatingSystemConfigReady,
@@ -530,9 +533,8 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
 		})
-		waitUntilShootNamespacesReady = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
-		deployShootSystemResources    = g.AddGroup(b.ReconcileSystemResourcesTaskGroup().WithDependencies(syncPointReadyForSystemComponents))
-		_                             = g.Add(flow.Task{
+		deployShootSystemResources = g.AddGroup(b.ReconcileSystemResourcesTaskGroup().WithDependencies(syncPointReadyForSystemComponents))
+		_                          = g.Add(flow.Task{
 			Name:         "Populating static manifests from seed to shoot",
 			Fn:           flow.TaskFn(b.PopulateStaticManifestsFromSeedToShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, waitUntilShootNamespacesReady),
@@ -700,8 +702,11 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 
 func removeShootOperationAnnotation(ctx context.Context, gardenClient client.Client, shootObj *shoot.Shoot, operationAnnotation string) error {
 	return shootObj.UpdateInfo(ctx, gardenClient, false, func(s *gardencorev1beta1.Shoot) error {
-		if s.Annotations[v1beta1constants.GardenerOperation] == operationAnnotation {
+		remaining := v1beta1helper.RemoveOperation(v1beta1helper.GetShootGardenerOperations(s.Annotations), operationAnnotation)
+		if len(remaining) == 0 {
 			delete(s.Annotations, v1beta1constants.GardenerOperation)
+		} else {
+			s.Annotations[v1beta1constants.GardenerOperation] = strings.Join(remaining, v1beta1constants.GardenerOperationsSeparator)
 		}
 		return nil
 	})

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -275,28 +275,9 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilKubeAPIServerServiceIsReady),
 		})
-		deployInternalDomainDNSRecord = g.Add(flow.Task{
-			Name: "Deploying internal domain DNS record",
-			Fn: func(ctx context.Context) error {
-				if err := b.DeployOrDestroyInternalDNSRecord(ctx); err != nil {
-					return err
-				}
-				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskDeployDNSRecordInternal)
-			},
-			SkipIf:       b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
-		})
-		_ = g.Add(flow.Task{
-			Name: "Deploying external domain DNS record",
-			Fn: func(ctx context.Context) error {
-				if err := b.DeployOrDestroyExternalDNSRecord(ctx); err != nil {
-					return err
-				}
-				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskDeployDNSRecordExternal)
-			},
-			SkipIf:       b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
-		})
+		reconcileDNSRecords = g.AddGroup(b.ReconcileDNSRecordsTaskGroup().WithDependencies(
+			waitUntilKubeAPIServerServiceIsReady,
+		))
 		deploySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Deploying source backup entry",
 			Fn:           b.DeploySourceBackupEntry,
@@ -454,7 +435,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Name:         "Initializing connection to Shoot",
 			Fn:           flow.TaskFn(b.InitializeDesiredShootClients).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			SkipIf:       b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployGardenerAccess),
+			Dependencies: flow.NewTaskIDs(reconcileDNSRecords, deployGardenerAccess),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Sync public service account signing keys to Garden cluster",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -621,6 +621,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			SkipIf:       flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterKAPI),
 		})
+		_                                   = g.AddGroup(b.ReconcileContainerRuntimeTaskGroup(flowCtx.skipReadiness))
 		waitUntilOperatingSystemConfigReady = g.AddGroup(b.ReconcileOperatingSystemConfigTaskGroup(flowCtx.skipReadiness).WithDependencies(
 			waitUntilInfrastructureReady,
 			waitUntilControlPlaneReady,
@@ -925,36 +926,6 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Fn:           b.Shoot.Components.Extensions.Extension.WaitCleanupStaleResources,
 			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deleteStaleExtensionResources),
-		})
-		deployContainerRuntimeResources = g.Add(flow.Task{
-			Name:         "Deploying container runtime resources",
-			Fn:           flow.TaskFn(b.DeployContainerRuntime).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, initializeShootClients),
-		})
-		_ = g.Add(flow.Task{
-			Name: "Waiting until container runtime resources are ready",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.Extensions.ContainerRuntime.Wait(ctx)
-			}),
-			SkipIf:       b.Shoot.IsWorkerless || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployContainerRuntimeResources),
-		})
-		deleteStaleContainerRuntimeResources = g.Add(flow.Task{
-			Name: "Deleting stale container runtime resources",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.Extensions.ContainerRuntime.DeleteStaleResources(ctx)
-			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(initializeShootClients),
-		})
-		_ = g.Add(flow.Task{
-			Name: "Waiting until stale container runtime resources are deleted",
-			Fn: func(ctx context.Context) error {
-				return b.Shoot.Components.Extensions.ContainerRuntime.WaitCleanupStaleResources(ctx)
-			},
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deleteStaleContainerRuntimeResources),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Restarting control plane pods",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -169,13 +169,10 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
 	}
 
-	// TODO(rfranzke): Remove this if-condition once the Shoot controller flow has progressed.
-	if !b.Shoot.IsSelfHosted() {
-		b.Logger.Info("Cleaning no longer required secrets")
-		if err := b.SecretsManager.Cleanup(ctx); err != nil {
-			err = fmt.Errorf("failed to clean no longer required secrets: %w", err)
-			return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
-		}
+	b.Logger.Info("Cleaning no longer required secrets")
+	if err := b.SecretsManager.Cleanup(ctx); err != nil {
+		err = fmt.Errorf("failed to clean no longer required secrets: %w", err)
+		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 	}
 
 	if !r.ShootStateControllerEnabled && b.Shoot.IsRestorePhase() {

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -267,7 +267,6 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		_ = g.Add(flow.Task{
 			Name:         "Ensuring advertised addresses for the Shoot",
 			Fn:           b.UpdateAdvertisedAddresses,
-			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilKubeAPIServerServiceIsReady),
 		})
 		reconcileDNSRecords      = g.AddGroup(b.ReconcileDNSRecordsTaskGroup().WithDependencies(waitUntilKubeAPIServerServiceIsReady))
@@ -330,6 +329,8 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Dependencies: flow.NewTaskIDs(scaleEtcdAfterRestore),
 		})
 		waitUntilGardenerResourceManagerReady = g.AddGroup(b.ReconcileGardenerResourceManagerTaskGroup(true, flowCtx.skipReadiness).WithDependencies(waitUntilKubeAPIServerIsReady))
+		reconcileStaticControlPlanePods       = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false))
+		waitUntilControlPlaneReady            = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
 		_                                     = g.Add(flow.Task{
 			Name: "Renewing shoot access secrets after creation of new ServiceAccount signing key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
@@ -341,13 +342,10 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			SkipIf: !sets.New(
 				gardencorev1beta1.RotationPreparing,
 				gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
-			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)) || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
+			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)),
+			Dependencies: flow.NewTaskIDs(reconcileStaticControlPlanePods, waitUntilGardenerResourceManagerReady),
 		})
-		waitUntilControlPlaneReady    = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
-		_                             = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false))
-		waitUntilShootNamespacesReady = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
-		deployGardenerAccess          = g.Add(flow.Task{
+		deployGardenerAccess = g.Add(flow.Task{
 			Name:         "Deploying Gardener shoot access resources",
 			Fn:           flow.TaskFn(b.Shoot.Components.GardenerAccess.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsSelfHosted(),
@@ -356,13 +354,12 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		initializeShootClients = g.Add(flow.Task{
 			Name:         "Initializing connection to Shoot",
 			Fn:           flow.TaskFn(b.InitializeDesiredShootClients).RetryUntilTimeout(defaultInterval, 2*time.Minute),
-			SkipIf:       b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(reconcileDNSRecords, deployGardenerAccess),
+			Dependencies: flow.NewTaskIDs(reconcileDNSRecords, deployGardenerAccess, reconcileStaticControlPlanePods),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Sync public service account signing keys to Garden cluster",
 			Fn:           b.SyncPublicServiceAccountKeys,
-			SkipIf:       b.Shoot.HibernationEnabled || !v1beta1helper.HasManagedIssuer(b.Shoot.GetInfo()) || b.Shoot.IsSelfHosted(),
+			SkipIf:       b.Shoot.HibernationEnabled || !v1beta1helper.HasManagedIssuer(b.Shoot.GetInfo()),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
 		rewriteResourcesAddLabel = g.Add(flow.Task{
@@ -370,7 +367,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, b.Logger, b.SeedClientSet.Client(), b.ShootClientSet, b.SecretsManager, b.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer, b.Shoot.ResourcesToEncrypt, b.Shoot.EncryptedResources, gardenerutils.DefaultGVKsForEncryption())
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf: b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted() ||
+			SkipIf: b.Shoot.HibernationEnabled ||
 				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
 					sets.New(b.Shoot.ResourcesToEncrypt...).Equal(sets.New(b.Shoot.EncryptedResources...)) && (b.Shoot.EncryptionProviderToUse == b.Shoot.UsedEncryptionProvider ||
 					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting)),
@@ -381,7 +378,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Fn: func(ctx context.Context) error {
 				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, b.SeedClientSet.Client(), b.SnapshotEtcd, b.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer)
 			},
-			SkipIf: !flowCtx.allowBackup || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted() ||
+			SkipIf: !flowCtx.allowBackup || b.Shoot.HibernationEnabled ||
 				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
 					sets.New(b.Shoot.ResourcesToEncrypt...).Equal(sets.New(b.Shoot.EncryptedResources...)) && (b.Shoot.EncryptionProviderToUse == b.Shoot.UsedEncryptionProvider ||
 					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting)),
@@ -429,7 +426,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 
 				return nil
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf: b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted() ||
+			SkipIf: b.Shoot.HibernationEnabled ||
 				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting &&
 					sets.New(b.Shoot.ResourcesToEncrypt...).Equal(sets.New(b.Shoot.EncryptedResources...)) && (b.Shoot.EncryptionProviderToUse == b.Shoot.UsedEncryptionProvider ||
 					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPreparing ||
@@ -447,7 +444,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		_ = g.Add(flow.Task{
 			Name:         "Reconciling Kubernetes vertical pod autoscaler",
 			Fn:           flow.TaskFn(b.DeployVerticalPodAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted(),
+			SkipIf:       b.Shoot.IsWorkerless || shootIsGarden,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		_ = g.Add(flow.Task{
@@ -473,7 +470,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.CreateNewServiceAccountSecrets(ctx, b.Logger, b.ShootClientSet.Client(), b.SecretsManager)
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf:       !saKeyRotationPreparing || b.Shoot.IsSelfHosted(),
+			SkipIf:       !saKeyRotationPreparing,
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilKubeControllerManagerReady),
 		})
 		_ = g.Add(flow.Task{
@@ -481,7 +478,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.DeleteOldServiceAccountSecrets(ctx, b.Logger, b.ShootClientSet.Client(), b.Shoot.GetInfo().Status.Credentials.Rotation.ServiceAccountKey.LastInitiationFinishedTime.Time)
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf:       v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting || b.Shoot.IsSelfHosted(),
+			SkipIf:       v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting,
 			Dependencies: flow.NewTaskIDs(initializeShootClients, waitUntilKubeControllerManagerReady),
 		})
 		waitUntilKubeRootCAConfigMapsUpdated = g.Add(flow.Task{
@@ -493,7 +490,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		deleteBastions = g.Add(flow.Task{
 			Name:         "Deleting Bastions",
 			Fn:           b.DeleteBastions,
-			SkipIf:       flowCtx.shootSSHAccessEnabled || b.Shoot.IsSelfHosted(),
+			SkipIf:       flowCtx.shootSSHAccessEnabled,
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady),
 		})
 		waitUntilExtensionResourcesAfterKAPIReady = g.AddGroup(b.ReconcileExtensionsAfterKubeAPIServerTaskGroup(flowCtx.skipReadiness).WithDependencies(initializeShootClients))
@@ -506,12 +503,17 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 			waitUntilGardenerResourceManagerReady,
 		)
-
-		deployShootSystemResources = g.AddGroup(b.ReconcileSystemResourcesTaskGroup().WithDependencies(syncPointReadyForSystemComponents))
-		_                          = g.Add(flow.Task{
+		deployManagedResourceForGardenerNodeAgent = g.Add(flow.Task{
+			Name:         "Deploying gardener-node-agent's OperatingSystemConfig secrets and RBAC resources",
+			Fn:           flow.TaskFn(b.DeployManagedResourceForGardenerNodeAgent).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
+			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
+		})
+		waitUntilShootNamespacesReady = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
+		deployShootSystemResources    = g.AddGroup(b.ReconcileSystemResourcesTaskGroup().WithDependencies(syncPointReadyForSystemComponents))
+		_                             = g.Add(flow.Task{
 			Name:         "Populating static manifests from seed to shoot",
 			Fn:           flow.TaskFn(b.PopulateStaticManifestsFromSeedToShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, waitUntilShootNamespacesReady),
 		})
 		reconcileVPNComponents    = g.AddGroup(b.ReconcileVPNComponentsTaskGroup(flowCtx.skipReadiness).WithDependencies(syncPointReadyForSystemComponents))
@@ -519,12 +521,6 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			initializeShootClients,
 			deployKubeScheduler,
 		))
-		deployManagedResourceForGardenerNodeAgent = g.Add(flow.Task{
-			Name:         "Deploying managed resources for the gardener-node-agent",
-			Fn:           flow.TaskFn(b.DeployManagedResourceForGardenerNodeAgent).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
-		})
 		syncPointAllSystemComponentsDeployed = flow.NewTaskIDs(
 			reconcileSystemComponents,
 			deployShootSystemResources,
@@ -550,7 +546,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		_ = g.Add(flow.Task{
 			Name:         "Checking if we have dual-stack pod CIDRs in nodes",
 			Fn:           b.CheckPodCIDRsInNodes,
-			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
+			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -222,17 +222,10 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 	}
 
 	var (
-		deployExtensionAfterKAPIMsg = "Deploying extension resources after kube-apiserver"
-		waitExtensionAfterKAPIMsg   = "Waiting until extension resources handled after kube-apiserver are ready"
-
 		rotationPreparingPhases = sets.New(gardencorev1beta1.RotationPreparing, gardencorev1beta1.RotationPreparingWithoutWorkersRollout)
 		caRotationPreparing     = rotationPreparingPhases.Has(v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials))
 		saKeyRotationPreparing  = rotationPreparingPhases.Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials))
 	)
-	if b.Shoot.HibernationEnabled {
-		deployExtensionAfterKAPIMsg = "Hibernating extension resources before kube-apiserver hibernation"
-		waitExtensionAfterKAPIMsg = "Waiting until extension resources hibernated before kube-apiserver hibernation are ready"
-	}
 
 	var (
 		deployNamespace            = g.AddGroup(b.DeployNamespacesTaskGroup())
@@ -601,18 +594,9 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			SkipIf:       flowCtx.shootSSHAccessEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady),
 		})
-		deployExtensionResourcesAfterKAPI = g.Add(flow.Task{
-			Name:         deployExtensionAfterKAPIMsg,
-			Fn:           flow.TaskFn(b.DeployExtensionsAfterKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, initializeShootClients),
-		})
-		waitUntilExtensionResourcesAfterKAPIReady = g.Add(flow.Task{
-			Name:         waitExtensionAfterKAPIMsg,
-			Fn:           b.Shoot.Components.Extensions.Extension.WaitAfterKubeAPIServer,
-			SkipIf:       flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterKAPI),
-		})
+		waitUntilExtensionResourcesAfterKAPIReady = g.AddGroup(b.ReconcileExtensionsAfterKubeAPIServerTaskGroup(flowCtx.skipReadiness).WithDependencies(
+			initializeShootClients,
+		))
 		_                                   = g.AddGroup(b.ReconcileContainerRuntimeTaskGroup(flowCtx.skipReadiness))
 		waitUntilOperatingSystemConfigReady = g.AddGroup(b.ReconcileOperatingSystemConfigTaskGroup(flowCtx.skipReadiness).WithDependencies(
 			waitUntilInfrastructureReady,
@@ -905,18 +889,6 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Fn:           b.DestroyInternalDNSRecord,
 			SkipIf:       !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
-		})
-		deleteStaleExtensionResources = g.Add(flow.Task{
-			Name:         "Deleting stale extension resources",
-			Fn:           flow.TaskFn(b.Shoot.Components.Extensions.Extension.DeleteStaleResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(initializeShootClients),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Waiting until stale extension resources are deleted",
-			Fn:           b.Shoot.Components.Extensions.Extension.WaitCleanupStaleResources,
-			SkipIf:       b.Shoot.HibernationEnabled || flowCtx.skipReadiness || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(deleteStaleExtensionResources),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Restarting control plane pods",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -342,6 +342,28 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)),
 			Dependencies: flow.NewTaskIDs(reconcileStaticControlPlanePods, waitUntilGardenerResourceManagerReady),
 		})
+		_ = g.Add(flow.Task{
+			Name: "Renewing garden access secrets after creation of new ServiceAccount signing key in garden cluster",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				if err := tokenrequest.RenewAccessSecrets(ctx, b.SeedClientSet.Client(), client.MatchingLabels{resourcesv1alpha1.ResourceManagerClass: resourcesv1alpha1.ResourceManagerClassGarden}); err != nil {
+					return err
+				}
+				return removeShootOperationAnnotation(ctx, b.GardenClient, b.Shoot, v1beta1constants.SeedOperationRenewGardenAccessSecrets)
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       !b.Shoot.IsSelfHosted() || b.Shoot.GetInfo().Annotations[v1beta1constants.GardenerOperation] != v1beta1constants.SeedOperationRenewGardenAccessSecrets,
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Renewing workload identity tokens after rotation of workload identity key",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				if err := tokenrequest.RenewWorkloadIdentityTokens(ctx, b.SeedClientSet.Client()); err != nil {
+					return err
+				}
+				return removeShootOperationAnnotation(ctx, b.GardenClient, b.Shoot, v1beta1constants.SeedOperationRenewWorkloadIdentityTokens)
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       !b.Shoot.IsSelfHosted() || b.Shoot.GetInfo().Annotations[v1beta1constants.GardenerOperation] != v1beta1constants.SeedOperationRenewWorkloadIdentityTokens,
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
+		})
 		deployGardenerAccess = g.Add(flow.Task{
 			Name:         "Deploying Gardener shoot access resources",
 			Fn:           flow.TaskFn(b.Shoot.Components.GardenerAccess.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -674,4 +696,13 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 	)
 
 	return nil
+}
+
+func removeShootOperationAnnotation(ctx context.Context, gardenClient client.Client, shootObj *shoot.Shoot, operationAnnotation string) error {
+	return shootObj.UpdateInfo(ctx, gardenClient, false, func(s *gardencorev1beta1.Shoot) error {
+		if s.Annotations[v1beta1constants.GardenerOperation] == operationAnnotation {
+			delete(s.Annotations, v1beta1constants.GardenerOperation)
+		}
+		return nil
+	})
 }

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -536,27 +536,10 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			waitUntilOperatingSystemConfigReady,
 		))
 		_ = g.Add(flow.Task{
-			Name: "Deploying shoot cluster identity",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.DeployClusterIdentity(ctx)
-			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
-		})
-		_ = g.Add(flow.Task{
 			Name:         "Populating static manifests from seed to shoot",
 			Fn:           flow.TaskFn(b.PopulateStaticManifestsFromSeedToShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, waitUntilShootNamespacesReady),
-		})
-		deployMetricsServer = g.Add(flow.Task{
-			Name: "Deploying metrics-server system component",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.SystemComponents.MetricsServer.Deploy(ctx)
-			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				waitUntilGardenerResourceManagerReady, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployVPNShoot = g.Add(flow.Task{
 			Name:   "Deploying vpn-shoot system component",
@@ -573,15 +556,6 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted() || flowCtx.skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployVPNShoot),
 		})
-		deployNodeProblemDetector = g.Add(flow.Task{
-			Name: "Deploying node-problem-detector system component",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return b.Shoot.Components.SystemComponents.NodeProblemDetector.Deploy(ctx)
-			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				waitUntilGardenerResourceManagerReady, waitUntilOperatingSystemConfigReady, waitUntilShootNamespacesReady),
-		})
 		reconcileSystemComponents = g.AddGroup(b.ReconcileSystemComponentsTaskGroup(flowCtx.kubeProxyEnabled, flowCtx.skipReadiness).WithDependencies(
 			waitUntilControlPlaneReady,
 			waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
@@ -596,34 +570,6 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
-		deployBlackboxExporter = g.Add(flow.Task{
-			Name:   "Deploying blackbox-exporter",
-			Fn:     flow.TaskFn(b.ReconcileBlackboxExporterCluster).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
-		})
-		deployNodeExporter = g.Add(flow.Task{
-			Name:   "Deploying node-exporter",
-			Fn:     flow.TaskFn(b.ReconcileNodeExporter).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
-		})
-		deployKubernetesDashboard = g.Add(flow.Task{
-			Name:   "Deploying addon Kubernetes Dashboard",
-			Fn:     flow.TaskFn(b.DeployKubernetesDashboard).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
-		})
-		deployNginxIngressAddon = g.Add(flow.Task{
-			Name:   "Deploying addon Nginx Ingress Controller",
-			Fn:     flow.TaskFn(b.DeployNginxIngressAddon).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
-				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
-		})
 		deployManagedResourceForGardenerNodeAgent = g.Add(flow.Task{
 			Name:         "Deploying managed resources for the gardener-node-agent",
 			Fn:           flow.TaskFn(b.DeployManagedResourceForGardenerNodeAgent).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -635,13 +581,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			reconcileSystemComponents,
 			deployAPIServerProxy,
 			deployShootSystemResources,
-			deployNodeExporter,
-			deployMetricsServer,
 			waitUntilVPNShootReady,
-			deployNodeProblemDetector,
-			deployBlackboxExporter,
-			deployKubernetesDashboard,
-			deployNginxIngressAddon,
 		)
 
 		scaleClusterAutoscalerToZero = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -687,45 +687,13 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Dependencies: flow.NewTaskIDs(waitUntilAlertmanagerReconciled, waitUntilPrometheusReconciled, waitUntilPlutonoReconciled),
 		})
 
-		hibernateControlPlane = g.Add(flow.Task{
-			Name:         "Hibernating control plane",
-			Fn:           flow.TaskFn(b.HibernateControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
-			SkipIf:       !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(initializeShootClients, deployPrometheus, deployAlertmanager, deploySeedLogging, waitUntilWorkerReady, waitUntilExtensionResourcesAfterKAPIReady, waitUntilEtcdScaledAfterRestore),
-		})
-
-		// logic is inverted here
-		// extensions that are deployed before the kube-apiserver are hibernated after it
-		hibernateExtensionResourcesAfterKAPIHibernation = g.Add(flow.Task{
-			Name:         "Hibernating extension resources after kube-apiserver hibernation",
-			Fn:           flow.TaskFn(b.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Waiting until extension resources hibernated after kube-apiserver hibernation are ready",
-			Fn:           b.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
-			SkipIf:       flowCtx.skipReadiness || !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(hibernateExtensionResourcesAfterKAPIHibernation),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Destroying ingress domain DNS record if hibernated",
-			Fn:           b.DestroyIngressDNSRecord,
-			SkipIf:       !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Destroying external domain DNS record if hibernated",
-			Fn:           b.DestroyExternalDNSRecord,
-			SkipIf:       !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Destroying internal domain DNS record if hibernated",
-			Fn:           b.DestroyInternalDNSRecord,
-			SkipIf:       !b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
-			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
-		})
+		_ = g.AddGroup(b.HibernateControlPlaneTaskGroup(flowCtx.skipReadiness).WithDependencies(
+			initializeShootClients,
+			deployPrometheus,
+			deployAlertmanager,
+			deploySeedLogging,
+			waitUntilEtcdScaledAfterRestore,
+		))
 		_ = g.Add(flow.Task{
 			Name: "Restarting control plane pods",
 			Fn: func(ctx context.Context) error {

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -271,8 +271,8 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilKubeAPIServerServiceIsReady),
 		})
 		reconcileDNSRecords      = g.AddGroup(b.ReconcileDNSRecordsTaskGroup().WithDependencies(waitUntilKubeAPIServerServiceIsReady))
-		reconcileBackupResources = g.AddGroup(b.ReconcileBackupResourcesTaskGroup(flowCtx.allowBackup, flowCtx.isCopyOfBackupsRequired, flowCtx.skipReadiness))
-		waitUntilEtcdReady       = g.AddGroup(b.ReconcileETCDsTaskGroup(shootIsGarden, flowCtx.isRestoringHAControlPlane, flowCtx.skipReadiness).WithDependencies(reconcileBackupResources))
+		_                        = g.AddGroup(b.ReconcileBackupResourcesTaskGroup(flowCtx.allowBackup, flowCtx.isCopyOfBackupsRequired, flowCtx.skipReadiness))
+		waitUntilEtcdReady       = g.AddGroup(b.ReconcileETCDsTaskGroup(shootIsGarden, flowCtx.isRestoringHAControlPlane, flowCtx.skipReadiness))
 		destroySourceBackupEntry = g.Add(flow.Task{
 			Name:         "Destroying source backup entry",
 			Fn:           b.DestroySourceBackupEntry,
@@ -344,10 +344,10 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			).Has(v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials)) || b.Shoot.IsSelfHosted(),
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
-		waitUntilControlPlaneReady      = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
-		reconcileStaticControlPlanePods = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false).WithDependencies(waitUntilExtensionResourcesBeforeKAPIReady))
-		waitUntilShootNamespacesReady   = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
-		deployGardenerAccess            = g.Add(flow.Task{
+		waitUntilControlPlaneReady    = g.AddGroup(b.ReconcileControlPlaneTaskGroup(flowCtx.skipReadiness))
+		_                             = g.AddGroup(b.ReconcileStaticControlPlanePodsTaskGroup(false))
+		waitUntilShootNamespacesReady = g.AddGroup(b.ReconcileShootNamespacesTaskGroup(flowCtx.skipReadiness))
+		deployGardenerAccess          = g.Add(flow.Task{
 			Name:         "Deploying Gardener shoot access resources",
 			Fn:           flow.TaskFn(b.Shoot.Components.GardenerAccess.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsSelfHosted(),
@@ -498,13 +498,8 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		})
 		waitUntilExtensionResourcesAfterKAPIReady = g.AddGroup(b.ReconcileExtensionsAfterKubeAPIServerTaskGroup(flowCtx.skipReadiness).WithDependencies(initializeShootClients))
 		_                                         = g.AddGroup(b.ReconcileContainerRuntimeTaskGroup(flowCtx.skipReadiness))
-		waitUntilOperatingSystemConfigReady       = g.AddGroup(b.ReconcileOperatingSystemConfigTaskGroup(flowCtx.skipReadiness).WithDependencies(
-			waitUntilInfrastructureReady,
-			waitUntilControlPlaneReady,
-			deleteBastions,
-			waitUntilExtensionResourcesAfterKAPIReady,
-		))
-		syncPointReadyForSystemComponents = flow.NewTaskIDs(
+		waitUntilOperatingSystemConfigReady       = g.AddGroup(b.ReconcileOperatingSystemConfigTaskGroup(flowCtx.skipReadiness).WithDependencies(deleteBastions))
+		syncPointReadyForSystemComponents         = flow.NewTaskIDs(
 			initializeShootClients,
 			waitUntilOperatingSystemConfigReady,
 			waitUntilControlPlaneReady,
@@ -521,10 +516,7 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 		})
 		reconcileVPNComponents    = g.AddGroup(b.ReconcileVPNComponentsTaskGroup(flowCtx.skipReadiness).WithDependencies(syncPointReadyForSystemComponents))
 		reconcileSystemComponents = g.AddGroup(b.ReconcileSystemComponentsTaskGroup(flowCtx.kubeProxyEnabled, flowCtx.skipReadiness).WithDependencies(
-			waitUntilControlPlaneReady,
-			waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 			initializeShootClients,
-			ensureShootClusterIdentity,
 			deployKubeScheduler,
 		))
 		deployManagedResourceForGardenerNodeAgent = g.Add(flow.Task{
@@ -546,17 +538,13 @@ func (r *Reconciler) setupShootReconciliationFlow(ctx context.Context, b *botani
 			Dependencies: flow.NewTaskIDs(deployManagedResourceForGardenerNodeAgent),
 		})
 		_ = g.AddGroup(b.ReconcileMachineControllerManagerTaskGroup().WithDependencies(
-			waitUntilInfrastructureReady,
 			initializeShootClients,
-			waitUntilOperatingSystemConfigReady,
 			createNewServiceAccountSecrets,
 			scaleClusterAutoscalerToZero,
-			reconcileStaticControlPlanePods,
 		))
 		waitUntilWorkerReady = g.AddGroup(b.ReconcileWorkerTaskGroup(flowCtx.skipReadiness).WithDependencies(
 			deployManagedResourceForGardenerNodeAgent,
 			waitUntilKubeRootCAConfigMapsUpdated,
-			waitUntilOperatingSystemConfigReady,
 		))
 		_ = g.AddGroup(b.ReconcileExtensionsAfterWorkerTaskGroup(flowCtx.skipReadiness))
 		_ = g.Add(flow.Task{

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -6,6 +6,7 @@ package botanist
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -132,11 +133,46 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 		gardencorev1beta1.RotationPreparing,
 		gardencorev1beta1.RotationPreparingWithoutWorkersRollout,
 	).Has(v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials)) {
-		if err := flow.Parallel(
-			b.Shoot.Components.ControlPlane.EtcdMain.RolloutPeerCA,
-			b.Shoot.Components.ControlPlane.EtcdEvents.RolloutPeerCA,
-		)(ctx); err != nil {
-			return err
+		var taskFns []flow.TaskFn
+
+		for name, component := range map[string]etcd.Interface{
+			"etcd-main":   b.Shoot.Components.ControlPlane.EtcdMain,
+			"etcd-events": b.Shoot.Components.ControlPlane.EtcdEvents,
+		} {
+			if peerCARolloutCompleted, err := component.IsPeerCARolledOut(ctx); err != nil {
+				return fmt.Errorf("failed to check if peer CA rollout is completed for %s: %w", name, err)
+			} else if !peerCARolloutCompleted {
+				taskFns = append(taskFns, func(ctx context.Context) error {
+					if err := component.RolloutPeerCA(ctx); err != nil {
+						return err
+					}
+
+					// For hosted shoots, changing the Etcd resources leads to a rollout of the pods. This is not true
+					// for self-hosted shoots: Here, we first have to translate the created StatefulSet into static
+					// pods, populate them via OperatingSystemConfig to the node, and wait for kubelet to restart them.
+					// Since all this is a bit more involved, we are performing these steps in the
+					// `ReconcileStaticControlPlanePodsTaskGroup` function as part of the flow (instead of doing
+					// it here like for hosted shoots).
+					if b.Shoot.IsSelfHosted() {
+						return nil
+					}
+
+					return component.MarkAsPeerCARolloutCompleted(ctx)
+				})
+			}
+		}
+
+		if len(taskFns) > 0 {
+			if err := flow.Parallel(taskFns...)(ctx); err != nil {
+				return err
+			}
+
+			// For self-hosted shoots, we have to first translate the Etcd StatefulSet into static pods and roll them
+			// out before we can continue and modify the change the Etcd resource again. Hence, we stop here and call
+			// the `DeployEtcd` function again in the `ReconcileStaticControlPlanePodsTaskGroup` function.
+			if b.Shoot.IsSelfHosted() {
+				return nil
+			}
 		}
 	}
 

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -1057,6 +1057,55 @@ func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd boo
 	return g
 }
 
+// TaskGroupHibernateControlPlane is a flow.TaskID for a logical flow.TaskGroup.
+const TaskGroupHibernateControlPlane flow.TaskID = "TaskGroupHibernateControlPlane"
+
+// HibernateControlPlaneTaskGroup hibernates the control plane of a hosted shoot.
+func (b *Botanist) HibernateControlPlaneTaskGroup(skipReadiness bool) flow.TaskGroup {
+	var (
+		g = flow.NewTaskGroup(TaskGroupHibernateControlPlane).WithDependencies(
+			TaskGroupReconcileWorker,
+			TaskGroupReconcileExtensionsAfterKubeAPIServer,
+		).SkipIf(!b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted())
+
+		hibernateControlPlane = g.Add(flow.Task{
+			Name: "Hibernating control plane",
+			Fn:   flow.TaskFn(b.HibernateControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+		})
+
+		// logic is inverted here
+		// extensions that are deployed before the kube-apiserver are hibernated after it
+		hibernateExtensionResourcesAfterKAPIHibernation = g.Add(flow.Task{
+			Name:         "Hibernating extension resources after kube-apiserver hibernation",
+			Fn:           flow.TaskFn(b.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Waiting until extension resources hibernated after kube-apiserver hibernation are ready",
+			Fn:           b.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
+			SkipIf:       skipReadiness,
+			Dependencies: flow.NewTaskIDs(hibernateExtensionResourcesAfterKAPIHibernation),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Destroying ingress domain DNS record if hibernated",
+			Fn:           b.DestroyIngressDNSRecord,
+			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Destroying external domain DNS record if hibernated",
+			Fn:           b.DestroyExternalDNSRecord,
+			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Destroying internal domain DNS record if hibernated",
+			Fn:           b.DestroyInternalDNSRecord,
+			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
+		})
+	)
+
+	return g
+}
+
 func (b *Botanist) isGardenadmBootstrap() bool {
 	return b.Shoot.IsSelfHosted() && !b.Shoot.RunsControlPlane()
 }

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -140,54 +140,68 @@ func (b *Botanist) InitializeSecretsManagementTaskGroup() flow.TaskGroup {
 	}).WithDependencies(TaskGroupReconcileClusterResource)
 }
 
+// TaskGroupReconcileRuntimeGardenerResourceManager is a flow.TaskID for a logical flow.TaskGroup.
+const TaskGroupReconcileRuntimeGardenerResourceManager flow.TaskID = "TaskGroupReconcileRuntimeGardenerResourceManager"
+
+// ReconcileRuntimeGardenerResourceManagerTaskGroup returns the flow.TaskGroup for deploying the runtime
+// gardener-resource-manager instances.
+func (b *Botanist) ReconcileRuntimeGardenerResourceManagerTaskGroup(podNetworkAvailable, shootIsGarden, skipReadiness bool) flow.TaskGroup {
+	var (
+		g = flow.NewTaskGroup(TaskGroupReconcileRuntimeGardenerResourceManager).WithDependencies(
+			TaskGroupDeployNamespaces,
+			TaskGroupInitializeSecretsManagement,
+			TaskGroupReconcileCustomResourceDefinitions,
+		).SkipIf(!b.Shoot.IsSelfHosted() || shootIsGarden || b.isGardenadmBootstrap())
+
+		deployGardenerResourceManager = g.Add(flow.Task{
+			Name: "Deploying runtime gardener-resource-manager",
+			Fn: func(ctx context.Context) error {
+				if b.Shoot.IsSelfHosted() {
+					b.Shoot.Components.ControlPlane.RuntimeResourceManager.SetBootstrapControlPlaneNode(!podNetworkAvailable)
+				}
+				return b.DeployRuntimeGardenerResourceManager(ctx)
+			},
+		})
+		_ = g.Add(flow.Task{
+			Name: "Waiting until runtime gardener-resource-manager reports readiness",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.ControlPlane.RuntimeResourceManager.Wait(ctx)
+			},
+			SkipIf:       b.Shoot.HibernationEnabled || skipReadiness,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
+		})
+	)
+
+	return g
+}
+
 // TaskGroupReconcileGardenerResourceManager is a flow.TaskID for a logical flow.TaskGroup.
 const TaskGroupReconcileGardenerResourceManager flow.TaskID = "TaskGroupReconcileGardenerResourceManager"
 
 // ReconcileGardenerResourceManagerTaskGroup returns the flow.TaskGroup for deploying the gardener-resource-manager
-// instances. It waits for their readiness and also deploys the seed and shoot system resources afterwards.
-func (b *Botanist) ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, shootIsGarden, skipReadiness bool) flow.TaskGroup {
+// instances.
+func (b *Botanist) ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, skipReadiness bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileGardenerResourceManager).WithDependencies(
 			TaskGroupDeployNamespaces,
 			TaskGroupInitializeSecretsManagement,
 			TaskGroupReconcileCustomResourceDefinitions,
+			TaskGroupReconcileRuntimeGardenerResourceManager,
 		)
-
-		skipRuntimeResourceManager = !b.Shoot.IsSelfHosted() || shootIsGarden || b.isGardenadmBootstrap()
 
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name: "Deploying gardener-resource-manager",
 			Fn: func(ctx context.Context) error {
 				if b.Shoot.IsSelfHosted() {
 					b.Shoot.Components.ControlPlane.ResourceManager.SetBootstrapControlPlaneNode(!podNetworkAvailable)
-					if !skipRuntimeResourceManager {
-						b.Shoot.Components.ControlPlane.RuntimeResourceManager.SetBootstrapControlPlaneNode(!podNetworkAvailable)
-					}
 				}
-
-				if skipRuntimeResourceManager {
-					return b.DeployGardenerResourceManager(ctx)
-				}
-
-				// Deploy sequentially: only `RuntimeResourceManager` installs the `ManagedResource` CRD, and
-				// `ResourceManager.Deploy` creates a `ManagedResource` object on the same client.
-				return flow.Sequential(
-					b.DeployRuntimeGardenerResourceManager,
-					b.DeployGardenerResourceManager,
-				)(ctx)
+				return b.DeployGardenerResourceManager(ctx)
 			},
 		})
 		_ = g.Add(flow.Task{
 			Name: "Waiting until gardener-resource-manager reports readiness",
 			Fn: func(ctx context.Context) error {
-				if skipRuntimeResourceManager {
-					return b.Shoot.Components.ControlPlane.ResourceManager.Wait(ctx)
-				}
-
-				return flow.Parallel(
-					b.Shoot.Components.ControlPlane.RuntimeResourceManager.Wait,
-					b.Shoot.Components.ControlPlane.ResourceManager.Wait,
-				)(ctx)
+				return b.Shoot.Components.ControlPlane.ResourceManager.Wait(ctx)
 			},
 			SkipIf:       b.Shoot.HibernationEnabled || skipReadiness,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -414,6 +414,9 @@ func (b *Botanist) ReconcileControlPlaneTaskGroup(skipReadiness bool) flow.TaskG
 				TaskGroupReconcileGardenerResourceManager,
 				TaskGroupReconcileInfrastructure,
 				TaskGroupReconcileReferencedResources,
+			).
+			WithDependenciesIf(b.isGardenlet(),
+				TaskGroupReconcileStaticPods,
 			)
 
 		deployControlPlane = g.Add(flow.Task{
@@ -700,6 +703,7 @@ const TaskGroupReconcileWorker flow.TaskID = "TaskGroupReconcileWorker"
 func (b *Botanist) ReconcileWorkerTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
 		g = flow.NewTaskGroup(TaskGroupReconcileWorker).
+			SkipIf(b.Shoot.IsWorkerless || !b.Shoot.HasManagedInfrastructure()).
 			WithDependencies(
 				TaskGroupInitializeSecretsManagement,
 				TaskGroupDeployCloudProviderSecret,
@@ -718,22 +722,21 @@ func (b *Botanist) ReconcileWorkerTaskGroup(skipReadiness bool) flow.TaskGroup {
 		}
 
 		deployWorker = g.Add(flow.Task{
-			Name:   "Configuring worker pools",
-			Fn:     b.DeployWorker,
-			SkipIf: !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless,
+			Name: "Configuring worker pools",
+			Fn:   b.DeployWorker,
 		})
 		waitUntilWorkerStatusUpdate = g.Add(flow.Task{
 			Name: "Waiting until worker resource status is updated with latest machine deployments",
 			Fn: func(ctx context.Context) error {
 				return b.Shoot.Components.Extensions.Worker.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)
 			},
-			SkipIf:       !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployWorker),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying cluster-autoscaler",
 			Fn:           b.DeployClusterAutoscaler,
-			SkipIf:       !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+			SkipIf:       b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
 		})
 		_ = g.Add(flow.Task{
@@ -774,7 +777,7 @@ func (b *Botanist) ReconcileWorkerTaskGroup(skipReadiness bool) flow.TaskGroup {
 
 				return nil
 			},
-			SkipIf:       !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless || skipReadiness,
+			SkipIf:       skipReadiness,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
 		})
 	)
@@ -1057,7 +1060,6 @@ func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd boo
 			WithDependencies(
 				TaskGroupInitializeSecretsManagement,
 				TaskGroupReconcileGardenerResourceManager,
-				TaskGroupReconcileControlPlane,
 				TaskGroupReconcileETCDs,
 			).
 			WithDependenciesIf(b.isGardenlet(),

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -899,6 +899,47 @@ func (b *Botanist) ReconcileSystemComponentsTaskGroup(kubeProxyEnabled, skipRead
 	return g
 }
 
+// TaskGroupReconcileVPNComponents is a flow.TaskID for a logical flow.TaskGroup.
+const TaskGroupReconcileVPNComponents flow.TaskID = "TaskGroupReconcileVPNComponents"
+
+// ReconcileVPNComponentsTaskGroup returns the flow.TaskGroup for reconciling VPN components.
+func (b *Botanist) ReconcileVPNComponentsTaskGroup(skipReadiness bool) flow.TaskGroup {
+	var (
+		g = flow.NewTaskGroup(TaskGroupReconcileVPNComponents).WithDependencies(
+			TaskGroupDeployNamespaces,
+			TaskGroupInitializeSecretsManagement,
+			TaskGroupReconcileGardenerResourceManager,
+		).SkipIf(b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted())
+
+		deployVPNSeedServer = g.Add(flow.Task{
+			Name: "Deploying vpn-seed-server",
+			Fn:   flow.TaskFn(b.DeployVPNServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
+		})
+
+		_ = g.Add(flow.Task{
+			Name: "Deploying apiserver-proxy",
+			Fn:   flow.TaskFn(b.DeployAPIServerProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+		})
+
+		deployVPNShoot = g.Add(flow.Task{
+			Name:         "Deploying vpn-shoot system component",
+			Fn:           flow.TaskFn(b.DeployVPNShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       b.Shoot.HibernationEnabled,
+			Dependencies: flow.NewTaskIDs(deployVPNSeedServer),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Waiting until vpn-shoot system component is ready",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.SystemComponents.VPNShoot.Wait(ctx)
+			},
+			SkipIf:       b.Shoot.HibernationEnabled || skipReadiness,
+			Dependencies: flow.NewTaskIDs(deployVPNShoot),
+		})
+	)
+
+	return g
+}
+
 // TaskGroupReconcileETCDs is a flow.TaskID for a logical flow.TaskGroup.
 const TaskGroupReconcileETCDs flow.TaskID = "TaskGroupReconcileETCDs"
 

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -1107,7 +1107,7 @@ func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd boo
 		waitUntilControlPlaneComponentsRolledOut = g.Add(flow.Task{
 			Name: "Waiting until control plane components (static pods) are rolled out and ready",
 			Fn: func(ctx context.Context) error {
-				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, true)
+				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, b.isGardenlet(), true)
 			},
 			Dependencies: flow.NewTaskIDs(updateNodeAgentSecretNameLabels),
 		})
@@ -1165,7 +1165,7 @@ func (b *Botanist) handleCredentialsRotationForStaticPods(g *flow.TaskGroup, rea
 		_ = g.Add(flow.Task{
 			Name: "Waiting until control plane components (static pods) are rolled out and ready (second rollout)",
 			Fn: func(ctx context.Context) error {
-				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, true)
+				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, true, true)
 			},
 			SkipIf:       !etcdEncryptionKeyRotationPreparing && !caRotationPreparing,
 			Dependencies: flow.NewTaskIDs(deployControlPlaneDeployments),

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -22,6 +24,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/logging/fluentoperator"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
 	seedsystem "github.com/gardener/gardener/pkg/component/seed/system"
+	"github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerextensions "github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot/helper"
@@ -1101,8 +1104,8 @@ func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd boo
 			SkipIf:       !controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskUpdateGardenerNodeAgentSecretName),
 			Dependencies: flow.NewTaskIDs(deployControlPlaneDeployments),
 		})
-		_ = g.Add(flow.Task{
-			Name: "Waiting until control plane components (static pods) are ready",
+		waitUntilControlPlaneComponentsRolledOut = g.Add(flow.Task{
+			Name: "Waiting until control plane components (static pods) are rolled out and ready",
 			Fn: func(ctx context.Context) error {
 				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, true)
 			},
@@ -1110,7 +1113,40 @@ func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd boo
 		})
 	)
 
+	b.handleCredentialsRotationForStaticPods(&g, waitUntilControlPlaneComponentsRolledOut)
 	return g
+}
+
+func (b *Botanist) handleCredentialsRotationForStaticPods(g *flow.TaskGroup, readyForSecondRollout flow.TaskIDer) {
+	var (
+		rotationPreparingPhases            = sets.New(gardencorev1beta1.RotationPreparing, gardencorev1beta1.RotationPreparingWithoutWorkersRollout)
+		etcdEncryptionKeyRotationPreparing = rotationPreparingPhases.Has(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials))
+
+		patchKubeAPIServerDeployment = g.Add(flow.Task{
+			Name: "Marking kube-apiserver deployment as ready for encryption key switch",
+			Fn: func(ctx context.Context) error {
+				return shared.MarkAPIServerDeploymentAsReadyForEncryptionKeySwitch(ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer)
+			},
+			SkipIf:       !etcdEncryptionKeyRotationPreparing,
+			Dependencies: flow.NewTaskIDs(readyForSecondRollout),
+		})
+		deployControlPlaneDeployments = g.Add(flow.Task{
+			Name: "Deploying control plane components as Deployments/StatefulSets and updating gardener-node-agent Secret (second rollout)",
+			Fn: func(ctx context.Context) error {
+				return b.DeployStaticControlPlaneDeployments(ctx, false)
+			},
+			SkipIf:       !etcdEncryptionKeyRotationPreparing,
+			Dependencies: flow.NewTaskIDs(patchKubeAPIServerDeployment),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Waiting until control plane components (static pods) are rolled out and ready (second rollout)",
+			Fn: func(ctx context.Context) error {
+				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, true)
+			},
+			SkipIf:       !etcdEncryptionKeyRotationPreparing,
+			Dependencies: flow.NewTaskIDs(deployControlPlaneDeployments),
+		})
+	)
 }
 
 // TaskGroupHibernateControlPlane is a flow.TaskID for a logical flow.TaskGroup.

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -355,7 +355,7 @@ func (b *Botanist) ReconcileExtensionsBeforeKubeAPIServerTaskGroup(skipReadiness
 			TaskGroupReconcileInfrastructure,
 		).SkipIf(b.Shoot.HibernationEnabled)
 
-		deployExtensionResourcesBeforeKAPI = g.Add(flow.Task{
+		deployExtensionResources = g.Add(flow.Task{
 			Name: "Deploying extension resources before kube-apiserver",
 			Fn:   flow.TaskFn(b.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
 		})
@@ -363,9 +363,61 @@ func (b *Botanist) ReconcileExtensionsBeforeKubeAPIServerTaskGroup(skipReadiness
 			Name:         "Waiting until extension resources handled before kube-apiserver are ready",
 			Fn:           b.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
 			SkipIf:       skipReadiness,
-			Dependencies: flow.NewTaskIDs(deployExtensionResourcesBeforeKAPI),
+			Dependencies: flow.NewTaskIDs(deployExtensionResources),
 		})
 	)
+
+	return g
+}
+
+// TaskGroupReconcileExtensionsAfterKubeAPIServer is a flow.TaskID for a logical flow.TaskGroup.
+const TaskGroupReconcileExtensionsAfterKubeAPIServer flow.TaskID = "TaskGroupReconcileExtensionsAfterKubeAPIServer"
+
+// ReconcileExtensionsAfterKubeAPIServerTaskGroup returns the flow.TaskGroup for deploying the Extensions resources
+// after kube-apiserver and waiting for their readiness.
+func (b *Botanist) ReconcileExtensionsAfterKubeAPIServerTaskGroup(skipReadiness bool) flow.TaskGroup {
+	var (
+		deployExtensionAfterKAPIMsg = "Deploying extension resources after kube-apiserver"
+		waitExtensionAfterKAPIMsg   = "Waiting until extension resources handled after kube-apiserver are ready"
+	)
+	if b.Shoot.HibernationEnabled {
+		deployExtensionAfterKAPIMsg = "Hibernating extension resources before kube-apiserver hibernation"
+		waitExtensionAfterKAPIMsg = "Waiting until extension resources hibernated before kube-apiserver hibernation are ready"
+	}
+
+	var (
+		g = flow.NewTaskGroup(TaskGroupReconcileExtensionsAfterKubeAPIServer).WithDependencies(
+			TaskGroupDeployCloudProviderSecret,
+			TaskGroupInitializeSecretsManagement,
+			TaskGroupReconcileReferencedResources,
+			TaskGroupReconcileInfrastructure,
+		)
+
+		deployExtensionResources = g.Add(flow.Task{
+			Name: deployExtensionAfterKAPIMsg,
+			Fn:   flow.TaskFn(b.DeployExtensionsAfterKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
+		})
+		_ = g.Add(flow.Task{
+			Name:         waitExtensionAfterKAPIMsg,
+			Fn:           b.Shoot.Components.Extensions.Extension.WaitAfterKubeAPIServer,
+			SkipIf:       skipReadiness,
+			Dependencies: flow.NewTaskIDs(deployExtensionResources),
+		})
+		deleteStaleExtensionResources = g.Add(flow.Task{
+			Name: "Deleting stale extension resources",
+			Fn:   flow.TaskFn(b.Shoot.Components.Extensions.Extension.DeleteStaleResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Waiting until stale extension resources are deleted",
+			Fn:           b.Shoot.Components.Extensions.Extension.WaitCleanupStaleResources,
+			SkipIf:       b.Shoot.HibernationEnabled || skipReadiness,
+			Dependencies: flow.NewTaskIDs(deleteStaleExtensionResources),
+		})
+	)
+
+	if b.Shoot.IsSelfHosted() {
+		g = g.WithDependencies(TaskGroupReconcileStaticPods)
+	}
 
 	return g
 }

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -7,6 +7,7 @@ package botanist
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
@@ -164,11 +165,13 @@ const TaskGroupReconcileRuntimeGardenerResourceManager flow.TaskID = "TaskGroupR
 // gardener-resource-manager instances.
 func (b *Botanist) ReconcileRuntimeGardenerResourceManagerTaskGroup(podNetworkAvailable, shootIsGarden, skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileRuntimeGardenerResourceManager).WithDependencies(
-			TaskGroupDeployNamespaces,
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupReconcileCustomResourceDefinitions,
-		).SkipIf(!b.Shoot.IsSelfHosted() || shootIsGarden || b.isGardenadmBootstrap())
+		g = flow.NewTaskGroup(TaskGroupReconcileRuntimeGardenerResourceManager).
+			SkipIf(!b.Shoot.IsSelfHosted() || shootIsGarden || b.isGardenadmBootstrap()).
+			WithDependencies(
+				TaskGroupDeployNamespaces,
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupReconcileCustomResourceDefinitions,
+			)
 
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name: "Deploying runtime gardener-resource-manager",
@@ -199,12 +202,13 @@ const TaskGroupReconcileGardenerResourceManager flow.TaskID = "TaskGroupReconcil
 // instances.
 func (b *Botanist) ReconcileGardenerResourceManagerTaskGroup(podNetworkAvailable, skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileGardenerResourceManager).WithDependencies(
-			TaskGroupDeployNamespaces,
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupReconcileCustomResourceDefinitions,
-			TaskGroupReconcileRuntimeGardenerResourceManager,
-		)
+		g = flow.NewTaskGroup(TaskGroupReconcileGardenerResourceManager).
+			WithDependencies(
+				TaskGroupDeployNamespaces,
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupReconcileCustomResourceDefinitions,
+				TaskGroupReconcileRuntimeGardenerResourceManager,
+			)
 
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name: "Deploying gardener-resource-manager",
@@ -234,10 +238,11 @@ const TaskGroupReconcileSystemResources flow.TaskID = "TaskGroupReconcileSystemR
 // ReconcileSystemResourcesTaskGroup returns the flow.TaskGroup for deploying the system resources.
 func (b *Botanist) ReconcileSystemResourcesTaskGroup() flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileSystemResources).WithDependencies(
-			TaskGroupReconcileGardenerResourceManager,
-			TaskGroupReconcileReferencedResources,
-		)
+		g = flow.NewTaskGroup(TaskGroupReconcileSystemResources).
+			WithDependencies(
+				TaskGroupReconcileGardenerResourceManager,
+				TaskGroupReconcileReferencedResources,
+			)
 
 		_ = g.Add(flow.Task{
 			Name: "Deploying seed system resources",
@@ -261,15 +266,22 @@ const TaskGroupReconcileMachineControllerManager flow.TaskID = "TaskGroupReconci
 
 // ReconcileMachineControllerManagerTaskGroup returns the flow.TaskGroup for deploying the machine-controller-manager.
 func (b *Botanist) ReconcileMachineControllerManagerTaskGroup() flow.TaskGroup {
-	return flow.NewTaskGroup(TaskGroupReconcileMachineControllerManager, flow.Task{
-		Name:   "Deploying machine-controller-manager",
-		Fn:     flow.TaskFn(b.DeployMachineControllerManager).RetryUntilTimeout(time.Second, time.Minute),
-		SkipIf: !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless,
-	}).WithDependencies(
-		TaskGroupInitializeSecretsManagement,
-		TaskGroupDeployCloudProviderSecret,
-		TaskGroupReconcileGardenerResourceManager,
-	)
+	return flow.
+		NewTaskGroup(TaskGroupReconcileMachineControllerManager, flow.Task{
+			Name:   "Deploying machine-controller-manager",
+			Fn:     flow.TaskFn(b.DeployMachineControllerManager).RetryUntilTimeout(time.Second, time.Minute),
+			SkipIf: !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless,
+		}).
+		WithDependencies(
+			TaskGroupInitializeSecretsManagement,
+			TaskGroupDeployCloudProviderSecret,
+			TaskGroupReconcileGardenerResourceManager,
+		).
+		WithDependenciesIf(b.isGardenlet(),
+			TaskGroupReconcileInfrastructure,
+			TaskGroupReconcileOperatingSystemConfig,
+			TaskGroupReconcileStaticPods,
+		)
 }
 
 // TaskGroupReconcileBackupResources is a flow.TaskID for a logical flow.TaskGroup.
@@ -279,12 +291,13 @@ const TaskGroupReconcileBackupResources flow.TaskID = "TaskGroupReconcileBackupR
 // resources and waiting for their readiness.
 func (b *Botanist) ReconcileBackupResourcesTaskGroup(allowBackup, isCopyOfBackupsRequired, skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileBackupResources).WithDependencies(
-			TaskGroupDeployNamespaces,
-			TaskGroupDeployCloudProviderSecret,
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupReconcileReferencedResources,
-		)
+		g = flow.NewTaskGroup(TaskGroupReconcileBackupResources).
+			WithDependencies(
+				TaskGroupDeployNamespaces,
+				TaskGroupDeployCloudProviderSecret,
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupReconcileReferencedResources,
+			)
 
 		deploySourceBackupEntry = g.Add(flow.Task{
 			Name:   "Deploying source backup entry",
@@ -357,11 +370,12 @@ const TaskGroupReconcileInfrastructure flow.TaskID = "TaskGroupReconcileInfrastr
 // waiting for its readiness.
 func (b *Botanist) ReconcileInfrastructureTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileInfrastructure).WithDependencies(
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupDeployCloudProviderSecret,
-			TaskGroupReconcileReferencedResources,
-		)
+		g = flow.NewTaskGroup(TaskGroupReconcileInfrastructure).
+			WithDependencies(
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupDeployCloudProviderSecret,
+				TaskGroupReconcileReferencedResources,
+			)
 
 		deployInfrastructure = g.Add(flow.Task{
 			Name:   "Deploying Shoot infrastructure",
@@ -393,13 +407,14 @@ const TaskGroupReconcileControlPlane flow.TaskID = "TaskGroupReconcileControlPla
 // waiting for its readiness.
 func (b *Botanist) ReconcileControlPlaneTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileControlPlane).WithDependencies(
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupDeployCloudProviderSecret,
-			TaskGroupReconcileGardenerResourceManager,
-			TaskGroupReconcileInfrastructure,
-			TaskGroupReconcileReferencedResources,
-		)
+		g = flow.NewTaskGroup(TaskGroupReconcileControlPlane).
+			WithDependencies(
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupDeployCloudProviderSecret,
+				TaskGroupReconcileGardenerResourceManager,
+				TaskGroupReconcileInfrastructure,
+				TaskGroupReconcileReferencedResources,
+			)
 
 		deployControlPlane = g.Add(flow.Task{
 			Name:   "Deploying shoot control plane components",
@@ -426,9 +441,11 @@ const TaskGroupReconcileDNSRecords flow.TaskID = "TaskGroupReconcileDNSRecords"
 // and waiting for their readiness.
 func (b *Botanist) ReconcileDNSRecordsTaskGroup() flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileDNSRecords).WithDependencies(
-			TaskGroupReconcileReferencedResources,
-		).SkipIf(b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted())
+		g = flow.NewTaskGroup(TaskGroupReconcileDNSRecords).
+			SkipIf(b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted()).
+			WithDependencies(
+				TaskGroupReconcileReferencedResources,
+			)
 
 		_ = g.Add(flow.Task{
 			Name: "Deploying internal domain DNS record",
@@ -460,12 +477,14 @@ const TaskGroupReconcileExtensionsBeforeKubeAPIServer flow.TaskID = "TaskGroupRe
 // before kube-apiserver and waiting for their readiness.
 func (b *Botanist) ReconcileExtensionsBeforeKubeAPIServerTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileExtensionsBeforeKubeAPIServer).WithDependencies(
-			TaskGroupDeployCloudProviderSecret,
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupReconcileReferencedResources,
-			TaskGroupReconcileInfrastructure,
-		).SkipIf(b.Shoot.HibernationEnabled)
+		g = flow.NewTaskGroup(TaskGroupReconcileExtensionsBeforeKubeAPIServer).
+			SkipIf(b.Shoot.HibernationEnabled).
+			WithDependencies(
+				TaskGroupDeployCloudProviderSecret,
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupReconcileReferencedResources,
+				TaskGroupReconcileInfrastructure,
+			)
 
 		deployExtensionResources = g.Add(flow.Task{
 			Name: "Deploying extension resources before kube-apiserver",
@@ -498,12 +517,16 @@ func (b *Botanist) ReconcileExtensionsAfterKubeAPIServerTaskGroup(skipReadiness 
 	}
 
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileExtensionsAfterKubeAPIServer).WithDependencies(
-			TaskGroupDeployCloudProviderSecret,
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupReconcileReferencedResources,
-			TaskGroupReconcileInfrastructure,
-		)
+		g = flow.NewTaskGroup(TaskGroupReconcileExtensionsAfterKubeAPIServer).
+			WithDependencies(
+				TaskGroupDeployCloudProviderSecret,
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupReconcileReferencedResources,
+				TaskGroupReconcileInfrastructure,
+			).
+			WithDependenciesIf(b.Shoot.IsSelfHosted(),
+				TaskGroupReconcileStaticPods,
+			)
 
 		deployExtensionResources = g.Add(flow.Task{
 			Name: deployExtensionAfterKAPIMsg,
@@ -527,10 +550,6 @@ func (b *Botanist) ReconcileExtensionsAfterKubeAPIServerTaskGroup(skipReadiness 
 		})
 	)
 
-	if b.Shoot.IsSelfHosted() {
-		g = g.WithDependencies(TaskGroupReconcileStaticPods)
-	}
-
 	return g
 }
 
@@ -541,12 +560,14 @@ const TaskGroupReconcileExtensionsAfterWorker flow.TaskID = "TaskGroupReconcileE
 // after the Worker resource and waiting for their readiness.
 func (b *Botanist) ReconcileExtensionsAfterWorkerTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileExtensionsAfterWorker).WithDependencies(
-			TaskGroupDeployCloudProviderSecret,
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupReconcileReferencedResources,
-			TaskGroupReconcileWorker,
-		).SkipIf(b.Shoot.IsWorkerless)
+		g = flow.NewTaskGroup(TaskGroupReconcileExtensionsAfterWorker).
+			SkipIf(b.Shoot.IsWorkerless).
+			WithDependencies(
+				TaskGroupDeployCloudProviderSecret,
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupReconcileReferencedResources,
+				TaskGroupReconcileWorker,
+			)
 
 		deployExtensionResources = g.Add(flow.Task{
 			Name: "Deploying extension resources after workers",
@@ -570,11 +591,13 @@ const TaskGroupReconcileContainerRuntime flow.TaskID = "TaskGroupReconcileContai
 // and waiting for its readiness.
 func (b *Botanist) ReconcileContainerRuntimeTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileContainerRuntime).WithDependencies(
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupReconcileReferencedResources,
-			TaskGroupReconcileGardenerResourceManager,
-		).SkipIf(b.Shoot.IsWorkerless)
+		g = flow.NewTaskGroup(TaskGroupReconcileContainerRuntime).
+			SkipIf(b.Shoot.IsWorkerless).
+			WithDependencies(
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupReconcileReferencedResources,
+				TaskGroupReconcileGardenerResourceManager,
+			)
 
 		deployContainerRuntimeResources = g.Add(flow.Task{
 			Name: "Deploying container runtime resources",
@@ -614,12 +637,20 @@ const TaskGroupReconcileOperatingSystemConfig flow.TaskID = "TaskGroupReconcileO
 // resource and waiting for its readiness.
 func (b *Botanist) ReconcileOperatingSystemConfigTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileOperatingSystemConfig).WithDependencies(
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupDeployCloudProviderSecret,
-			TaskGroupReconcileGardenerResourceManager,
-			TaskGroupReconcileReferencedResources,
-		).SkipIf(b.Shoot.IsSelfHosted() && !b.isGardenadmBootstrap())
+		g = flow.
+			NewTaskGroup(TaskGroupReconcileOperatingSystemConfig).
+			SkipIf(b.Shoot.IsSelfHosted() && !b.isGardenadmBootstrap()).
+			WithDependencies(
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupDeployCloudProviderSecret,
+				TaskGroupReconcileGardenerResourceManager,
+				TaskGroupReconcileReferencedResources,
+			).
+			WithDependenciesIf(b.isGardenlet(),
+				TaskGroupReconcileInfrastructure,
+				TaskGroupReconcileControlPlane,
+				TaskGroupReconcileExtensionsAfterKubeAPIServer,
+			)
 
 		deployOperatingSystemConfig = g.Add(flow.Task{
 			Name: "Deploying OperatingSystemConfig resources for worker pools",
@@ -668,14 +699,18 @@ const TaskGroupReconcileWorker flow.TaskID = "TaskGroupReconcileWorker"
 // to get reconciled.
 func (b *Botanist) ReconcileWorkerTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileWorker).WithDependencies(
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupDeployCloudProviderSecret,
-			TaskGroupReconcileGardenerResourceManager,
-			TaskGroupReconcileInfrastructure,
-			TaskGroupReconcileMachineControllerManager,
-			TaskGroupReconcileSystemResources,
-		)
+		g = flow.NewTaskGroup(TaskGroupReconcileWorker).
+			WithDependencies(
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupDeployCloudProviderSecret,
+				TaskGroupReconcileGardenerResourceManager,
+				TaskGroupReconcileInfrastructure,
+				TaskGroupReconcileMachineControllerManager,
+				TaskGroupReconcileSystemResources,
+			).
+			WithDependenciesIf(b.isGardenlet(),
+				TaskGroupReconcileOperatingSystemConfig,
+			)
 
 		shootHasPendingInPlaceUpdateWorkers = func(shoot *gardencorev1beta1.Shoot) bool {
 			return shoot.Status.InPlaceUpdates != nil && shoot.Status.InPlaceUpdates.PendingWorkerUpdates != nil &&
@@ -754,7 +789,10 @@ const TaskGroupReconcileShootNamespaces flow.TaskID = "TaskGroupReconcileShootNa
 // readiness.
 func (b *Botanist) ReconcileShootNamespacesTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileShootNamespaces).WithDependencies(TaskGroupReconcileGardenerResourceManager)
+		g = flow.NewTaskGroup(TaskGroupReconcileShootNamespaces).
+			WithDependencies(
+				TaskGroupReconcileGardenerResourceManager,
+			)
 
 		deployShootNamespaces = g.Add(flow.Task{
 			Name: "Deploying shoot namespaces system component",
@@ -777,11 +815,16 @@ const TaskGroupReconcileSystemComponents flow.TaskID = "TaskGroupReconcileSystem
 // ReconcileSystemComponentsTaskGroup returns the flow.TaskGroup for reconciling shoot system components.
 func (b *Botanist) ReconcileSystemComponentsTaskGroup(kubeProxyEnabled, skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileSystemComponents).WithDependencies(
-			TaskGroupReconcileInfrastructure,
-			TaskGroupReconcileGardenerResourceManager,
-			TaskGroupReconcileShootNamespaces,
-		)
+		g = flow.NewTaskGroup(TaskGroupReconcileSystemComponents).
+			WithDependencies(
+				TaskGroupReconcileInfrastructure,
+				TaskGroupReconcileGardenerResourceManager,
+				TaskGroupReconcileShootNamespaces,
+			).
+			WithDependenciesIf(b.isGardenlet(),
+				TaskGroupReconcileControlPlane,
+				TaskGroupReconcileExtensionsAfterKubeAPIServer, // Extensions might deploy webhooks for system components
+			)
 
 		deployNetwork = g.Add(flow.Task{
 			Name:   "Deploying shoot network plugin",
@@ -905,11 +948,13 @@ const TaskGroupReconcileVPNComponents flow.TaskID = "TaskGroupReconcileVPNCompon
 // ReconcileVPNComponentsTaskGroup returns the flow.TaskGroup for reconciling VPN components.
 func (b *Botanist) ReconcileVPNComponentsTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileVPNComponents).WithDependencies(
-			TaskGroupDeployNamespaces,
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupReconcileGardenerResourceManager,
-		).SkipIf(b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted())
+		g = flow.NewTaskGroup(TaskGroupReconcileVPNComponents).
+			SkipIf(b.Shoot.IsWorkerless || b.Shoot.IsSelfHosted()).
+			WithDependencies(
+				TaskGroupDeployNamespaces,
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupReconcileGardenerResourceManager,
+			)
 
 		deployVPNSeedServer = g.Add(flow.Task{
 			Name: "Deploying vpn-seed-server",
@@ -947,10 +992,14 @@ const TaskGroupReconcileETCDs flow.TaskID = "TaskGroupReconcileETCDs"
 // their readiness.
 func (b *Botanist) ReconcileETCDsTaskGroup(shootIsGarden, isRestoringHAControlPlane, skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileETCDs).WithDependencies(
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupDeployCloudProviderSecret,
-		)
+		g = flow.NewTaskGroup(TaskGroupReconcileETCDs).
+			WithDependencies(
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupDeployCloudProviderSecret,
+			).
+			WithDependenciesIf(b.isGardenlet(),
+				TaskGroupReconcileBackupResources,
+			)
 
 		deployEtcdDruid = g.Add(flow.Task{
 			Name: "Deploying ETCD Druid",
@@ -1003,12 +1052,17 @@ const TaskGroupReconcileStaticPods flow.TaskID = "TaskGroupReconcileStaticPods"
 // changes to be rolled out.
 func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileStaticPods).WithDependencies(
-			TaskGroupInitializeSecretsManagement,
-			TaskGroupReconcileGardenerResourceManager,
-			TaskGroupReconcileControlPlane,
-			TaskGroupReconcileETCDs,
-		).SkipIf(!b.Shoot.IsSelfHosted())
+		g = flow.NewTaskGroup(TaskGroupReconcileStaticPods).
+			SkipIf(!b.Shoot.IsSelfHosted()).
+			WithDependencies(
+				TaskGroupInitializeSecretsManagement,
+				TaskGroupReconcileGardenerResourceManager,
+				TaskGroupReconcileControlPlane,
+				TaskGroupReconcileETCDs,
+			).
+			WithDependenciesIf(b.isGardenlet(),
+				TaskGroupReconcileExtensionsBeforeKubeAPIServer,
+			)
 
 		_ = g.Add(flow.Task{
 			Name: "Reconciling cluster-admin access resources for kubeconfig on control plane nodes",
@@ -1063,10 +1117,12 @@ const TaskGroupHibernateControlPlane flow.TaskID = "TaskGroupHibernateControlPla
 // HibernateControlPlaneTaskGroup hibernates the control plane of a hosted shoot.
 func (b *Botanist) HibernateControlPlaneTaskGroup(skipReadiness bool) flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupHibernateControlPlane).WithDependencies(
-			TaskGroupReconcileWorker,
-			TaskGroupReconcileExtensionsAfterKubeAPIServer,
-		).SkipIf(!b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted())
+		g = flow.NewTaskGroup(TaskGroupHibernateControlPlane).
+			SkipIf(!b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted()).
+			WithDependencies(
+				TaskGroupReconcileWorker,
+				TaskGroupReconcileExtensionsAfterKubeAPIServer,
+			)
 
 		hibernateControlPlane = g.Add(flow.Task{
 			Name: "Hibernating control plane",
@@ -1108,4 +1164,8 @@ func (b *Botanist) HibernateControlPlaneTaskGroup(skipReadiness bool) flow.TaskG
 
 func (b *Botanist) isGardenadmBootstrap() bool {
 	return b.Shoot.IsSelfHosted() && !b.Shoot.RunsControlPlane()
+}
+
+func (b *Botanist) isGardenlet() bool {
+	return strings.HasPrefix(b.Shoot.GetInfo().Status.Gardener.Name, v1beta1constants.DeploymentNameGardenlet)
 }

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -29,6 +29,11 @@ import (
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
+const (
+	defaultTimeout  = 30 * time.Second
+	defaultInterval = 5 * time.Second
+)
+
 // TaskGroupDeployNamespaces is a flow.TaskID for a logical flow.TaskGroup.
 const TaskGroupDeployNamespaces flow.TaskID = "TaskGroupDeployNamespaces"
 
@@ -129,6 +134,18 @@ func (b *Botanist) ReconcileClusterResourceTaskGroup() flow.TaskGroup {
 	}).WithDependencies(TaskGroupReconcileCustomResourceDefinitions).SkipIf(!b.Shoot.IsSelfHosted())
 }
 
+// TaskGroupReconcileReferencedResources is a flow.TaskID for a logical flow.TaskGroup.
+const TaskGroupReconcileReferencedResources flow.TaskID = "TaskGroupReconcileReferencedResources"
+
+// ReconcileReferencedResourcesTaskGroup returns the flow.TaskGroup for reconciling the resources referenced in the
+// Shoot specification.
+func (b *Botanist) ReconcileReferencedResourcesTaskGroup() flow.TaskGroup {
+	return flow.NewTaskGroup(TaskGroupReconcileReferencedResources, flow.Task{
+		Name: "Reconciling referenced resources",
+		Fn:   flow.TaskFn(b.DeployReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
+	}).WithDependencies(TaskGroupDeployNamespaces, TaskGroupReconcileRuntimeGardenerResourceManager)
+}
+
 // TaskGroupInitializeSecretsManagement is a flow.TaskID for a logical flow.TaskGroup.
 const TaskGroupInitializeSecretsManagement flow.TaskID = "TaskGroupInitializeSecretsManagement"
 
@@ -217,7 +234,10 @@ const TaskGroupReconcileSystemResources flow.TaskID = "TaskGroupReconcileSystemR
 // ReconcileSystemResourcesTaskGroup returns the flow.TaskGroup for deploying the system resources.
 func (b *Botanist) ReconcileSystemResourcesTaskGroup() flow.TaskGroup {
 	var (
-		g = flow.NewTaskGroup(TaskGroupReconcileSystemResources).WithDependencies(TaskGroupReconcileGardenerResourceManager)
+		g = flow.NewTaskGroup(TaskGroupReconcileSystemResources).WithDependencies(
+			TaskGroupReconcileGardenerResourceManager,
+			TaskGroupReconcileReferencedResources,
+		)
 
 		_ = g.Add(flow.Task{
 			Name: "Deploying seed system resources",
@@ -262,6 +282,7 @@ func (b *Botanist) ReconcileInfrastructureTaskGroup(skipReadiness bool) flow.Tas
 		g = flow.NewTaskGroup(TaskGroupReconcileInfrastructure).WithDependencies(
 			TaskGroupInitializeSecretsManagement,
 			TaskGroupDeployCloudProviderSecret,
+			TaskGroupReconcileReferencedResources,
 		)
 
 		deployInfrastructure = g.Add(flow.Task{
@@ -299,6 +320,7 @@ func (b *Botanist) ReconcileControlPlaneTaskGroup(skipReadiness bool) flow.TaskG
 			TaskGroupDeployCloudProviderSecret,
 			TaskGroupReconcileGardenerResourceManager,
 			TaskGroupReconcileInfrastructure,
+			TaskGroupReconcileReferencedResources,
 		)
 
 		deployControlPlane = g.Add(flow.Task{
@@ -330,6 +352,7 @@ func (b *Botanist) ReconcileOperatingSystemConfigTaskGroup(skipReadiness bool) f
 			TaskGroupInitializeSecretsManagement,
 			TaskGroupDeployCloudProviderSecret,
 			TaskGroupReconcileGardenerResourceManager,
+			TaskGroupReconcileReferencedResources,
 		).SkipIf(b.Shoot.IsSelfHosted() && !b.isGardenadmBootstrap())
 
 		deployOperatingSystemConfig = g.Add(flow.Task{

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -1120,6 +1120,7 @@ func (b *Botanist) ReconcileStaticControlPlanePodsTaskGroup(useBootstrapEtcd boo
 func (b *Botanist) handleCredentialsRotationForStaticPods(g *flow.TaskGroup, readyForSecondRollout flow.TaskIDer) {
 	var (
 		rotationPreparingPhases            = sets.New(gardencorev1beta1.RotationPreparing, gardencorev1beta1.RotationPreparingWithoutWorkersRollout)
+		caRotationPreparing                = rotationPreparingPhases.Has(v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials))
 		etcdEncryptionKeyRotationPreparing = rotationPreparingPhases.Has(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials))
 
 		patchKubeAPIServerDeployment = g.Add(flow.Task{
@@ -1130,20 +1131,43 @@ func (b *Botanist) handleCredentialsRotationForStaticPods(g *flow.TaskGroup, rea
 			SkipIf:       !etcdEncryptionKeyRotationPreparing,
 			Dependencies: flow.NewTaskIDs(readyForSecondRollout),
 		})
+		patchETCDs = g.Add(flow.Task{
+			Name: "Marking Etcd resources as peer CA rotation completed",
+			Fn: flow.Parallel(
+				b.Shoot.Components.ControlPlane.EtcdMain.MarkAsPeerCARolloutCompleted,
+				b.Shoot.Components.ControlPlane.EtcdEvents.MarkAsPeerCARolloutCompleted,
+			),
+			SkipIf:       !caRotationPreparing,
+			Dependencies: flow.NewTaskIDs(readyForSecondRollout),
+		})
+
+		deployEtcds = g.Add(flow.Task{
+			Name:         "Deploying main and events ETCDs (second rollout)",
+			Fn:           flow.TaskFn(b.DeployEtcd).RetryUntilTimeout(5*time.Second, helper.GetEtcdDeployTimeout(b.Shoot, 30*time.Second)),
+			SkipIf:       !caRotationPreparing,
+			Dependencies: flow.NewTaskIDs(patchETCDs),
+		})
+		waitUntilEtcdsReady = g.Add(flow.Task{
+			Name:         "Waiting until main and event ETCDs have been reconciled (second rollout)",
+			Fn:           b.WaitUntilEtcdsReady,
+			SkipIf:       !caRotationPreparing,
+			Dependencies: flow.NewTaskIDs(deployEtcds),
+		})
+
 		deployControlPlaneDeployments = g.Add(flow.Task{
 			Name: "Deploying control plane components as Deployments/StatefulSets and updating gardener-node-agent Secret (second rollout)",
 			Fn: func(ctx context.Context) error {
 				return b.DeployStaticControlPlaneDeployments(ctx, false)
 			},
-			SkipIf:       !etcdEncryptionKeyRotationPreparing,
-			Dependencies: flow.NewTaskIDs(patchKubeAPIServerDeployment),
+			SkipIf:       !etcdEncryptionKeyRotationPreparing && !caRotationPreparing,
+			Dependencies: flow.NewTaskIDs(patchKubeAPIServerDeployment, waitUntilEtcdsReady),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Waiting until control plane components (static pods) are rolled out and ready (second rollout)",
 			Fn: func(ctx context.Context) error {
 				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, true)
 			},
-			SkipIf:       !etcdEncryptionKeyRotationPreparing,
+			SkipIf:       !etcdEncryptionKeyRotationPreparing && !caRotationPreparing,
 			Dependencies: flow.NewTaskIDs(deployControlPlaneDeployments),
 		})
 	)

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -853,6 +853,47 @@ func (b *Botanist) ReconcileSystemComponentsTaskGroup(kubeProxyEnabled, skipRead
 			SkipIf:       b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilNetworkReady),
 		})
+		_ = g.Add(flow.Task{
+			Name: "Deploying shoot cluster identity",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return b.DeployClusterIdentity(ctx)
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf: b.Shoot.HibernationEnabled,
+		})
+		_ = g.Add(flow.Task{
+			Name: "Deploying metrics-server system component",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return b.Shoot.Components.SystemComponents.MetricsServer.Deploy(ctx)
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+		})
+		_ = g.Add(flow.Task{
+			Name: "Deploying node-problem-detector system component",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return b.Shoot.Components.SystemComponents.NodeProblemDetector.Deploy(ctx)
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+		})
+		_ = g.Add(flow.Task{
+			Name:   "Deploying blackbox-exporter",
+			Fn:     flow.TaskFn(b.ReconcileBlackboxExporterCluster).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
+		})
+		_ = g.Add(flow.Task{
+			Name:   "Deploying node-exporter",
+			Fn:     flow.TaskFn(b.ReconcileNodeExporter).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
+		})
+		_ = g.Add(flow.Task{
+			Name:   "Deploying addon Kubernetes Dashboard",
+			Fn:     flow.TaskFn(b.DeployKubernetesDashboard).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
+		})
+		_ = g.Add(flow.Task{
+			Name:   "Deploying addon Nginx Ingress Controller",
+			Fn:     flow.TaskFn(b.DeployNginxIngressAddon).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf: b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted(),
+		})
 	)
 
 	return g

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -297,8 +297,6 @@ func (b *Botanist) ReconcileBackupResourcesTaskGroup(allowBackup, isCopyOfBackup
 		g = flow.NewTaskGroup(TaskGroupReconcileBackupResources).
 			WithDependencies(
 				TaskGroupDeployNamespaces,
-				TaskGroupDeployCloudProviderSecret,
-				TaskGroupInitializeSecretsManagement,
 				TaskGroupReconcileReferencedResources,
 			)
 
@@ -966,12 +964,10 @@ func (b *Botanist) ReconcileVPNComponentsTaskGroup(skipReadiness bool) flow.Task
 			Name: "Deploying vpn-seed-server",
 			Fn:   flow.TaskFn(b.DeployVPNServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
 		})
-
 		_ = g.Add(flow.Task{
 			Name: "Deploying apiserver-proxy",
 			Fn:   flow.TaskFn(b.DeployAPIServerProxy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 		})
-
 		deployVPNShoot = g.Add(flow.Task{
 			Name:         "Deploying vpn-shoot system component",
 			Fn:           flow.TaskFn(b.DeployVPNShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -341,6 +341,50 @@ func (b *Botanist) ReconcileControlPlaneTaskGroup(skipReadiness bool) flow.TaskG
 	return g
 }
 
+// TaskGroupReconcileContainerRuntime is a flow.TaskID for a logical flow.TaskGroup.
+const TaskGroupReconcileContainerRuntime flow.TaskID = "TaskGroupReconcileContainerRuntime"
+
+// ReconcileContainerRuntimeTaskGroup returns the flow.TaskGroup for deploying the ContainerRuntime extension resource
+// and waiting for its readiness.
+func (b *Botanist) ReconcileContainerRuntimeTaskGroup(skipReadiness bool) flow.TaskGroup {
+	var (
+		g = flow.NewTaskGroup(TaskGroupReconcileContainerRuntime).WithDependencies(
+			TaskGroupInitializeSecretsManagement,
+			TaskGroupReconcileReferencedResources,
+			TaskGroupReconcileGardenerResourceManager,
+		).SkipIf(b.Shoot.IsWorkerless)
+
+		deployContainerRuntimeResources = g.Add(flow.Task{
+			Name: "Deploying container runtime resources",
+			Fn:   flow.TaskFn(b.DeployContainerRuntime).RetryUntilTimeout(defaultInterval, defaultTimeout),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Waiting until container runtime resources are ready",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.Extensions.ContainerRuntime.Wait(ctx)
+			},
+			SkipIf:       skipReadiness,
+			Dependencies: flow.NewTaskIDs(deployContainerRuntimeResources),
+		})
+		deleteStaleContainerRuntimeResources = g.Add(flow.Task{
+			Name: "Deleting stale container runtime resources",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return b.Shoot.Components.Extensions.ContainerRuntime.DeleteStaleResources(ctx)
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
+		})
+		_ = g.Add(flow.Task{
+			Name: "Waiting until stale container runtime resources are deleted",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.Extensions.ContainerRuntime.WaitCleanupStaleResources(ctx)
+			},
+			SkipIf:       b.Shoot.HibernationEnabled || skipReadiness,
+			Dependencies: flow.NewTaskIDs(deleteStaleContainerRuntimeResources),
+		})
+	)
+
+	return g
+}
+
 // TaskGroupReconcileOperatingSystemConfig is a flow.TaskID for a logical flow.TaskGroup.
 const TaskGroupReconcileOperatingSystemConfig flow.TaskID = "TaskGroupReconcileOperatingSystemConfig"
 

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -422,6 +422,35 @@ func (b *Botanist) ReconcileExtensionsAfterKubeAPIServerTaskGroup(skipReadiness 
 	return g
 }
 
+// TaskGroupReconcileExtensionsAfterWorker is a flow.TaskID for a logical flow.TaskGroup.
+const TaskGroupReconcileExtensionsAfterWorker flow.TaskID = "TaskGroupReconcileExtensionsAfterWorker"
+
+// ReconcileExtensionsAfterWorkerTaskGroup returns the flow.TaskGroup for deploying the Extensions resources
+// after the Worker resource and waiting for their readiness.
+func (b *Botanist) ReconcileExtensionsAfterWorkerTaskGroup(skipReadiness bool) flow.TaskGroup {
+	var (
+		g = flow.NewTaskGroup(TaskGroupReconcileExtensionsAfterWorker).WithDependencies(
+			TaskGroupDeployCloudProviderSecret,
+			TaskGroupInitializeSecretsManagement,
+			TaskGroupReconcileReferencedResources,
+			TaskGroupReconcileWorker,
+		).SkipIf(b.Shoot.IsWorkerless)
+
+		deployExtensionResources = g.Add(flow.Task{
+			Name: "Deploying extension resources after workers",
+			Fn:   b.DeployExtensionsAfterWorker,
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Waiting until extension resources handled after workers are ready",
+			Fn:           b.Shoot.Components.Extensions.Extension.WaitAfterWorker,
+			SkipIf:       skipReadiness,
+			Dependencies: flow.NewTaskIDs(deployExtensionResources),
+		})
+	)
+
+	return g
+}
+
 // TaskGroupReconcileContainerRuntime is a flow.TaskID for a logical flow.TaskGroup.
 const TaskGroupReconcileContainerRuntime flow.TaskID = "TaskGroupReconcileContainerRuntime"
 
@@ -553,18 +582,6 @@ func (b *Botanist) ReconcileWorkerTaskGroup(skipReadiness bool) flow.TaskGroup {
 			},
 			SkipIf:       !b.Shoot.HasManagedInfrastructure() || b.Shoot.IsWorkerless || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(deployWorker),
-		})
-		deployExtensionResourcesAfterWorker = g.Add(flow.Task{
-			Name:         "Deploying extension resources after workers",
-			Fn:           b.DeployExtensionsAfterWorker,
-			SkipIf:       b.isGardenadmBootstrap() || b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Waiting until extension resources handled after workers are ready",
-			Fn:           b.Shoot.Components.Extensions.Extension.WaitAfterWorker,
-			SkipIf:       b.isGardenadmBootstrap() || b.Shoot.IsWorkerless || skipReadiness,
-			Dependencies: flow.NewTaskIDs(deployExtensionResourcesAfterWorker),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying cluster-autoscaler",

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -341,6 +341,40 @@ func (b *Botanist) ReconcileControlPlaneTaskGroup(skipReadiness bool) flow.TaskG
 	return g
 }
 
+// TaskGroupReconcileDNSRecords is a flow.TaskID for a logical flow.TaskGroup.
+const TaskGroupReconcileDNSRecords flow.TaskID = "TaskGroupReconcileDNSRecords"
+
+// ReconcileDNSRecordsTaskGroup returns the flow.TaskGroup for deploying the DNSRecords extension resources
+// and waiting for their readiness.
+func (b *Botanist) ReconcileDNSRecordsTaskGroup() flow.TaskGroup {
+	var (
+		g = flow.NewTaskGroup(TaskGroupReconcileDNSRecords).WithDependencies(
+			TaskGroupReconcileReferencedResources,
+		).SkipIf(b.Shoot.HibernationEnabled || b.Shoot.IsSelfHosted())
+
+		_ = g.Add(flow.Task{
+			Name: "Deploying internal domain DNS record",
+			Fn: func(ctx context.Context) error {
+				if err := b.DeployOrDestroyInternalDNSRecord(ctx); err != nil {
+					return err
+				}
+				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskDeployDNSRecordInternal)
+			},
+		})
+		_ = g.Add(flow.Task{
+			Name: "Deploying external domain DNS record",
+			Fn: func(ctx context.Context) error {
+				if err := b.DeployOrDestroyExternalDNSRecord(ctx); err != nil {
+					return err
+				}
+				return b.RemoveTaskAnnotation(ctx, v1beta1constants.ShootTaskDeployDNSRecordExternal)
+			},
+		})
+	)
+
+	return g
+}
+
 // TaskGroupReconcileExtensionsBeforeKubeAPIServer is a flow.TaskID for a logical flow.TaskGroup.
 const TaskGroupReconcileExtensionsBeforeKubeAPIServer flow.TaskID = "TaskGroupReconcileExtensionsBeforeKubeAPIServer"
 

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -341,6 +341,35 @@ func (b *Botanist) ReconcileControlPlaneTaskGroup(skipReadiness bool) flow.TaskG
 	return g
 }
 
+// TaskGroupReconcileExtensionsBeforeKubeAPIServer is a flow.TaskID for a logical flow.TaskGroup.
+const TaskGroupReconcileExtensionsBeforeKubeAPIServer flow.TaskID = "TaskGroupReconcileExtensionsBeforeKubeAPIServer"
+
+// ReconcileExtensionsBeforeKubeAPIServerTaskGroup returns the flow.TaskGroup for deploying the Extensions resources
+// before kube-apiserver and waiting for their readiness.
+func (b *Botanist) ReconcileExtensionsBeforeKubeAPIServerTaskGroup(skipReadiness bool) flow.TaskGroup {
+	var (
+		g = flow.NewTaskGroup(TaskGroupReconcileExtensionsBeforeKubeAPIServer).WithDependencies(
+			TaskGroupDeployCloudProviderSecret,
+			TaskGroupInitializeSecretsManagement,
+			TaskGroupReconcileReferencedResources,
+			TaskGroupReconcileInfrastructure,
+		).SkipIf(b.Shoot.HibernationEnabled)
+
+		deployExtensionResourcesBeforeKAPI = g.Add(flow.Task{
+			Name: "Deploying extension resources before kube-apiserver",
+			Fn:   flow.TaskFn(b.DeployExtensionsBeforeKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Waiting until extension resources handled before kube-apiserver are ready",
+			Fn:           b.Shoot.Components.Extensions.Extension.WaitBeforeKubeAPIServer,
+			SkipIf:       skipReadiness,
+			Dependencies: flow.NewTaskIDs(deployExtensionResourcesBeforeKAPI),
+		})
+	)
+
+	return g
+}
+
 // TaskGroupReconcileContainerRuntime is a flow.TaskID for a logical flow.TaskGroup.
 const TaskGroupReconcileContainerRuntime flow.TaskID = "TaskGroupReconcileContainerRuntime"
 

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -272,6 +272,84 @@ func (b *Botanist) ReconcileMachineControllerManagerTaskGroup() flow.TaskGroup {
 	)
 }
 
+// TaskGroupReconcileBackupResources is a flow.TaskID for a logical flow.TaskGroup.
+const TaskGroupReconcileBackupResources flow.TaskID = "TaskGroupReconcileBackupResources"
+
+// ReconcileBackupResourcesTaskGroup returns the flow.TaskGroup for deploying the BackupBucket or BackupEntry extension
+// resources and waiting for their readiness.
+func (b *Botanist) ReconcileBackupResourcesTaskGroup(allowBackup, isCopyOfBackupsRequired, skipReadiness bool) flow.TaskGroup {
+	var (
+		g = flow.NewTaskGroup(TaskGroupReconcileBackupResources).WithDependencies(
+			TaskGroupDeployNamespaces,
+			TaskGroupDeployCloudProviderSecret,
+			TaskGroupInitializeSecretsManagement,
+			TaskGroupReconcileReferencedResources,
+		)
+
+		deploySourceBackupEntry = g.Add(flow.Task{
+			Name:   "Deploying source backup entry",
+			Fn:     b.DeploySourceBackupEntry,
+			SkipIf: !isCopyOfBackupsRequired || b.Shoot.IsSelfHosted(),
+		})
+		waitUntilSourceBackupEntryInGardenReconciled = g.Add(flow.Task{
+			Name:         "Waiting until the source backup entry has been reconciled",
+			Fn:           b.Shoot.Components.SourceBackupEntry.Wait,
+			SkipIf:       skipReadiness || !isCopyOfBackupsRequired || b.Shoot.IsSelfHosted(),
+			Dependencies: flow.NewTaskIDs(deploySourceBackupEntry),
+		})
+
+		deployBackupBucketInGarden = g.Add(flow.Task{
+			Name: "Deploying BackupBucket for ETCD data",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.BackupBucket.Deploy(ctx)
+			},
+			SkipIf: !allowBackup || !b.Shoot.IsSelfHosted(),
+		})
+		waitUntilBackupBucketInGardenReconciled = g.Add(flow.Task{
+			Name: "Waiting until the BackupBucket for ETCD data has been reconciled",
+			Fn: func(ctx context.Context) error {
+				return b.Shoot.Components.BackupBucket.Wait(ctx)
+			},
+			SkipIf:       skipReadiness || !allowBackup || !b.Shoot.IsSelfHosted(),
+			Dependencies: flow.NewTaskIDs(deployBackupBucketInGarden),
+		})
+
+		deployBackupEntryInGarden = g.Add(flow.Task{
+			Name:         "Deploying BackupEntry for ETCD data",
+			Fn:           b.DeployBackupEntry,
+			SkipIf:       !allowBackup,
+			Dependencies: flow.NewTaskIDs(waitUntilSourceBackupEntryInGardenReconciled, waitUntilBackupBucketInGardenReconciled),
+		})
+		waitUntilBackupEntryInGardenReconciled = g.Add(flow.Task{
+			Name:         "Waiting until the BackupEntry for ETCD data has been reconciled",
+			Fn:           b.Shoot.Components.BackupEntry.Wait,
+			SkipIf:       skipReadiness || !allowBackup,
+			Dependencies: flow.NewTaskIDs(deployBackupEntryInGarden),
+		})
+
+		copyEtcdBackups = g.Add(flow.Task{
+			Name:         "Copying etcd backups to new seed's backup bucket",
+			Fn:           b.DeployEtcdCopyBackupsTask,
+			SkipIf:       !isCopyOfBackupsRequired,
+			Dependencies: flow.NewTaskIDs(waitUntilBackupEntryInGardenReconciled, waitUntilSourceBackupEntryInGardenReconciled),
+		})
+		waitUntilEtcdBackupsCopied = g.Add(flow.Task{
+			Name:         "Waiting until etcd backups are copied",
+			Fn:           b.Shoot.Components.ControlPlane.EtcdCopyBackupsTask.Wait,
+			SkipIf:       skipReadiness || !isCopyOfBackupsRequired,
+			Dependencies: flow.NewTaskIDs(copyEtcdBackups),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Destroying copy etcd backups task resource",
+			Fn:           b.Shoot.Components.ControlPlane.EtcdCopyBackupsTask.Destroy,
+			SkipIf:       !isCopyOfBackupsRequired,
+			Dependencies: flow.NewTaskIDs(waitUntilEtcdBackupsCopied),
+		})
+	)
+
+	return g
+}
+
 // TaskGroupReconcileInfrastructure is a flow.TaskID for a logical flow.TaskGroup.
 const TaskGroupReconcileInfrastructure flow.TaskID = "TaskGroupReconcileInfrastructure"
 

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -6,10 +6,13 @@ package botanist
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/version"
@@ -19,6 +22,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
@@ -27,6 +31,7 @@ import (
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
+	"github.com/gardener/gardener/pkg/utils/managedresources/builder"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
@@ -212,7 +217,7 @@ const GardenerNodeAgentManagedResourceName = "shoot-gardener-node-agent"
 // DeployManagedResourceForGardenerNodeAgent creates the ManagedResource that contains:
 // - A secret containing the raw original OperatingSystemConfig for each worker pool.
 // - A secret containing some shared RBAC resources for downloading the OSC secrets + bootstrapping the node.
-func (b *Botanist) DeployManagedResourceForGardenerNodeAgent(ctx context.Context) error {
+func (b *Botanist) DeployManagedResourceForGardenerNodeAgent(ctx context.Context, forControlPlanePoolOnly bool) error {
 	var (
 		managedResource                  = managedresources.NewForShoot(b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, GardenerNodeAgentManagedResourceName, managedresources.LabelValueGardener, false)
 		managedResourceSecretsCount      = len(b.Shoot.GetInfo().Spec.Provider.Workers) + 1
@@ -225,8 +230,13 @@ func (b *Botanist) DeployManagedResourceForGardenerNodeAgent(ctx context.Context
 		fns = make([]flow.TaskFn, 0, managedResourceSecretsCount)
 	)
 
-	// Generate operating system config secrets for all worker pools.
-	for _, worker := range b.Shoot.GetInfo().Spec.Provider.Workers {
+	workerPools, err := b.relevantWorkerPools(forControlPlanePoolOnly)
+	if err != nil {
+		return err
+	}
+
+	// Generate operating system config secrets for the relevant worker pools.
+	for _, worker := range workerPools {
 		oscData, ok := workerNameToOperatingSystemConfigMaps[worker.Name]
 		if !ok {
 			return fmt.Errorf("did not find osc data for worker pool %q", worker.Name)
@@ -269,6 +279,16 @@ func (b *Botanist) DeployManagedResourceForGardenerNodeAgent(ctx context.Context
 		})
 	}
 
+	// If we want to update the configuration for the control plane worker pool only, we don't want to override/touch
+	// the ManagedResource secrets for other worker pools. In addition, we also don't want to remove their references
+	// from the ManagedResource's `.spec.secretRefs[]` - otherwise, they would be deleted.
+	// To prevent this, we check if the ManagedResource already exists, and if so, we collect all existing references
+	if forControlPlanePoolOnly {
+		if err := b.mergeExistingSecretRefsIntoNodeAgentManagedResource(ctx, managedResource, managedResourceSecretNamesWanted); err != nil {
+			return fmt.Errorf("failed to merge existing ManagedResource secret references into the gardener-node-agent ManagedResource: %w", err)
+		}
+	}
+
 	if err := flow.Parallel(fns...)(ctx); err != nil {
 		return err
 	}
@@ -290,6 +310,38 @@ func (b *Botanist) DeployManagedResourceForGardenerNodeAgent(ctx context.Context
 		}
 		return !managedResourceSecretNamesWanted.Has(acc.GetName())
 	})
+}
+
+func (b *Botanist) relevantWorkerPools(controlPlanePoolOnly bool) ([]gardencorev1beta1.Worker, error) {
+	workerPools := b.Shoot.GetInfo().Spec.Provider.Workers
+	if !controlPlanePoolOnly {
+		return workerPools, nil
+	}
+
+	controlPlanePool := v1beta1helper.ControlPlaneWorkerPoolForShoot(workerPools)
+	if controlPlanePool == nil {
+		return nil, errors.New("failed to find control plane worker pool for shoot")
+	}
+	return []gardencorev1beta1.Worker{*controlPlanePool}, nil
+}
+
+func (b *Botanist) mergeExistingSecretRefsIntoNodeAgentManagedResource(ctx context.Context, managedResource *builder.ManagedResource, managedResourceSecretNamesWanted sets.Set[string]) error {
+	existingManagedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: GardenerNodeAgentManagedResourceName, Namespace: b.Shoot.ControlPlaneNamespace}}
+	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKeyFromObject(existingManagedResource), existingManagedResource); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to read ManagedResource %s: %w", client.ObjectKeyFromObject(existingManagedResource), err)
+		}
+		return nil
+	}
+
+	for _, secretRef := range existingManagedResource.Spec.SecretRefs {
+		if managedResourceSecretName := secretRef.Name; !managedResourceSecretNamesWanted.Has(secretRef.Name) {
+			managedResource.WithSecretRef(managedResourceSecretName)
+			managedResourceSecretNamesWanted.Insert(managedResourceSecretName)
+		}
+	}
+
+	return nil
 }
 
 func (b *Botanist) generateOperatingSystemConfigSecretForWorker(

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -302,7 +302,7 @@ var _ = Describe("operatingsystemconfig", func() {
 			It("should fail because the operating system config maps for a worker pool are not available", func() {
 				operatingSystemConfig.EXPECT().WorkerPoolNameToOperatingSystemConfigsMap().Return(nil)
 
-				Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx)).To(MatchError(ContainSubstring("did not find osc data for worker pool")))
+				Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx, false)).To(MatchError(ContainSubstring("did not find osc data for worker pool")))
 			})
 
 			When("operating system config maps are available", func() {
@@ -315,7 +315,7 @@ var _ = Describe("operatingsystemconfig", func() {
 						return nil, fakeErr
 					}))
 
-					Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx)).To(MatchError(fakeErr))
+					Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx, false)).To(MatchError(fakeErr))
 				})
 
 				It("should fail because the RBAC resources data generation function fails", func() {
@@ -323,7 +323,7 @@ var _ = Describe("operatingsystemconfig", func() {
 						return nil, fakeErr
 					}))
 
-					Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx)).To(MatchError(fakeErr))
+					Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx, false)).To(MatchError(fakeErr))
 				})
 
 				It("should successfully generate the resources and cleanup stale resources", func() {
@@ -340,7 +340,7 @@ var _ = Describe("operatingsystemconfig", func() {
 					Expect(fakeClient.Create(ctx, oldSecret2)).To(Succeed())
 
 					By("Execute DeployManagedResourceForGardenerNodeAgent function")
-					Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx)).To(Succeed())
+					Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx, false)).To(Succeed())
 
 					expectedOSCSecretWorker1, err := NodeAgentOSCSecretFn(ctx, fakeClient, workerNameToOperatingSystemConfigMaps[worker1Name].Original.Object, worker1Key, worker1Name, true)
 					Expect(err).NotTo(HaveOccurred())
@@ -436,6 +436,143 @@ var _ = Describe("operatingsystemconfig", func() {
 					By("Assert expected deletion of no longer required ManagedResource secrets")
 					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(oldSecret1), oldSecret1)).To(BeNotFoundError())
 					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(oldSecret2), oldSecret2)).To(BeNotFoundError())
+				})
+			})
+
+			When("forControlPlanePoolOnly is true", func() {
+				BeforeEach(func() {
+					botanist.SeedClientSet = fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build()
+				})
+
+				It("should fail because no control plane worker pool exists", func() {
+					operatingSystemConfig.EXPECT().WorkerPoolNameToOperatingSystemConfigsMap().Return(workerNameToOperatingSystemConfigMaps)
+
+					Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx, true)).To(MatchError(ContainSubstring("failed to find control plane worker pool for shoot")))
+				})
+
+				When("a control plane worker pool exists", func() {
+					BeforeEach(func() {
+						operatingSystemConfig.EXPECT().WorkerPoolNameToOperatingSystemConfigsMap().Return(workerNameToOperatingSystemConfigMaps)
+					})
+
+					JustBeforeEach(func() {
+						shoot := botanist.Shoot.GetInfo().DeepCopy()
+						shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
+							{
+								Name:         worker1Name,
+								ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+							},
+							{
+								Name:                  worker2Name,
+								KubeletDataVolumeName: &worker2KubeletDataVolumeName,
+								DataVolumes: []gardencorev1beta1.DataVolume{
+									{Name: worker2KubeletDataVolumeName},
+								},
+								Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+									Version: &worker2KubernetesVersion,
+								},
+							},
+						}
+						botanist.Shoot.SetInfo(shoot)
+					})
+
+					It("should only generate resources for the control plane worker pool when no ManagedResource exists yet", func() {
+						By("Execute DeployManagedResourceForGardenerNodeAgent function")
+						Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx, true)).To(Succeed())
+
+						expectedOSCSecretWorker1, err := NodeAgentOSCSecretFn(ctx, fakeClient, workerNameToOperatingSystemConfigMaps[worker1Name].Original.Object, worker1Key, worker1Name, true)
+						Expect(err).NotTo(HaveOccurred())
+
+						versions := schema.GroupVersions([]schema.GroupVersion{corev1.SchemeGroupVersion})
+						codec := kubernetes.ShootCodec.CodecForVersions(kubernetes.ShootSerializer, kubernetes.ShootSerializer, versions, versions)
+						expectedOSCSecretWorker1Raw, err := runtime.Encode(codec, expectedOSCSecretWorker1)
+						Expect(err).NotTo(HaveOccurred())
+						compressedOSCSecretWorker1Raw, err := test.BrotliCompression(expectedOSCSecretWorker1Raw)
+						Expect(err).NotTo(HaveOccurred())
+
+						expectedMRSecretWorker1 := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:            "managedresource-shoot-gardener-node-agent-" + worker1Name,
+								Namespace:       namespace,
+								Labels:          map[string]string{"managed-resource": "shoot-gardener-node-agent"},
+								ResourceVersion: "1",
+							},
+							Type: corev1.SecretTypeOpaque,
+							Data: map[string][]byte{"data.yaml.br": compressedOSCSecretWorker1Raw},
+						}
+						utilruntime.Must(kubernetesutils.MakeUnique(expectedMRSecretWorker1))
+
+						nodeAgentRBACResourcesData, err := NodeAgentRBACResourcesDataFn()
+						Expect(err).NotTo(HaveOccurred())
+						expectedMRSecretRBAC := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:            "managedresource-shoot-gardener-node-agent-rbac",
+								Namespace:       namespace,
+								Labels:          map[string]string{"managed-resource": "shoot-gardener-node-agent"},
+								ResourceVersion: "1",
+							},
+							Type: corev1.SecretTypeOpaque,
+							Data: nodeAgentRBACResourcesData,
+						}
+						utilruntime.Must(kubernetesutils.MakeUnique(expectedMRSecretRBAC))
+
+						By("Assert only the control plane pool secret and RBAC secret were created")
+						mrSecretWorker1 := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: expectedMRSecretWorker1.Name, Namespace: namespace}}
+						Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(mrSecretWorker1), mrSecretWorker1)).To(Succeed())
+						Expect(mrSecretWorker1).To(Equal(expectedMRSecretWorker1))
+
+						mrSecretRBAC := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: expectedMRSecretRBAC.Name, Namespace: namespace}}
+						Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(mrSecretRBAC), mrSecretRBAC)).To(Succeed())
+						Expect(mrSecretRBAC).To(Equal(expectedMRSecretRBAC))
+
+						By("Assert ManagedResource references only the control plane pool and RBAC secrets")
+						managedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: "shoot-gardener-node-agent", Namespace: namespace}}
+						Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+						Expect(managedResource.Spec.SecretRefs).To(ConsistOf(
+							corev1.LocalObjectReference{Name: expectedMRSecretWorker1.Name},
+							corev1.LocalObjectReference{Name: expectedMRSecretRBAC.Name},
+						))
+
+						By("Assert no secret was created for the non-control-plane worker pool")
+						secretList := &corev1.SecretList{}
+						Expect(fakeClient.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabels{"managed-resource": "shoot-gardener-node-agent"})).To(Succeed())
+						for _, s := range secretList.Items {
+							Expect(s.Name).NotTo(ContainSubstring(worker2Name))
+						}
+					})
+
+					It("should merge existing secret refs from other worker pools when a ManagedResource already exists", func() {
+						existingWorker2SecretName := "managedresource-shoot-gardener-node-agent-" + worker2Name + "-existing"
+
+						By("Create existing ManagedResource referencing both pools")
+						existingMR := &resourcesv1alpha1.ManagedResource{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "shoot-gardener-node-agent",
+								Namespace: namespace,
+							},
+							Spec: resourcesv1alpha1.ManagedResourceSpec{
+								SecretRefs: []corev1.LocalObjectReference{
+									{Name: existingWorker2SecretName},
+								},
+							},
+						}
+						Expect(fakeClient.Create(ctx, existingMR)).To(Succeed())
+
+						By("Execute DeployManagedResourceForGardenerNodeAgent function")
+						Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx, true)).To(Succeed())
+
+						By("Assert ManagedResource references both the new control plane pool secrets and the preserved worker2 ref")
+						managedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: "shoot-gardener-node-agent", Namespace: namespace}}
+						Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+
+						secretRefNames := make([]string, 0, len(managedResource.Spec.SecretRefs))
+						for _, ref := range managedResource.Spec.SecretRefs {
+							secretRefNames = append(secretRefNames, ref.Name)
+						}
+						Expect(secretRefNames).To(ContainElement(existingWorker2SecretName))
+						Expect(secretRefNames).To(ContainElement(ContainSubstring(worker1Name)))
+						Expect(secretRefNames).To(ContainElement(ContainSubstring("rbac")))
+					})
 				})
 			})
 		})

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -53,7 +53,7 @@ type staticControlPlaneComponent struct {
 	mutate       func(*corev1.Pod)
 }
 
-func (b *Botanist) deployETCD(role string, bootstrapEtcdBackupPath string) func(context.Context) error {
+func (b *Botanist) deployBootstrapETCD(role string, bootstrapEtcdBackupPath string) func(context.Context) error {
 	var portClient, portPeer, portMetrics int32 = 2379, 2380, 2381
 	if role == v1beta1constants.ETCDRoleEvents {
 		portClient, portPeer, portMetrics = etcdconstants.StaticPodPortEtcdEventsClient, 2383, 2384
@@ -132,8 +132,8 @@ func (b *Botanist) staticControlPlaneComponents(useBootstrapEtcd, useShootAccess
 
 	if useBootstrapEtcd {
 		components = append(components,
-			staticControlPlaneComponent{b.deployETCD(v1beta1constants.ETCDRoleMain, bootstrapEtcdBackupPath), bootstrapetcd.Name(v1beta1constants.ETCDRoleMain), &appsv1.StatefulSet{}, nil},
-			staticControlPlaneComponent{b.deployETCD(v1beta1constants.ETCDRoleEvents, bootstrapEtcdBackupPath), bootstrapetcd.Name(v1beta1constants.ETCDRoleEvents), &appsv1.StatefulSet{}, nil},
+			staticControlPlaneComponent{b.deployBootstrapETCD(v1beta1constants.ETCDRoleMain, bootstrapEtcdBackupPath), bootstrapetcd.Name(v1beta1constants.ETCDRoleMain), &appsv1.StatefulSet{}, nil},
+			staticControlPlaneComponent{b.deployBootstrapETCD(v1beta1constants.ETCDRoleEvents, bootstrapEtcdBackupPath), bootstrapetcd.Name(v1beta1constants.ETCDRoleEvents), &appsv1.StatefulSet{}, nil},
 		)
 	} else {
 		components = append(components,

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -171,7 +171,7 @@ func (b *Botanist) DeployStaticControlPlaneDeployments(ctx context.Context, useB
 		return fmt.Errorf("failed waiting for OperatingSystemConfig to be ready: %w", err)
 	}
 
-	if err := b.DeployManagedResourceForGardenerNodeAgent(ctx); err != nil {
+	if err := b.DeployManagedResourceForGardenerNodeAgent(ctx, b.isGardenlet()); err != nil {
 		return fmt.Errorf("failed deploying ManagedResource containing Secret with OperatingSystemConfig for gardener-node-agent: %w", err)
 	}
 

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -40,7 +40,6 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
-	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
 // PathKubeconfig is the path to a file on the control plane node containing an admin kubeconfig.
@@ -93,18 +92,6 @@ func (b *Botanist) deployBootstrapETCD(role string, bootstrapEtcdBackupPath stri
 func (b *Botanist) deployKubeAPIServer(ctx context.Context, useShootAccessTokens bool) error {
 	if !useShootAccessTokens {
 		b.Shoot.Components.ControlPlane.KubeAPIServer.EnableStaticTokenKubeconfig()
-	} else {
-		// Usually, these secrets would be deleted by a `b.SecretsManager.Cleanup()` call. However, we don't run this
-		// call in gardenlet yet. Hence, for now, let's explicitly delete them.
-		// TODO(rfranzke): Remove this in favor of the `b.SecretsManager.Cleanup()` call at the end of the shoot
-		//  reconciliation (see TODO statement there).
-		if err := b.SeedClientSet.Client().DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(b.Shoot.ControlPlaneNamespace), client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(
-			utils.MustNewRequirement(secretsmanager.LabelKeyManagedBy, selection.Equals, secretsmanager.LabelValueSecretsManager),
-			utils.MustNewRequirement(secretsmanager.LabelKeyManagerIdentity, selection.Equals, b.SecretsManager.Identity()),
-			utils.MustNewRequirement(secretsmanager.LabelKeyName, selection.In, kubeapiserver.SecretNameUserKubeconfig),
-		)}); err != nil {
-			return fmt.Errorf("failed to cleanup static token kubeconfig and user kubeconfig secrets: %w", err)
-		}
 	}
 
 	b.Shoot.Components.ControlPlane.KubeAPIServer.SetAutoscalingReplicas(new(int32(0)))

--- a/pkg/gardenlet/operation/botanist/vpa.go
+++ b/pkg/gardenlet/operation/botanist/vpa.go
@@ -20,17 +20,17 @@ func (b *Botanist) DefaultVerticalPodAutoscaler() (vpa.Interface, error) {
 		return nil, nil
 	}
 
-	imageAdmissionController, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameVpaAdmissionController, imagevectorutils.RuntimeVersion(b.SeedVersion()), imagevectorutils.TargetVersion(b.ShootVersion()))
+	imageAdmissionController, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameVpaAdmissionController, imagevectorutils.RuntimeVersion(b.Shoot.RuntimeKubernetesVersion.String()), imagevectorutils.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return nil, err
 	}
 
-	imageRecommender, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameVpaRecommender, imagevectorutils.RuntimeVersion(b.SeedVersion()), imagevectorutils.TargetVersion(b.ShootVersion()))
+	imageRecommender, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameVpaRecommender, imagevectorutils.RuntimeVersion(b.Shoot.RuntimeKubernetesVersion.String()), imagevectorutils.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return nil, err
 	}
 
-	imageUpdater, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameVpaUpdater, imagevectorutils.RuntimeVersion(b.SeedVersion()), imagevectorutils.TargetVersion(b.ShootVersion()))
+	imageUpdater, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameVpaUpdater, imagevectorutils.RuntimeVersion(b.Shoot.RuntimeKubernetesVersion.String()), imagevectorutils.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,12 @@ func (b *Botanist) DefaultVerticalPodAutoscaler() (vpa.Interface, error) {
 		}
 		featureGates  map[string]bool
 		isManagedSeed = b.ManagedSeed != nil
+		clusterType   = component.ClusterTypeShoot
 	)
+
+	if b.Shoot.IsSelfHosted() {
+		clusterType = component.ClusterTypeSeed
+	}
 
 	if vpaConfig := b.Shoot.GetInfo().Spec.Kubernetes.VerticalPodAutoscaler; vpaConfig != nil {
 		valuesRecommender.Interval = vpaConfig.RecommenderInterval
@@ -86,7 +91,7 @@ func (b *Botanist) DefaultVerticalPodAutoscaler() (vpa.Interface, error) {
 		b.Shoot.ControlPlaneNamespace,
 		b.SecretsManager,
 		vpa.Values{
-			ClusterType:              component.ClusterTypeShoot,
+			ClusterType:              clusterType,
 			IsManagedSeed:            isManagedSeed,
 			SecretNameServerCA:       v1beta1constants.SecretNameCACluster,
 			RuntimeKubernetesVersion: b.Shoot.RuntimeKubernetesVersion,

--- a/pkg/gardenlet/operation/botanist/worker.go
+++ b/pkg/gardenlet/operation/botanist/worker.go
@@ -116,9 +116,9 @@ func WorkerPoolToNodesMap(ctx context.Context, shootClient client.Client) (map[s
 // WorkerPoolToOperatingSystemConfigSecretMetaMap lists all the cloud-config secrets with the given client in the shoot cluster.
 // It returns a map whose key is the name of a worker pool and whose values are the corresponding metadata of the
 // cloud-config script stored inside the secret's data.
-func WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx context.Context, shootClient client.Client, roleValue string) (map[string]metav1.ObjectMeta, error) {
+func WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx context.Context, shootClient client.Client) (map[string]metav1.ObjectMeta, error) {
 	secretList := &corev1.SecretList{}
-	if err := shootClient.List(ctx, secretList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{v1beta1constants.GardenRole: roleValue}); err != nil {
+	if err := shootClient.List(ctx, secretList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleOperatingSystemConfig}); err != nil {
 		return nil, err
 	}
 
@@ -224,13 +224,18 @@ func getTimeoutWaitOperatingSystemConfigUpdated(shoot *shootpkg.Shoot) time.Dura
 // WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools waits for a maximum of 2*GetTimeoutWaitOperatingSystemConfigUpdated
 // until all the non-preserved nodes for all the worker pools in the Shoot have successfully applied the desired version of their
 // operating system config.
-func (b *Botanist) WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx context.Context, tolerateErrors bool) error {
+func (b *Botanist) WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx context.Context, forControlPlanePoolOnly, tolerateErrors bool) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, GetTimeoutWaitOperatingSystemConfigUpdated(b.Shoot))
 	defer cancel()
 
 	retryFn := retry.SevereError
 	if tolerateErrors {
 		retryFn = retry.MinorError
+	}
+
+	workerPools, err := b.relevantWorkerPools(forControlPlanePoolOnly)
+	if err != nil {
+		return err
 	}
 
 	// managedresources.WaitUntilHealthy internally treats transient errors while getting the ManagedResource (e.g., "connection refused")
@@ -256,12 +261,12 @@ func (b *Botanist) WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx co
 			return retryFn(err)
 		}
 
-		workerPoolToOperatingSystemConfigSecretMeta, err := WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx, b.ShootClientSet.Client(), v1beta1constants.GardenRoleOperatingSystemConfig)
+		workerPoolToOperatingSystemConfigSecretMeta, err := WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx, b.ShootClientSet.Client())
 		if err != nil {
 			return retryFn(err)
 		}
 
-		if err := OperatingSystemConfigUpdatedForAllWorkerPools(b.Shoot.GetInfo().Spec.Provider.Workers, workerPoolToNodes, workerPoolToOperatingSystemConfigSecretMeta); err != nil {
+		if err := OperatingSystemConfigUpdatedForAllWorkerPools(workerPools, workerPoolToNodes, workerPoolToOperatingSystemConfigSecretMeta); err != nil {
 			return retry.MinorError(err)
 		}
 

--- a/pkg/gardenlet/operation/botanist/worker_test.go
+++ b/pkg/gardenlet/operation/botanist/worker_test.go
@@ -204,13 +204,13 @@ var _ = Describe("Worker", func() {
 				},
 			}).Build()
 
-			workerPoolToCloudConfigSecretMeta, err := WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx, c, "operating-system-config")
+			workerPoolToCloudConfigSecretMeta, err := WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx, c)
 			Expect(workerPoolToCloudConfigSecretMeta).To(BeNil())
 			Expect(err).To(MatchError(fakeErr))
 		})
 
 		It("should return an empty map when there are no secrets", func() {
-			workerPoolToCloudConfigSecretMeta, err := WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx, c, "operating-system-config")
+			workerPoolToCloudConfigSecretMeta, err := WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx, c)
 			Expect(workerPoolToCloudConfigSecretMeta).To(BeEmpty())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -269,7 +269,7 @@ var _ = Describe("Worker", func() {
 			Expect(c.Create(ctx, &secret3WithoutWorkerPoolLabel)).To(Succeed())
 			Expect(c.Create(ctx, &secret4WithoutAnnotations)).To(Succeed())
 
-			workerPoolToCloudConfigSecretMeta, err := WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx, c, "operating-system-config")
+			workerPoolToCloudConfigSecretMeta, err := WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx, c)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(workerPoolToCloudConfigSecretMeta).To(Equal(map[string]metav1.ObjectMeta{
 				pool1: {
@@ -558,6 +558,8 @@ var _ = Describe("Worker", func() {
 				&GetTimeoutWaitOperatingSystemConfigUpdated, func(*shootpkg.Shoot) time.Duration { return 5 * time.Millisecond },
 			))
 
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
+
 			// Create ManagedResource with Generation != ObservedGeneration (not populated yet)
 			mr := &resourcesv1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{
@@ -568,7 +570,7 @@ var _ = Describe("Worker", func() {
 			}
 			Expect(seedFakeClient.Create(ctx, mr)).To(Succeed())
 
-			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)).To(MatchError(ContainSubstring("the operating system configs for the worker nodes were not populated yet")))
+			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false, false)).To(MatchError(ContainSubstring("the operating system configs for the worker nodes were not populated yet")))
 		})
 
 		It("should fail when the operating system config was not updated for all worker pools", func() {
@@ -633,7 +635,7 @@ var _ = Describe("Worker", func() {
 				},
 			})).To(Succeed())
 
-			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)).To(MatchError(ContainSubstring("is outdated")))
+			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false, false)).To(MatchError(ContainSubstring("is outdated")))
 		})
 
 		It("should succeed when the operating system config was updated for all worker pools", func() {
@@ -698,7 +700,7 @@ var _ = Describe("Worker", func() {
 				},
 			})).To(Succeed())
 
-			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)).To(Succeed())
+			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false, false)).To(Succeed())
 		})
 
 		It("should succeed when tolerating errors and the managed resource becomes healthy after a transient error", func() {
@@ -778,7 +780,110 @@ var _ = Describe("Worker", func() {
 				},
 			})).To(Succeed())
 
-			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, true)).To(Succeed())
+			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false, true)).To(Succeed())
+		})
+
+		When("forControlPlanePoolOnly is true", func() {
+			It("should fail when no control plane worker pool exists", func() {
+				DeferCleanup(test.WithVar(
+					&GetTimeoutWaitOperatingSystemConfigUpdated, func(*shootpkg.Shoot) time.Duration { return 5 * time.Millisecond },
+				))
+
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Provider: gardencorev1beta1.Provider{
+							Workers: []gardencorev1beta1.Worker{
+								{Name: "pool1"},
+							},
+						},
+					},
+				})
+
+				Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, true, false)).To(MatchError(ContainSubstring("failed to find control plane worker pool for shoot")))
+			})
+
+			It("should succeed when only the control plane pool node is up-to-date, ignoring other pools", func() {
+				DeferCleanup(test.WithVars(
+					&IntervalWaitOperatingSystemConfigUpdated, time.Millisecond,
+					&GetTimeoutWaitOperatingSystemConfigUpdated, func(*shootpkg.Shoot) time.Duration { return time.Millisecond },
+				))
+
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Provider: gardencorev1beta1.Provider{
+							Workers: []gardencorev1beta1.Worker{
+								{
+									Name:         "cp-pool",
+									ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+								},
+								{
+									Name: "worker-pool",
+								},
+							},
+						},
+					},
+				})
+
+				mr := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "shoot-gardener-node-agent",
+						Namespace:  controlPlaneNamespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionTrue},
+							{Type: resourcesv1alpha1.ResourcesHealthy, Status: gardencorev1beta1.ConditionTrue},
+						},
+					},
+				}
+				Expect(seedFakeClient.Create(ctx, mr)).To(Succeed())
+
+				// Control plane pool node: up-to-date
+				Expect(shootFakeClient.Create(ctx, &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cp-node",
+						Labels: map[string]string{
+							"worker.gardener.cloud/pool":                            "cp-pool",
+							"worker.gardener.cloud/kubernetes-version":              "1.26.0",
+							"worker.gardener.cloud/gardener-node-agent-secret-name": "gardener-node-agent-cp-pool-abc12",
+						},
+						Annotations: map[string]string{"checksum/cloud-config-data": "match"},
+					},
+				})).To(Succeed())
+				Expect(shootFakeClient.Create(ctx, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "gardener-node-agent-cp-pool-abc12",
+						Namespace:   metav1.NamespaceSystem,
+						Labels:      map[string]string{"worker.gardener.cloud/pool": "cp-pool", "gardener.cloud/role": "operating-system-config"},
+						Annotations: map[string]string{"checksum/data-script": "match"},
+					},
+				})).To(Succeed())
+
+				// Worker pool node: outdated — should be ignored with forControlPlanePoolOnly=true
+				Expect(shootFakeClient.Create(ctx, &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-node",
+						Labels: map[string]string{
+							"worker.gardener.cloud/pool":                            "worker-pool",
+							"worker.gardener.cloud/kubernetes-version":              "1.26.0",
+							"worker.gardener.cloud/gardener-node-agent-secret-name": "gardener-node-agent-worker-pool-def34",
+						},
+						Annotations: map[string]string{"checksum/cloud-config-data": "old"},
+					},
+				})).To(Succeed())
+				Expect(shootFakeClient.Create(ctx, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "gardener-node-agent-worker-pool-def34",
+						Namespace:   metav1.NamespaceSystem,
+						Labels:      map[string]string{"worker.gardener.cloud/pool": "worker-pool", "gardener.cloud/role": "operating-system-config"},
+						Annotations: map[string]string{"checksum/data-script": "new"},
+					},
+				})).To(Succeed())
+
+				Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, true, false)).To(Succeed())
+			})
 		})
 	})
 })

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -429,8 +429,7 @@ func (r *Reconciler) reconcile(
 				}
 				virtualClusterClient = virtualClusterClientSet.Client()
 				return nil
-			}).
-				RetryUntilTimeout(time.Second, defaultTimeout),
+			}).RetryUntilTimeout(time.Second, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerService, deployVirtualGardenGardenerAccess, renewVirtualClusterAccess),
 		})
 		_ = g.Add(flow.Task{
@@ -535,13 +534,29 @@ func (r *Reconciler) reconcile(
 			SkipIf:       helper.GetServiceAccountKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
 			Dependencies: flow.NewTaskIDs(renewGardenAccessSecretsInAllSeeds),
 		})
+		renewGardenAccessSecretsInAllSelfHostedShoots = g.Add(flow.Task{
+			Name: "Annotate self-hosted Shoot resources to trigger renewal of their garden access secrets",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return secretsrotation.RenewGardenSecretsInAllSelfHostedShoots(ctx, log.WithValues(secretsTypeKey, secretsTypeGardenAccess), virtualClusterClient, v1beta1constants.SeedOperationRenewGardenAccessSecrets)
+			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
+			SkipIf:       helper.GetServiceAccountKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
+			Dependencies: flow.NewTaskIDs(initializeVirtualClusterClient),
+		})
+		checkIfGardenAccessSecretsRenewalCompletedInAllSelfHostedShoots = g.Add(flow.Task{
+			Name: "Check if all self-hosted shoots finished the renewal of their garden access secrets",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return secretsrotation.CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots(ctx, virtualClusterClient, v1beta1constants.SeedOperationRenewGardenAccessSecrets, secretsTypeGardenAccess)
+			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
+			SkipIf:       helper.GetServiceAccountKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
+			Dependencies: flow.NewTaskIDs(renewGardenAccessSecretsInAllSelfHostedShoots),
+		})
 		renewWorkloadIdentityTokensInAllSeeds = g.Add(flow.Task{
 			Name: "Annotate Seed resources to trigger renewal of workload identity tokens",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.RenewGardenSecretsInAllSeeds(ctx, log.WithValues(secretsTypeKey, secretsTypeWorkloadIdentity), virtualClusterClient, v1beta1constants.SeedOperationRenewWorkloadIdentityTokens)
 			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
 			SkipIf:       helper.GetWorkloadIdentityKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
-			Dependencies: flow.NewTaskIDs(initializeVirtualClusterClient, waitUntilGardenerAPIServerReady, checkIfGardenAccessSecretsRenewalCompletedInAllSeeds),
+			Dependencies: flow.NewTaskIDs(initializeVirtualClusterClient, waitUntilGardenerAPIServerReady, checkIfGardenAccessSecretsRenewalCompletedInAllSeeds, checkIfGardenAccessSecretsRenewalCompletedInAllSelfHostedShoots),
 		})
 		checkIfWorkloadIdentityTokensRenewalCompletedInAllSeeds = g.Add(flow.Task{
 			Name: "Check if all seeds finished the renewal of their workload identity tokens",
@@ -551,13 +566,29 @@ func (r *Reconciler) reconcile(
 			SkipIf:       helper.GetWorkloadIdentityKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
 			Dependencies: flow.NewTaskIDs(renewWorkloadIdentityTokensInAllSeeds),
 		})
+		renewWorkloadIdentityTokensInAllSelfHostedShoots = g.Add(flow.Task{
+			Name: "Annotate self-hosted Shoot resources to trigger renewal of workload identity tokens",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return secretsrotation.RenewGardenSecretsInAllSelfHostedShoots(ctx, log.WithValues(secretsTypeKey, secretsTypeWorkloadIdentity), virtualClusterClient, v1beta1constants.SeedOperationRenewWorkloadIdentityTokens)
+			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
+			SkipIf:       helper.GetWorkloadIdentityKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
+			Dependencies: flow.NewTaskIDs(initializeVirtualClusterClient, waitUntilGardenerAPIServerReady, checkIfGardenAccessSecretsRenewalCompletedInAllSelfHostedShoots),
+		})
+		checkIfWorkloadIdentityTokensRenewalCompletedInAllSelfHostedShoots = g.Add(flow.Task{
+			Name: "Check if all self-hosted shoots finished the renewal of their workload identity tokens",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return secretsrotation.CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots(ctx, virtualClusterClient, v1beta1constants.SeedOperationRenewWorkloadIdentityTokens, secretsTypeWorkloadIdentity)
+			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
+			SkipIf:       helper.GetWorkloadIdentityKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
+			Dependencies: flow.NewTaskIDs(renewWorkloadIdentityTokensInAllSelfHostedShoots),
+		})
 		renewKubeconfigsOfSeedGardenlets = g.Add(flow.Task{
 			Name: "Annotate Seed resources to trigger renewal of their gardenlet kubeconfig",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.RenewGardenSecretsInAllSeeds(ctx, log.WithValues(secretsTypeKey, secretsTypeGardenletKubeconfig), virtualClusterClient, v1beta1constants.GardenerOperationRenewKubeconfig)
 			}).RetryUntilTimeout(defaultInterval, 10*time.Minute),
 			SkipIf:       helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
-			Dependencies: flow.NewTaskIDs(checkIfWorkloadIdentityTokensRenewalCompletedInAllSeeds),
+			Dependencies: flow.NewTaskIDs(checkIfWorkloadIdentityTokensRenewalCompletedInAllSeeds, checkIfWorkloadIdentityTokensRenewalCompletedInAllSelfHostedShoots),
 		})
 		checkIfSeedGardenletKubeconfigRenewalsCompleted = g.Add(flow.Task{
 			Name: "Check if all seed gardenlets finished the renewal of their kubeconfig",

--- a/pkg/utils/flow/group.go
+++ b/pkg/utils/flow/group.go
@@ -93,6 +93,15 @@ func (g TaskGroup) WithDependencies(dependencies ...TaskIDer) TaskGroup {
 	return g
 }
 
+// WithDependenciesIf inserts the TaskIDs of all TaskIDers into the dependencies of this group if the given condition
+// evaluates to true.
+func (g TaskGroup) WithDependenciesIf(condition bool, dependencies ...TaskIDer) TaskGroup {
+	for _, dependency := range dependencies {
+		g.dependencies.InsertIf(condition, dependency)
+	}
+	return g
+}
+
 // SkipIf marks every task in the group as skipped when the given condition evaluates to true.
 // Multiple calls OR the conditions together, and per-task `Task.SkipIf` values are preserved:
 // a task already flagged skipped stays skipped regardless of the group condition.

--- a/pkg/utils/flow/group_test.go
+++ b/pkg/utils/flow/group_test.go
@@ -104,6 +104,36 @@ var _ = Describe("TaskGroup", func() {
 		})
 	})
 
+	Describe("#WithDependenciesIf", func() {
+		It("should not add dependencies when the condition is false", func() {
+			var (
+				rec   = &recorder{}
+				graph = flow.NewGraph("foo")
+			)
+
+			pre := graph.Add(rec.task("pre"))
+			graph.AddGroup(flow.NewTaskGroup("group", rec.task("a"), rec.task("b")).WithDependenciesIf(false, pre))
+
+			Expect(graph.Compile().Run(context.Background(), flow.Opts{})).To(Succeed())
+			Expect(rec.executed()).To(ConsistOf("pre", "a", "b"))
+		})
+
+		It("should add dependencies when the condition is true", func() {
+			var (
+				rec   = &recorder{}
+				graph = flow.NewGraph("foo")
+			)
+
+			pre := graph.Add(rec.task("pre"))
+			graph.AddGroup(flow.NewTaskGroup("group", rec.task("a"), rec.task("b")).WithDependenciesIf(true, pre))
+
+			Expect(graph.Compile().Run(context.Background(), flow.Opts{})).To(Succeed())
+			executed := rec.executed()
+			Expect(executed[0]).To(Equal("pre"))
+			Expect(executed[1:]).To(ConsistOf("a", "b"))
+		})
+	})
+
 	Describe("#SkipIf", func() {
 		It("should not skip tasks when the condition is false", func() {
 			var (

--- a/pkg/utils/gardener/secretsrotation/constants.go
+++ b/pkg/utils/gardener/secretsrotation/constants.go
@@ -7,6 +7,8 @@ package secretsrotation
 const (
 	// AnnotationKeyNewEncryptionKeyPopulated is an annotation indicating that the new ETCD encryption key was populated
 	AnnotationKeyNewEncryptionKeyPopulated = "credentials.gardener.cloud/new-encryption-key-populated"
+	// AnnotationKeyPeerCARolledOut is an annotation indicating that the ETCD peer CA bundle has been rolled out.
+	AnnotationKeyPeerCARolledOut = "credentials.gardener.cloud/peer-ca-rolled-out"
 
 	// AnnotationKeyResourcesLabeled is an annotation indicating the completion of labeling the resources with the credentials.gardener.cloud/key-name label
 	AnnotationKeyResourcesLabeled = "credentials.gardener.cloud/resources-labeled"

--- a/pkg/utils/gardener/secretsrotation/gardenaccess.go
+++ b/pkg/utils/gardener/secretsrotation/gardenaccess.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
@@ -86,7 +87,7 @@ func RenewGardenSecretsInAllSelfHostedShoots(ctx context.Context, log logr.Logge
 		return err
 	}
 
-	var shoots []metav1.PartialObjectMetadata
+	var shootsThatAreNoSeeds []metav1.PartialObjectMetadata
 	for _, shoot := range shootList.Items {
 		seed := &metav1.PartialObjectMetadata{}
 		seed.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))
@@ -94,28 +95,26 @@ func RenewGardenSecretsInAllSelfHostedShoots(ctx context.Context, log logr.Logge
 			if !apierrors.IsNotFound(err) {
 				return fmt.Errorf("error checking whether self-hosted shoot %s is also registered as a seed: %w", client.ObjectKeyFromObject(&shoot), err)
 			}
-			shoots = append(shoots, shoot)
+			shootsThatAreNoSeeds = append(shootsThatAreNoSeeds, shoot)
 		}
 	}
 
-	log.Info("Self-hosted shoots requiring renewal of their secrets", v1beta1constants.GardenerOperation, operationAnnotation, "number", len(shoots))
+	log.Info("Self-hosted shoots requiring renewal of their secrets", v1beta1constants.GardenerOperation, operationAnnotation, "number", len(shootsThatAreNoSeeds))
 
 	var tasks []flow.TaskFn
-	for _, shoot := range shoots {
-		if shoot.Annotations[v1beta1constants.GardenerOperation] == operationAnnotation {
+	for _, shoot := range shootsThatAreNoSeeds {
+		existingOperations := v1beta1helper.GetShootGardenerOperations(shoot.Annotations)
+		if slices.Contains(existingOperations, operationAnnotation) {
 			continue
 		}
 
-		if shoot.Annotations[v1beta1constants.GardenerOperation] != "" {
-			return fmt.Errorf("error annotating self-hosted shoot %s: already annotated with \"%s: %s\"", client.ObjectKeyFromObject(&shoot), v1beta1constants.GardenerOperation, shoot.Annotations[v1beta1constants.GardenerOperation])
-		}
-
+		newAnnotation := strings.Join(append(existingOperations, operationAnnotation), v1beta1constants.GardenerOperationsSeparator)
 		tasks = append(tasks, func(ctx context.Context) error {
 			log := log.WithValues("shoot", client.ObjectKeyFromObject(&shoot))
 
 			shoot.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
 			patch := client.MergeFrom(shoot.DeepCopy())
-			kubernetesutils.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.GardenerOperation, operationAnnotation)
+			kubernetesutils.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.GardenerOperation, newAnnotation)
 			if err := c.Patch(ctx, &shoot, patch); err != nil {
 				return fmt.Errorf("error annotating self-hosted shoot %s: %w", client.ObjectKeyFromObject(&shoot), err)
 			}
@@ -137,7 +136,7 @@ func CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots(ctx context.Conte
 	}
 
 	for _, shoot := range shootList.Items {
-		if shoot.Annotations[v1beta1constants.GardenerOperation] != operationAnnotation {
+		if !slices.Contains(v1beta1helper.GetShootGardenerOperations(shoot.Annotations), operationAnnotation) {
 			continue
 		}
 

--- a/pkg/utils/gardener/secretsrotation/gardenaccess.go
+++ b/pkg/utils/gardener/secretsrotation/gardenaccess.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -70,6 +71,83 @@ func CheckIfGardenSecretsRenewalCompletedInAllSeeds(ctx context.Context, c clien
 	for _, seed := range seedList.Items {
 		if seed.Annotations[v1beta1constants.GardenerOperation] == operationAnnotation {
 			return fmt.Errorf("renewing %q secrets for seed %q is not yet completed", secretType, seed.Name)
+		}
+	}
+
+	return nil
+}
+
+// RenewGardenSecretsInAllSelfHostedShoots annotates all self-hosted Shoot resources (that are not also registered as
+// seeds) to trigger renewal of their garden secrets.
+func RenewGardenSecretsInAllSelfHostedShoots(ctx context.Context, log logr.Logger, c client.Client, operationAnnotation string) error {
+	shootList := &metav1.PartialObjectMetadataList{}
+	shootList.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("ShootList"))
+	if err := c.List(ctx, shootList, client.MatchingLabels{v1beta1constants.ShootIsSelfHosted: "true"}); err != nil {
+		return err
+	}
+
+	var shoots []metav1.PartialObjectMetadata
+	for _, shoot := range shootList.Items {
+		seed := &metav1.PartialObjectMetadata{}
+		seed.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))
+		if err := c.Get(ctx, client.ObjectKey{Name: shoot.Name}, seed); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("error checking whether self-hosted shoot %s is also registered as a seed: %w", client.ObjectKeyFromObject(&shoot), err)
+			}
+			shoots = append(shoots, shoot)
+		}
+	}
+
+	log.Info("Self-hosted shoots requiring renewal of their secrets", v1beta1constants.GardenerOperation, operationAnnotation, "number", len(shoots))
+
+	var tasks []flow.TaskFn
+	for _, shoot := range shoots {
+		if shoot.Annotations[v1beta1constants.GardenerOperation] == operationAnnotation {
+			continue
+		}
+
+		if shoot.Annotations[v1beta1constants.GardenerOperation] != "" {
+			return fmt.Errorf("error annotating self-hosted shoot %s: already annotated with \"%s: %s\"", client.ObjectKeyFromObject(&shoot), v1beta1constants.GardenerOperation, shoot.Annotations[v1beta1constants.GardenerOperation])
+		}
+
+		tasks = append(tasks, func(ctx context.Context) error {
+			log := log.WithValues("shoot", client.ObjectKeyFromObject(&shoot))
+
+			shoot.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
+			patch := client.MergeFrom(shoot.DeepCopy())
+			kubernetesutils.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.GardenerOperation, operationAnnotation)
+			if err := c.Patch(ctx, &shoot, patch); err != nil {
+				return fmt.Errorf("error annotating self-hosted shoot %s: %w", client.ObjectKeyFromObject(&shoot), err)
+			}
+			log.Info("Successfully annotated self-hosted shoot to renew its secrets", v1beta1constants.GardenerOperation, operationAnnotation)
+			return nil
+		})
+	}
+
+	return flow.ParallelN(5, tasks...)(ctx)
+}
+
+// CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots checks if renewal of garden secrets is completed for all
+// self-hosted Shoot resources (that are not also registered as seeds).
+func CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots(ctx context.Context, c client.Client, operationAnnotation string, secretType string) error {
+	shootList := &metav1.PartialObjectMetadataList{}
+	shootList.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("ShootList"))
+	if err := c.List(ctx, shootList, client.MatchingLabels{v1beta1constants.ShootIsSelfHosted: "true"}); err != nil {
+		return err
+	}
+
+	for _, shoot := range shootList.Items {
+		if shoot.Annotations[v1beta1constants.GardenerOperation] != operationAnnotation {
+			continue
+		}
+
+		seed := &metav1.PartialObjectMetadata{}
+		seed.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))
+		if err := c.Get(ctx, client.ObjectKey{Name: shoot.Name}, seed); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("error checking whether self-hosted shoot %s/%s is also registered as a seed: %w", shoot.Namespace, shoot.Name, err)
+			}
+			return fmt.Errorf("renewing %q secrets for self-hosted shoot %s/%s is not yet completed", secretType, shoot.Namespace, shoot.Name)
 		}
 	}
 

--- a/pkg/utils/gardener/secretsrotation/gardenaccess_test.go
+++ b/pkg/utils/gardener/secretsrotation/gardenaccess_test.go
@@ -315,11 +315,21 @@ var _ = Describe("RenewGardenAccess", func() {
 			}
 		})
 
-		It("should fail if some shoots have a different `gardener.cloud/operation` annotation", func() {
-			shoots[0].SetAnnotations(map[string]string{"gardener.cloud/operation": "reconcile"})
+		It("should succeed and append the operation if some shoots are already annotated with a different operation", func() {
+			shoots[0].SetAnnotations(map[string]string{"gardener.cloud/operation": renewWorkloadIdentityTokens})
 			Expect(createShoots()).To(Succeed())
 
-			Expect(RenewGardenSecretsInAllSelfHostedShoots(ctx, logger.WithValues(secretType, gardenAccess), gardenClient, renewGardenAccessSecrets)).To(MatchError(ContainSubstring("error annotating self-hosted shoot garden/shoot1: already annotated with \"gardener.cloud/operation: reconcile\"")))
+			Expect(RenewGardenSecretsInAllSelfHostedShoots(ctx, logger.WithValues(secretType, gardenAccess), gardenClient, renewGardenAccessSecrets)).To(Succeed())
+
+			updated := &gardencorev1beta1.Shoot{}
+			Expect(gardenClient.Get(ctx, client.ObjectKey{Name: "shoot1", Namespace: "garden"}, updated)).To(Succeed())
+			Expect(updated.Annotations["gardener.cloud/operation"]).To(Equal(renewWorkloadIdentityTokens + ";" + renewGardenAccessSecrets))
+
+			shootList := gardencorev1beta1.ShootList{}
+			Expect(gardenClient.List(ctx, &shootList)).To(Succeed())
+			for _, shoot := range shootList.Items {
+				Expect(shoot.Annotations["gardener.cloud/operation"]).To(ContainSubstring(renewGardenAccessSecrets))
+			}
 		})
 
 		It("should skip non-self-hosted shoots", func() {
@@ -381,6 +391,13 @@ var _ = Describe("RenewGardenAccess", func() {
 
 		It("should fail if some self-hosted shoots are still annotated", func() {
 			shoots[1].SetAnnotations(map[string]string{"gardener.cloud/operation": renewGardenAccessSecrets})
+			Expect(createShoots()).To(Succeed())
+
+			Expect(CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots(ctx, gardenClient, renewGardenAccessSecrets, gardenAccess)).To(MatchError(ContainSubstring("renewing \"garden access\" secrets for self-hosted shoot garden/shoot2 is not yet completed")))
+		})
+
+		It("should fail if some self-hosted shoots have a combined annotation that still includes the operation", func() {
+			shoots[1].SetAnnotations(map[string]string{"gardener.cloud/operation": renewWorkloadIdentityTokens + ";" + renewGardenAccessSecrets})
 			Expect(createShoots()).To(Succeed())
 
 			Expect(CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots(ctx, gardenClient, renewGardenAccessSecrets, gardenAccess)).To(MatchError(ContainSubstring("renewing \"garden access\" secrets for self-hosted shoot garden/shoot2 is not yet completed")))

--- a/pkg/utils/gardener/secretsrotation/gardenaccess_test.go
+++ b/pkg/utils/gardener/secretsrotation/gardenaccess_test.go
@@ -269,4 +269,130 @@ var _ = Describe("RenewGardenAccess", func() {
 			Expect(CheckIfKubeconfigRenewalCompletedInAllShootGardenlets(ctx, gardenClient)).To(Succeed())
 		})
 	})
+
+	Context("#RenewGardenSecretsInAllSelfHostedShoots", func() {
+		var shoots []gardencorev1beta1.Shoot
+
+		BeforeEach(func() {
+			shoots = []gardencorev1beta1.Shoot{
+				{ObjectMeta: metav1.ObjectMeta{Name: "shoot1", Namespace: "garden", Labels: map[string]string{"shoot.gardener.cloud/self-hosted": "true"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "shoot2", Namespace: "garden", Labels: map[string]string{"shoot.gardener.cloud/self-hosted": "true"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "shoot3", Namespace: "garden", Labels: map[string]string{"shoot.gardener.cloud/self-hosted": "true"}}},
+			}
+		})
+
+		createShoots := func() error {
+			for _, shoot := range shoots {
+				if err := gardenClient.Create(ctx, &shoot); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		It("should succeed and annotate all self-hosted shoots", func() {
+			Expect(createShoots()).To(Succeed())
+
+			Expect(RenewGardenSecretsInAllSelfHostedShoots(ctx, logger.WithValues(secretType, gardenAccess), gardenClient, renewGardenAccessSecrets)).To(Succeed())
+
+			shootList := gardencorev1beta1.ShootList{}
+			Expect(gardenClient.List(ctx, &shootList)).To(Succeed())
+			for _, shoot := range shootList.Items {
+				Expect(shoot.Annotations["gardener.cloud/operation"]).To(Equal(renewGardenAccessSecrets))
+			}
+		})
+
+		It("should succeed if some shoots are already annotated with the operation", func() {
+			shoots[0].SetAnnotations(map[string]string{"gardener.cloud/operation": renewGardenAccessSecrets})
+			Expect(createShoots()).To(Succeed())
+
+			Expect(RenewGardenSecretsInAllSelfHostedShoots(ctx, logger.WithValues(secretType, gardenAccess), gardenClient, renewGardenAccessSecrets)).To(Succeed())
+
+			shootList := gardencorev1beta1.ShootList{}
+			Expect(gardenClient.List(ctx, &shootList)).To(Succeed())
+			for _, shoot := range shootList.Items {
+				Expect(shoot.Annotations["gardener.cloud/operation"]).To(Equal(renewGardenAccessSecrets))
+			}
+		})
+
+		It("should fail if some shoots have a different `gardener.cloud/operation` annotation", func() {
+			shoots[0].SetAnnotations(map[string]string{"gardener.cloud/operation": "reconcile"})
+			Expect(createShoots()).To(Succeed())
+
+			Expect(RenewGardenSecretsInAllSelfHostedShoots(ctx, logger.WithValues(secretType, gardenAccess), gardenClient, renewGardenAccessSecrets)).To(MatchError(ContainSubstring("error annotating self-hosted shoot garden/shoot1: already annotated with \"gardener.cloud/operation: reconcile\"")))
+		})
+
+		It("should skip non-self-hosted shoots", func() {
+			nonSelfHosted := gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: "regular-shoot", Namespace: "garden"}}
+			Expect(gardenClient.Create(ctx, &nonSelfHosted)).To(Succeed())
+			Expect(createShoots()).To(Succeed())
+
+			Expect(RenewGardenSecretsInAllSelfHostedShoots(ctx, logger.WithValues(secretType, gardenAccess), gardenClient, renewGardenAccessSecrets)).To(Succeed())
+
+			updated := &gardencorev1beta1.Shoot{}
+			Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(&nonSelfHosted), updated)).To(Succeed())
+			Expect(updated.Annotations["gardener.cloud/operation"]).To(BeEmpty())
+		})
+
+		It("should skip self-hosted shoots that are also registered as seeds", func() {
+			seed := gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: "shoot1"}}
+			Expect(gardenClient.Create(ctx, &seed)).To(Succeed())
+			Expect(createShoots()).To(Succeed())
+
+			Expect(RenewGardenSecretsInAllSelfHostedShoots(ctx, logger.WithValues(secretType, gardenAccess), gardenClient, renewGardenAccessSecrets)).To(Succeed())
+
+			updated := &gardencorev1beta1.Shoot{}
+			Expect(gardenClient.Get(ctx, client.ObjectKey{Name: "shoot1", Namespace: "garden"}, updated)).To(Succeed())
+			Expect(updated.Annotations["gardener.cloud/operation"]).To(BeEmpty())
+		})
+	})
+
+	Context("#CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots", func() {
+		var shoots []gardencorev1beta1.Shoot
+
+		BeforeEach(func() {
+			shoots = []gardencorev1beta1.Shoot{
+				{ObjectMeta: metav1.ObjectMeta{Name: "shoot1", Namespace: "garden", Labels: map[string]string{"shoot.gardener.cloud/self-hosted": "true"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "shoot2", Namespace: "garden", Labels: map[string]string{"shoot.gardener.cloud/self-hosted": "true"}}},
+			}
+		})
+
+		createShoots := func() error {
+			for _, shoot := range shoots {
+				if err := gardenClient.Create(ctx, &shoot); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		It("should succeed if no self-hosted shoot is annotated anymore", func() {
+			Expect(createShoots()).To(Succeed())
+
+			Expect(CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots(ctx, gardenClient, renewGardenAccessSecrets, gardenAccess)).To(Succeed())
+		})
+
+		It("should succeed if some shoots have a different `gardener.cloud/operation` annotation", func() {
+			shoots[0].SetAnnotations(map[string]string{"gardener.cloud/operation": "reconcile"})
+			Expect(createShoots()).To(Succeed())
+
+			Expect(CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots(ctx, gardenClient, renewGardenAccessSecrets, gardenAccess)).To(Succeed())
+		})
+
+		It("should fail if some self-hosted shoots are still annotated", func() {
+			shoots[1].SetAnnotations(map[string]string{"gardener.cloud/operation": renewGardenAccessSecrets})
+			Expect(createShoots()).To(Succeed())
+
+			Expect(CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots(ctx, gardenClient, renewGardenAccessSecrets, gardenAccess)).To(MatchError(ContainSubstring("renewing \"garden access\" secrets for self-hosted shoot garden/shoot2 is not yet completed")))
+		})
+
+		It("should succeed if only a self-hosted shoot registered as a seed is still annotated", func() {
+			shoots[1].SetAnnotations(map[string]string{"gardener.cloud/operation": renewGardenAccessSecrets})
+			Expect(createShoots()).To(Succeed())
+			seed := gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: "shoot2"}}
+			Expect(gardenClient.Create(ctx, &seed)).To(Succeed())
+
+			Expect(CheckIfGardenSecretsRenewalCompletedInAllSelfHostedShoots(ctx, gardenClient, renewGardenAccessSecrets, gardenAccess)).To(Succeed())
+		})
+	})
 })

--- a/pkg/utils/gardener/tokenrequest/secrets.go
+++ b/pkg/utils/gardener/tokenrequest/secrets.go
@@ -80,7 +80,7 @@ func RenewWorkloadIdentityTokens(ctx context.Context, c client.Client, opts ...c
 	return renewTokenInSecrets(ctx, c, securityv1alpha1constants.AnnotationWorkloadIdentityTokenRenewTimestamp, *workloadIdentityTokenRequestorRequirement, opts...)
 }
 
-// renewTokenInSecrets removes the [annotationKey] annotation from all secrets listed with with applied [labelSelector] and [opts].
+// renewTokenInSecrets removes the [annotationKey] annotation from all secrets listed with applied [labelSelector] and [opts].
 // Removal of annotation is expected to trigger reconciliation of the secrets by a token requestor controller.
 func renewTokenInSecrets(ctx context.Context, c client.Client, annotationKey string, labelSelector labels.Requirement, opts ...client.ListOption) error {
 	listOptions := &client.ListOptions{}
@@ -99,9 +99,7 @@ func renewTokenInSecrets(ctx context.Context, c client.Client, annotationKey str
 
 	var fns []flow.TaskFn
 
-	for _, obj := range secretList.Items {
-		secret := obj
-
+	for _, secret := range secretList.Items {
 		fns = append(fns, func(ctx context.Context) error {
 			patch := client.MergeFrom(secret.DeepCopy())
 			delete(secret.Annotations, annotationKey)

--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -268,10 +268,18 @@ func (c *mutationContext) addMetadataAnnotations(a admission.Attributes) {
 }
 
 func addInfrastructureDeploymentTask(shoot *core.Shoot) {
+	if helper.IsShootSelfHosted(shoot.Spec.Provider.Workers) && !helper.HasManagedInfrastructure(shoot) {
+		return
+	}
+
 	addDeploymentTasks(shoot, v1beta1constants.ShootTaskDeployInfrastructure)
 }
 
 func addDNSRecordDeploymentTasks(shoot *core.Shoot) {
+	if helper.IsShootSelfHosted(shoot.Spec.Provider.Workers) {
+		return
+	}
+
 	addDeploymentTasks(shoot,
 		v1beta1constants.ShootTaskDeployDNSRecordInternal,
 		v1beta1constants.ShootTaskDeployDNSRecordExternal,

--- a/plugin/pkg/shoot/mutator/admission_test.go
+++ b/plugin/pkg/shoot/mutator/admission_test.go
@@ -412,6 +412,137 @@ var _ = Describe("mutator", func() {
 				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployDNSRecordExternal")).To(BeFalse())
 				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployDNSRecordIngress")).To(BeFalse())
 			})
+
+			When("shoot is self-hosted", func() {
+				BeforeEach(func() {
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					oldShoot = shoot.DeepCopy()
+				})
+
+				It("should not add deploy tasks on creation", func() {
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeFalse())
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployDNSRecordInternal")).To(BeFalse())
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployDNSRecordExternal")).To(BeFalse())
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployDNSRecordIngress")).To(BeFalse())
+				})
+
+				It("should not add deploy tasks when waking up from hibernation", func() {
+					oldShoot.Spec.Hibernation = &core.Hibernation{Enabled: new(true)}
+					shoot.Spec.Hibernation = &core.Hibernation{Enabled: new(false)}
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeFalse())
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployDNSRecordInternal")).To(BeFalse())
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployDNSRecordExternal")).To(BeFalse())
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployDNSRecordIngress")).To(BeFalse())
+				})
+
+				It("should not add deploy infrastructure task when infrastructure config has changed", func() {
+					shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: []byte("infrastructure")}
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeFalse())
+				})
+
+				It("should not add deploy infrastructure task when ipFamilies have changed", func() {
+					oldShoot.Spec.Networking = &core.Networking{IPFamilies: []core.IPFamily{core.IPFamilyIPv4}}
+					shoot.Spec.Networking = &core.Networking{IPFamilies: []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}}
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeFalse())
+				})
+
+				It("should not add deploy infrastructure task when SSHAccess has changed", func() {
+					oldShoot.Spec.Provider.WorkersSettings = &core.WorkersSettings{SSHAccess: &core.SSHAccess{Enabled: true}}
+					shoot.Spec.Provider.WorkersSettings = &core.WorkersSettings{SSHAccess: &core.SSHAccess{Enabled: false}}
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeFalse())
+				})
+
+				It("should not add deploy dnsrecord tasks when dns config has changed", func() {
+					shoot.Spec.DNS = &core.DNS{}
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployDNSRecordInternal")).To(BeFalse())
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployDNSRecordExternal")).To(BeFalse())
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployDNSRecordIngress")).To(BeFalse())
+				})
+
+				It("should not add deploy infrastructure task when operation annotation to rotate ssh keypair was set", func() {
+					shoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.ShootOperationRotateSSHKeypair}
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeFalse())
+				})
+
+				It("should not add deploy infrastructure task when operation annotation to rotate all credentials was set", func() {
+					shoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.OperationRotateCredentialsStart}
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeFalse())
+				})
+
+				It("should not add deploy infrastructure task when operation annotation to rotate all credentials w/o workers rollout was set", func() {
+					shoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.OperationRotateCredentialsStartWithoutWorkersRollout}
+
+					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeFalse())
+				})
+
+				When("with managed infrastructure", func() {
+					BeforeEach(func() {
+						shoot.Spec.CredentialsBindingName = new("credentials")
+						oldShoot = shoot.DeepCopy()
+					})
+
+					It("should add deploy infrastructure task on creation", func() {
+						attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).To(Not(HaveOccurred()))
+						Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeTrue())
+					})
+
+					It("should add deploy infrastructure task when infrastructure config has changed", func() {
+						shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: []byte("infrastructure")}
+
+						attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).To(Not(HaveOccurred()))
+						Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, "deployInfrastructure")).To(BeTrue())
+					})
+				})
+			})
 		})
 
 		Context("shoot maintenance checks", func() {

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -1114,8 +1114,7 @@ var _ = Describe("Seed controller tests", func() {
 						"prometheus-aggregate",
 						"kube-state-metrics-seed",
 						"referenced-resources-" + seedName,
-						// Components not skipped for self-hosted shoots (only for garden):
-						"vpa",
+						// Components skipped only for garden (not for self-hosted shoots):
 						"plutono",
 						"vali",
 						"fluent-bit",


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This is the main step to make the gardenlet's `Shoot` controller functional for self-hosted clusters: it activates the relevant reconciliation flow tasks so that the full shoot lifecycle (system components, extensions, worker pools, backups, etc.) is handled end-to-end by the gardenlet running inside the self-hosted shoot itself.

As a prerequisite, the shoot reconciliation flow is refactored into composable `TaskGroup`s. Each group declares its conditional dependencies at definition time, making it straightforward to skip or activate entire groups based on whether the shoot is self-hosted. This refactor has no behavior change for hosted shoots.

Several bugs surfaced during activation and are fixed here: `gardenadm connect` now initializes `status.credentials.encryptionAtRest` from the spec before registering the shoot in the garden cluster — `gardenadm init` already set up etcd with the spec's encryption provider, so the gardenlet's first reconciliation correctly sees the encryption state as settled and skips the unnecessary rewrite tasks. ETCD encryption key rotation and CA certificate rotation are also wired up for self-hosted shoots, and worker pool update ordering is fixed (control plane pool must roll first, same as hosted shoots).

The final commit closes a gap in the garden CA and workload identity key rotation flows: gardener-operator now also annotates self-hosted `Shoot` resources (excluding those registered as seeds, which are already covered by the seed path) with `renew-garden-access-secrets` and `renew-workload-identity-tokens`. The shoot gardenlet handles these annotations by calling `tokenrequest.RenewAccessSecrets` / `RenewWorkloadIdentityTokens` on its seed cluster client and removing the annotation afterward. The self-hosted shoot tasks run in parallel with their seed counterparts and are sequenced correctly in the operator's rotation flow.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
The `TaskGroup` refactor (first ~12 commits) is pure restructuring with no behavior change for hosted shoots, though some commits already wire up self-hosted-specific behavior.

**Release note**:
```
NONE
```