### PR TITLE
Add `Seed` and `Garden` Perses instances

### DIFF
--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -151,6 +151,7 @@ build:
             - pkg/component/observability/monitoring/kubestatemetrics
             - pkg/component/observability/monitoring/metricsserver
             - pkg/component/observability/monitoring/nodeexporter
+            - pkg/component/observability/monitoring/perses
             - pkg/component/observability/monitoring/persesoperator
             - pkg/component/observability/monitoring/prometheus
             - pkg/component/observability/monitoring/prometheus/aggregate
@@ -696,6 +697,7 @@ build:
             - pkg/component/observability/monitoring/kubestatemetrics
             - pkg/component/observability/monitoring/metricsserver
             - pkg/component/observability/monitoring/nodeexporter
+            - pkg/component/observability/monitoring/perses
             - pkg/component/observability/monitoring/persesoperator
             - pkg/component/observability/monitoring/prometheus
             - pkg/component/observability/monitoring/prometheus/aggregate

--- a/dev-setup/skaffold-operator.yaml
+++ b/dev-setup/skaffold-operator.yaml
@@ -135,6 +135,7 @@ build:
             - pkg/component/observability/monitoring/blackboxexporter/garden
             - pkg/component/observability/monitoring/gardenermetricsexporter
             - pkg/component/observability/monitoring/kubestatemetrics
+            - pkg/component/observability/monitoring/perses
             - pkg/component/observability/monitoring/persesoperator
             - pkg/component/observability/monitoring/prometheus
             - pkg/component/observability/monitoring/prometheus/aggregate

--- a/dev-setup/skaffold-seed.yaml
+++ b/dev-setup/skaffold-seed.yaml
@@ -198,6 +198,7 @@ build:
             - pkg/component/observability/monitoring/kubestatemetrics
             - pkg/component/observability/monitoring/metricsserver
             - pkg/component/observability/monitoring/nodeexporter
+            - pkg/component/observability/monitoring/perses
             - pkg/component/observability/monitoring/persesoperator
             - pkg/component/observability/monitoring/prometheus
             - pkg/component/observability/monitoring/prometheus/aggregate

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/open-telemetry/opentelemetry-operator/apis v0.156.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml v1.9.5
+	github.com/perses/perses v0.54.0
 	github.com/perses/perses-operator v0.5.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.93.1
 	github.com/prometheus/blackbox_exporter v0.28.0
@@ -271,7 +272,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/perses/common v0.31.2 // indirect
-	github.com/perses/perses v0.54.0 // indirect
 	github.com/perses/spec v0.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/perses/perses v0.54.0
 	github.com/perses/perses-operator v0.5.0
+	github.com/perses/spec v0.2.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.93.1
 	github.com/prometheus/blackbox_exporter v0.28.0
 	github.com/prometheus/client_golang v1.24.1
@@ -272,7 +273,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/perses/common v0.31.2 // indirect
-	github.com/perses/spec v0.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/pkg/component/observability/monitoring/perses/allowedendpoints_internal_test.go
+++ b/pkg/component/observability/monitoring/perses/allowedendpoints_internal_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package perses
+
+import (
+	"net/http"
+	"regexp"
+	"testing"
+)
+
+// endpointAllowed reproduces how Perses evaluates the datasource proxy allow-list: it compiles each
+// endpointPattern as an (unanchored) regular expression and, for a matching HTTP method, checks whether the pattern
+// matches anywhere in the request path via regexp.FindAllString. See
+// github.com/perses/perses/internal/api/impl/proxy/proxy.go.
+func endpointAllowed(entries []map[string]any, method, path string) bool {
+	for _, entry := range entries {
+		if entry["method"] != method {
+			continue
+		}
+		if len(regexp.MustCompile(entry["endpointPattern"].(string)).FindAllString(path, -1)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAllowedEndpointsForPluginAreAnchored(t *testing.T) {
+	prometheus := allowedEndpointsForPlugin(pluginKindPrometheus)
+
+	allowed := []struct{ method, path string }{
+		{http.MethodGet, "/api/v1/query"},
+		{http.MethodPost, "/api/v1/query"},
+		{http.MethodGet, "/api/v1/query_range"},
+		{http.MethodGet, "/api/v1/label/instance/values"},
+	}
+	for _, tc := range allowed {
+		if !endpointAllowed(prometheus, tc.method, tc.path) {
+			t.Errorf("expected %s %s to be allowed for the Prometheus plugin, but it was rejected", tc.method, tc.path)
+		}
+	}
+
+	// Anchoring must reject paths that merely contain an allowed endpoint. Without "^...$" these would slip through
+	// because Perses matches the pattern as an unanchored substring, letting a caller reach write/admin endpoints.
+	rejected := []struct{ method, path string }{
+		{http.MethodGet, "/api/v1/query/../../admin/tsdb/delete_series"},
+		{http.MethodGet, "/api/v1/metadata/../admin"},
+		{http.MethodPost, "/api/v1/write"},
+		{http.MethodGet, "/prefix/api/v1/query"},
+	}
+	for _, tc := range rejected {
+		if endpointAllowed(prometheus, tc.method, tc.path) {
+			t.Errorf("expected %s %s to be rejected for the Prometheus plugin, but it was allowed", tc.method, tc.path)
+		}
+	}
+
+	victoriaLogs := allowedEndpointsForPlugin(pluginKindVictoriaLogs)
+	if !endpointAllowed(victoriaLogs, http.MethodPost, "/select/logsql/query") {
+		t.Error("expected POST /select/logsql/query to be allowed for the VictoriaLogs plugin, but it was rejected")
+	}
+	if endpointAllowed(victoriaLogs, http.MethodPost, "/select/logsql/query/../../admin") {
+		t.Error("expected POST /select/logsql/query/../../admin to be rejected for the VictoriaLogs plugin, but it was allowed")
+	}
+}

--- a/pkg/component/observability/monitoring/perses/component.go
+++ b/pkg/component/observability/monitoring/perses/component.go
@@ -109,6 +109,7 @@ func (p *perses) Deploy(ctx context.Context) error {
 		)
 	}
 	objs = append(objs, p.datasources()...)
+	objs = append(objs, p.dashboards()...)
 
 	resources, err := registry.AddAllAndSerialize(objs...)
 	if err != nil {

--- a/pkg/component/observability/monitoring/perses/component.go
+++ b/pkg/component/observability/monitoring/perses/component.go
@@ -106,16 +106,19 @@ func (p *perses) Deploy(ctx context.Context) error {
 
 	var objs []client.Object
 	if !p.values.OnlyDeployDatasourcesAndDashboards {
-		objs = append(objs,
-			p.perses(),
-			p.serviceMonitor(),
-		)
+		objs = append(objs, p.perses())
 
 		istioResources, err := p.istioResources(ctx)
 		if err != nil {
 			return err
 		}
 		objs = append(objs, istioResources...)
+
+		if vpa := p.vpa(); vpa != nil {
+			objs = append(objs, vpa)
+		}
+
+		objs = append(objs, p.serviceMonitor())
 	}
 	objs = append(objs, p.datasources()...)
 	objs = append(objs, p.dashboards()...)

--- a/pkg/component/observability/monitoring/perses/component.go
+++ b/pkg/component/observability/monitoring/perses/component.go
@@ -101,10 +101,14 @@ type perses struct {
 func (p *perses) Deploy(ctx context.Context) error {
 	registry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 
-	objs := []client.Object{
-		p.perses(),
-		p.serviceMonitor(),
+	var objs []client.Object
+	if !p.values.OnlyDeployDatasourcesAndDashboards {
+		objs = append(objs,
+			p.perses(),
+			p.serviceMonitor(),
+		)
 	}
+	objs = append(objs, p.datasources()...)
 
 	resources, err := registry.AddAllAndSerialize(objs...)
 	if err != nil {

--- a/pkg/component/observability/monitoring/perses/component.go
+++ b/pkg/component/observability/monitoring/perses/component.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package perses
+
+import (
+	"context"
+	"time"
+
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+const (
+	managedResourceNamePrefix = "perses"
+)
+
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
+// or deleted.
+var TimeoutWaitForManagedResource = 2 * time.Minute
+
+// Interface contains functions for a Perses deployer.
+type Interface interface {
+	component.DeployWaiter
+}
+
+// Values contains configuration values for the Perses resources.
+type Values struct {
+	// Image is the container image used for Perses.
+	Image string
+	// ClusterType is the type of the cluster.
+	ClusterType component.ClusterType
+	// Replicas is the number of replicas.
+	Replicas int32
+	// VPAEnabled states whether VerticalPodAutoscaler is enabled.
+	VPAEnabled bool
+	// IsGardenCluster specifies whether the cluster is a garden cluster.
+	IsGardenCluster bool
+	// ExternalExposure contains configuration for exposing this Perses instance via a VirtualService resource.
+	ExternalExposure *ExposureValues
+	// VictoriaLogsEnabled indicates whether VictoriaLogs is enabled as the logging backend.
+	VictoriaLogsEnabled bool
+	// OnlyDeployDatasourcesAndDashboards only leads to deployment of the PersesDatasource and PersesDashboard CRs.
+	// This is relevant when the Perses instance is already deployed by another component (e.g., gardener-operator),
+	// and the gardenlet wants to contribute seed-specific configuration.
+	OnlyDeployDatasourcesAndDashboards bool
+	// Dashboards is a map of PersesDashboard CRs to deploy, keyed by name.
+	Dashboards map[string]persesv1alpha2.Dashboard
+}
+
+// ExposureValues contains configuration for exposing this Perses instance via a VirtualService resource.
+type ExposureValues struct {
+	// AuthSecretName is the name of the auth secret.
+	AuthSecretName string
+	// Host is the hostname under which the Perses instance should be exposed.
+	Host string
+	// IsGardenCluster specifies whether the cluster is the garden cluster.
+	IsGardenCluster bool
+	// IstioIngressGatewayLabels are the labels identifying the corresponding istio ingress gateway.
+	IstioIngressGatewayLabels map[string]string
+	// IstioIngressGatewayNamespace is the namespace of the corresponding istio ingress gateway. The Gateway,
+	// VirtualService and DestinationRule are exported to this namespace only, and the TLS certificate is copied there.
+	IstioIngressGatewayNamespace string
+	// SecretsManager is the secrets manager used for generating the TLS certificate if no wildcard certificate is
+	// provided.
+	SecretsManager secretsmanager.Interface
+	// SigningCA is the name of the CA that should be used to sign a self-signed server certificate. Only needed when
+	// no wildcard certificate secret is provided.
+	SigningCA string
+	// WildcardCertSecretName is name of a secret containing the wildcard TLS certificate which is issued for the
+	// ingress domain. If not provided, a self-signed server certificate will be created.
+	WildcardCertSecretName *string
+}
+
+// New creates a new instance of Interface for Perses.
+func New(
+	client client.Client,
+	namespace string,
+	values Values,
+) Interface {
+	return &perses{
+		client:    client,
+		namespace: namespace,
+		values:    values,
+	}
+}
+
+type perses struct {
+	client    client.Client
+	namespace string
+	values    Values
+}
+
+func (p *perses) Deploy(ctx context.Context) error {
+	registry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
+
+	objs := []client.Object{
+		p.perses(),
+		p.serviceMonitor(),
+	}
+
+	resources, err := registry.AddAllAndSerialize(objs...)
+	if err != nil {
+		return err
+	}
+
+	return managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, p.managedResourceName(), false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, resources)
+}
+
+func (p *perses) Destroy(ctx context.Context) error {
+	return managedresources.DeleteForSeed(ctx, p.client, p.namespace, p.managedResourceName())
+}
+
+func (p *perses) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilHealthy(timeoutCtx, p.client, p.namespace, p.managedResourceName())
+}
+
+func (p *perses) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilDeleted(timeoutCtx, p.client, p.namespace, p.managedResourceName())
+}
+
+func (p *perses) managedResourceName() string {
+	if p.values.OnlyDeployDatasourcesAndDashboards {
+		return managedResourceNamePrefix + "-seed-config-only"
+	}
+	return managedResourceNamePrefix
+}

--- a/pkg/component/observability/monitoring/perses/component.go
+++ b/pkg/component/observability/monitoring/perses/component.go
@@ -59,6 +59,9 @@ type Values struct {
 type ExposureValues struct {
 	// AuthSecretName is the name of the auth secret.
 	AuthSecretName string
+	// AuthSecretManaged indicates whether the auth secret is managed by the secrets manager (referenced by its base
+	// name) or used verbatim.
+	AuthSecretManaged bool
 	// Host is the hostname under which the Perses instance should be exposed.
 	Host string
 	// IsGardenCluster specifies whether the cluster is the garden cluster.
@@ -107,6 +110,12 @@ func (p *perses) Deploy(ctx context.Context) error {
 			p.perses(),
 			p.serviceMonitor(),
 		)
+
+		istioResources, err := p.istioResources(ctx)
+		if err != nil {
+			return err
+		}
+		objs = append(objs, istioResources...)
 	}
 	objs = append(objs, p.datasources()...)
 	objs = append(objs, p.dashboards()...)

--- a/pkg/component/observability/monitoring/perses/dashboards.go
+++ b/pkg/component/observability/monitoring/perses/dashboards.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package perses
+
+import (
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (p *perses) dashboards() []client.Object {
+	var objs []client.Object
+
+	for name, config := range p.values.Dashboards {
+		objs = append(objs, &persesv1alpha2.PersesDashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: p.namespace,
+				Labels:    p.getLabels(),
+			},
+			Spec: persesv1alpha2.PersesDashboardSpec{
+				Config:           config,
+				InstanceSelector: p.instanceSelector(),
+			},
+		})
+	}
+
+	return objs
+}

--- a/pkg/component/observability/monitoring/perses/datasources.go
+++ b/pkg/component/observability/monitoring/perses/datasources.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package perses
+
+import (
+	"fmt"
+
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
+	persescommon "github.com/perses/spec/go/common"
+	"github.com/perses/spec/go/datasource"
+	persesplugin "github.com/perses/spec/go/plugin"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/component"
+	victorialogsconstants "github.com/gardener/gardener/pkg/component/observability/logging/victorialogs/constants"
+)
+
+func (p *perses) datasources() []client.Object {
+	var datasources []client.Object
+
+	if p.values.IsGardenCluster {
+		datasources = append(datasources,
+			p.newDatasource("prometheus-garden", "PrometheusDatasource", "http://prometheus-garden:80", true),
+			p.newDatasource("prometheus-longterm", "PrometheusDatasource", "http://prometheus-longterm:81", false),
+		)
+	} else if p.values.ClusterType == component.ClusterTypeSeed {
+		datasources = append(datasources,
+			p.newDatasource("prometheus-aggregate", "PrometheusDatasource", "http://prometheus-aggregate:80", !p.values.OnlyDeployDatasourcesAndDashboards),
+			p.newDatasource("prometheus-seed", "PrometheusDatasource", "http://prometheus-seed:80", false),
+		)
+	}
+
+	if p.values.VictoriaLogsEnabled && !p.values.OnlyDeployDatasourcesAndDashboards {
+		datasources = append(datasources,
+			p.newDatasource("victorialogs", "VictoriaLogsDatasource", fmt.Sprintf("http://%s.%s.svc:%d", victorialogsconstants.ServiceName, p.namespace, victorialogsconstants.VictoriaLogsPort), false),
+		)
+	}
+
+	return datasources
+}
+
+// newDatasource returns a project-scoped PersesDatasource. The perses-operator maps the resource's namespace to a
+// Perses project of the same name, so the datasource is explorable within that project.
+func (p *perses) newDatasource(dsName, pluginKind, url string, isDefault bool) *persesv1alpha2.PersesDatasource {
+	return &persesv1alpha2.PersesDatasource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsName,
+			Namespace: p.namespace,
+			Labels:    p.getLabels(),
+		},
+		Spec: persesv1alpha2.DatasourceSpec{
+			Config: persesv1alpha2.Datasource{
+				Spec: datasource.Spec{
+					Display: &persescommon.Display{
+						Name: dsName,
+					},
+					Default: isDefault,
+					Plugin: persesplugin.Plugin{
+						Kind: pluginKind,
+						Spec: map[string]any{
+							"proxy": map[string]any{
+								"kind": "HTTPProxy",
+								"spec": map[string]any{
+									"url": url,
+								},
+							},
+						},
+					},
+				},
+			},
+			InstanceSelector: p.instanceSelector(),
+		},
+	}
+}

--- a/pkg/component/observability/monitoring/perses/datasources.go
+++ b/pkg/component/observability/monitoring/perses/datasources.go
@@ -6,6 +6,7 @@ package perses
 
 import (
 	"fmt"
+	"net/http"
 
 	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
 	persescommon "github.com/perses/spec/go/common"
@@ -18,24 +19,29 @@ import (
 	victorialogsconstants "github.com/gardener/gardener/pkg/component/observability/logging/victorialogs/constants"
 )
 
+const (
+	pluginKindPrometheus   = "PrometheusDatasource"
+	pluginKindVictoriaLogs = "VictoriaLogsDatasource"
+)
+
 func (p *perses) datasources() []client.Object {
 	var datasources []client.Object
 
 	if p.values.IsGardenCluster {
 		datasources = append(datasources,
-			p.newDatasource("prometheus-garden", "PrometheusDatasource", "http://prometheus-garden:80", true),
-			p.newDatasource("prometheus-longterm", "PrometheusDatasource", "http://prometheus-longterm:81", false),
+			p.newDatasource("prometheus-garden", pluginKindPrometheus, "http://prometheus-garden:80", true),
+			p.newDatasource("prometheus-longterm", pluginKindPrometheus, "http://prometheus-longterm:81", false),
 		)
 	} else if p.values.ClusterType == component.ClusterTypeSeed {
 		datasources = append(datasources,
-			p.newDatasource("prometheus-aggregate", "PrometheusDatasource", "http://prometheus-aggregate:80", !p.values.OnlyDeployDatasourcesAndDashboards),
-			p.newDatasource("prometheus-seed", "PrometheusDatasource", "http://prometheus-seed:80", false),
+			p.newDatasource("prometheus-aggregate", pluginKindPrometheus, "http://prometheus-aggregate:80", !p.values.OnlyDeployDatasourcesAndDashboards),
+			p.newDatasource("prometheus-seed", pluginKindPrometheus, "http://prometheus-seed:80", false),
 		)
 	}
 
 	if p.values.VictoriaLogsEnabled && !p.values.OnlyDeployDatasourcesAndDashboards {
 		datasources = append(datasources,
-			p.newDatasource("victorialogs", "VictoriaLogsDatasource", fmt.Sprintf("http://%s.%s.svc:%d", victorialogsconstants.ServiceName, p.namespace, victorialogsconstants.VictoriaLogsPort), false),
+			p.newDatasource("victorialogs", pluginKindVictoriaLogs, fmt.Sprintf("http://%s.%s.svc:%d", victorialogsconstants.ServiceName, p.namespace, victorialogsconstants.VictoriaLogsPort), false),
 		)
 	}
 
@@ -65,6 +71,13 @@ func (p *perses) newDatasource(dsName, pluginKind, url string, isDefault bool) *
 								"kind": "HTTPProxy",
 								"spec": map[string]any{
 									"url": url,
+									// Restrict what can be proxied to the datasource. The Perses proxy forwards any
+									// request under the datasource path (with any method, and attaching the
+									// datasource's stored credentials) to the upstream. Without an allow-list, a user
+									// reaching the un-authenticated Perses API could use the proxy to send writes
+									// (e.g. Prometheus remote-write) or reach other upstream endpoints. The allow-list
+									// is limited to the read-only query endpoints the corresponding Perses plugin uses.
+									"allowedEndpoints": allowedEndpointsForPlugin(pluginKind),
 								},
 							},
 						},
@@ -74,4 +87,54 @@ func (p *perses) newDatasource(dsName, pluginKind, url string, isDefault bool) *
 			InstanceSelector: p.instanceSelector(),
 		},
 	}
+}
+
+// allowedEndpointsForPlugin returns the read-only upstream endpoints the given datasource plugin needs to be able to
+// proxy to. Each entry pairs an endpoint pattern (regular expression) with a single HTTP method, so endpoints served
+// via both GET and POST are listed twice.
+func allowedEndpointsForPlugin(pluginKind string) []map[string]any {
+	endpoint := func(pattern string, methods ...string) []map[string]any {
+		// Anchor the pattern. Perses matches the request path against the pattern with an unanchored substring
+		// search (regexp.FindAllString), so an unanchored pattern like "/api/v1/query" would also permit paths that
+		// merely contain it, e.g. "/api/v1/query/../admin". Anchoring restricts the allow-list to exactly the
+		// intended read endpoints.
+		anchored := "^" + pattern + "$"
+		entries := make([]map[string]any, 0, len(methods))
+		for _, method := range methods {
+			entries = append(entries, map[string]any{"endpointPattern": anchored, "method": method})
+		}
+		return entries
+	}
+
+	switch pluginKind {
+	case pluginKindPrometheus:
+		var endpoints []map[string]any
+		// The Prometheus plugin queries via GET and POST (POST is used for large requests).
+		for _, pattern := range []string{
+			"/api/v1/query",
+			"/api/v1/query_range",
+			"/api/v1/labels",
+			"/api/v1/label/[a-zA-Z0-9_]+/values",
+			"/api/v1/series",
+			"/api/v1/metadata",
+			"/api/v1/parse_query",
+		} {
+			endpoints = append(endpoints, endpoint(pattern, http.MethodGet, http.MethodPost)...)
+		}
+		return endpoints
+	case pluginKindVictoriaLogs:
+		var endpoints []map[string]any
+		// The VictoriaLogs plugin queries exclusively via POST.
+		for _, pattern := range []string{
+			"/select/logsql/query",
+			"/select/logsql/stats_query_range",
+			"/select/logsql/field_names",
+			"/select/logsql/field_values",
+		} {
+			endpoints = append(endpoints, endpoint(pattern, http.MethodPost)...)
+		}
+		return endpoints
+	}
+
+	return nil
 }

--- a/pkg/component/observability/monitoring/perses/istio_resources.go
+++ b/pkg/component/observability/monitoring/perses/istio_resources.go
@@ -7,7 +7,10 @@ package perses
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 
+	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,6 +101,53 @@ func (p *perses) istioResources(ctx context.Context) ([]client.Object, error) {
 	)(); err != nil {
 		return nil, fmt.Errorf("failed to create virtual service resource: %w", err)
 	}
+
+	// Perses runs without its own authentication (spec.config.security.enable_auth is false) so that the
+	// perses-operator can reconcile datasources and dashboards anonymously via the in-cluster Service. Since the
+	// instance is also exposed to users through the ingress, the privileged parts of its API must be blocked at the
+	// edge to prevent them from being exploited:
+	//   - Write verbs on /api/v1/ mutate datasources, dashboards, roles and users. Blocking them prevents privilege
+	//     escalation while leaving read access and the datasource proxy (used for querying) intact.
+	//   - The /proxy/unsaved/ endpoints proxy to an arbitrary, caller-supplied datasource spec, which would allow
+	//     reaching backends the network policy does not intend to expose. The frontend never uses them; the saved
+	//     datasource proxy (bounded to provisioned datasources) remains available for querying.
+	//   - The /debug/ endpoints (Go pprof) expose profiling data and are never needed through the ingress. They are
+	//     only served when Perses is started with -pprof, but are blocked unconditionally as a safeguard.
+	// These restrictions only apply to ingress traffic; the operator's in-cluster access to the Service is unaffected.
+	virtualService.Spec.Http = append([]*istioapinetworkingv1beta1.HTTPRoute{
+		{
+			Name: "block-debug",
+			Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{{
+				Uri: &istioapinetworkingv1beta1.StringMatch{
+					MatchType: &istioapinetworkingv1beta1.StringMatch_Prefix{Prefix: "/debug/"},
+				},
+			}},
+			DirectResponse: &istioapinetworkingv1beta1.HTTPDirectResponse{Status: 403},
+		},
+		{
+			Name: "block-unsaved-proxy",
+			Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{{
+				Uri: &istioapinetworkingv1beta1.StringMatch{
+					MatchType: &istioapinetworkingv1beta1.StringMatch_Prefix{Prefix: "/proxy/unsaved"},
+				},
+			}},
+			DirectResponse: &istioapinetworkingv1beta1.HTTPDirectResponse{Status: 403},
+		},
+		{
+			Name: "block-api-writes",
+			Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{{
+				Uri: &istioapinetworkingv1beta1.StringMatch{
+					MatchType: &istioapinetworkingv1beta1.StringMatch_Prefix{Prefix: "/api/v1/"},
+				},
+				Method: &istioapinetworkingv1beta1.StringMatch{
+					MatchType: &istioapinetworkingv1beta1.StringMatch_Regex{
+						Regex: strings.Join([]string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}, "|"),
+					},
+				},
+			}},
+			DirectResponse: &istioapinetworkingv1beta1.HTTPDirectResponse{Status: 403},
+		},
+	}, virtualService.Spec.Http...)
 
 	destinationRule := &istionetworkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: p.namespace}}
 	if err := istio.DestinationRuleWithLocalityPreference(destinationRule, p.getLabels(), []string{ingressNamespace}, destinationHost)(); err != nil {

--- a/pkg/component/observability/monitoring/perses/istio_resources.go
+++ b/pkg/component/observability/monitoring/perses/istio_resources.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package perses
+
+import (
+	"context"
+	"fmt"
+
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/component/networking/istiobasicauthserver"
+	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/istio"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+const persesContainerPort uint32 = 8080
+
+func (p *perses) istioResources(ctx context.Context) ([]client.Object, error) {
+	if p.values.ExternalExposure == nil {
+		return nil, nil
+	}
+
+	var (
+		ingressNamespace = p.values.ExternalExposure.IstioIngressGatewayNamespace
+		gatewayName      = p.persesName()
+	)
+
+	tlsSecretName := ptr.Deref(p.values.ExternalExposure.WildcardCertSecretName, "")
+	if tlsSecretName == "" && p.values.ExternalExposure.SecretsManager != nil {
+		ingressTLSSecret, err := p.values.ExternalExposure.SecretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
+			Name:                        p.persesName() + "-tls",
+			CommonName:                  p.persesName(),
+			Organization:                []string{"gardener.cloud:monitoring:ingress"},
+			DNSNames:                    []string{p.values.ExternalExposure.Host},
+			CertType:                    secretsutils.ServerCert,
+			Validity:                    new(v1beta1constants.IngressTLSCertificateValidity),
+			SkipPublishingCACertificate: true,
+		}, secretsmanager.SignedByCA(p.values.ExternalExposure.SigningCA))
+		if err != nil {
+			return nil, err
+		}
+		tlsSecretName = ingressTLSSecret.Name
+	}
+
+	// Istio expects the secret in the istio ingress gateway namespace => copy certificate to istio namespace
+	tlsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tlsSecretName,
+			Namespace: p.namespace,
+		},
+	}
+	if err := p.client.Get(ctx, client.ObjectKeyFromObject(tlsSecret), tlsSecret); err != nil {
+		return nil, fmt.Errorf("failed to get TLS secret %q: %w", tlsSecretName, err)
+	}
+
+	tlsSecretInIstioNamespace := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-%s", p.namespace, p.persesName(), tlsSecretName),
+			Namespace: ingressNamespace,
+			Labels:    p.getLabels(),
+		},
+		Data: tlsSecret.Data,
+	}
+
+	gateway := &istionetworkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: p.namespace}}
+	if err := istio.GatewayWithTLSTermination(
+		gateway,
+		p.getLabels(),
+		p.values.ExternalExposure.IstioIngressGatewayLabels,
+		[]string{p.values.ExternalExposure.Host},
+		tlsSecretInIstioNamespace.Name,
+	)(); err != nil {
+		return nil, fmt.Errorf("failed to create gateway resource: %w", err)
+	}
+
+	destinationHost := kubernetesutils.FQDNForService(p.persesName(), p.namespace)
+	virtualService := &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: p.namespace}}
+	if err := istio.VirtualServiceForTLSTermination(
+		virtualService,
+		utils.MergeStringMaps(p.getLabels(), istiobasicauthserver.BasicAuthLabels(p.values.ExternalExposure.IsGardenCluster, p.values.ExternalExposure.AuthSecretName, p.values.ExternalExposure.AuthSecretManaged)),
+		[]string{ingressNamespace},
+		[]string{p.values.ExternalExposure.Host},
+		gatewayName,
+		persesContainerPort,
+		destinationHost,
+		"",
+		"",
+	)(); err != nil {
+		return nil, fmt.Errorf("failed to create virtual service resource: %w", err)
+	}
+
+	destinationRule := &istionetworkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: p.namespace}}
+	if err := istio.DestinationRuleWithLocalityPreference(destinationRule, p.getLabels(), []string{ingressNamespace}, destinationHost)(); err != nil {
+		return nil, fmt.Errorf("failed to create destination rule resource: %w", err)
+	}
+
+	return []client.Object{tlsSecretInIstioNamespace, gateway, virtualService, destinationRule}, nil
+}

--- a/pkg/component/observability/monitoring/perses/perses.go
+++ b/pkg/component/observability/monitoring/perses/perses.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package perses
+
+import (
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
+	persesconfig "github.com/perses/perses/pkg/model/api/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/component"
+	victorialogsconstants "github.com/gardener/gardener/pkg/component/observability/logging/victorialogs/constants"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+const (
+	labelApp = "perses"
+)
+
+func (p *perses) persesName() string {
+	if p.values.IsGardenCluster {
+		return "perses-garden"
+	}
+	return "perses-seed"
+}
+
+func (p *perses) perses() *persesv1alpha2.Perses {
+	labels := p.getLabels()
+	labels["app.kubernetes.io/instance"] = p.persesName()
+
+	scrapeTargetAnnotationKey := resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationPrefix +
+		v1beta1constants.LabelNetworkPolicySeedScrapeTargets +
+		resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationSuffix
+	serviceAnnotations := map[string]string{
+		scrapeTargetAnnotationKey: `[{"protocol":"TCP","port":8080}]`,
+	}
+	if p.values.IsGardenCluster {
+		gardenScrapeKey := resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationPrefix +
+			v1beta1constants.LabelNetworkPolicyGardenScrapeTargets +
+			resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationSuffix
+		serviceAnnotations[gardenScrapeKey] = `[{"protocol":"TCP","port":8080}]`
+	}
+
+	obj := &persesv1alpha2.Perses{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.persesName(),
+			Namespace: p.namespace,
+			Labels:    labels,
+		},
+		Spec: persesv1alpha2.PersesSpec{
+			Metadata: &persesv1alpha2.Metadata{
+				Labels: p.getPodLabels(),
+			},
+			Service: &persesv1alpha2.PersesService{
+				Annotations: serviceAnnotations,
+			},
+			Config: persesv1alpha2.PersesConfig{
+				Config: persesconfig.Config{
+					Security: persesconfig.Security{
+						Readonly:   false,
+						EnableAuth: false,
+					},
+					Database: persesconfig.Database{
+						File: &persesconfig.File{
+							Folder: "/perses",
+						},
+					},
+					Frontend: persesconfig.Frontend{
+						Explorer: persesconfig.Explorer{
+							Enable: true,
+						},
+					},
+				},
+			},
+			Replicas:      &p.values.Replicas,
+			Image:         &p.values.Image,
+			ContainerPort: new(int32(8080)),
+			Resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			Storage: &persesv1alpha2.StorageConfiguration{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+
+	return obj
+}
+
+func (p *perses) getLabels() map[string]string {
+	return map[string]string{
+		v1beta1constants.LabelApp:  labelApp,
+		v1beta1constants.LabelRole: v1beta1constants.LabelMonitoring,
+	}
+}
+
+func (p *perses) getPodLabels() map[string]string {
+	labels := map[string]string{
+		v1beta1constants.LabelObservabilityApplication:        labelApp,
+		v1beta1constants.LabelRole:                            v1beta1constants.LabelMonitoring,
+		v1beta1constants.LabelNetworkPolicyToDNS:              v1beta1constants.LabelNetworkPolicyAllowed,
+		v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
+	}
+
+	if p.values.VictoriaLogsEnabled {
+		labels[gardenerutils.NetworkPolicyLabel(victorialogsconstants.ServiceName, victorialogsconstants.VictoriaLogsPort)] = v1beta1constants.LabelNetworkPolicyAllowed
+	}
+
+	seedSpecificLabels := map[string]string{
+		gardenerutils.NetworkPolicyLabel("prometheus-aggregate", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
+		gardenerutils.NetworkPolicyLabel("prometheus-seed", 9090):      v1beta1constants.LabelNetworkPolicyAllowed,
+	}
+
+	if p.values.IsGardenCluster {
+		labels[gardenerutils.NetworkPolicyLabel("prometheus-garden", 9090)] = v1beta1constants.LabelNetworkPolicyAllowed
+		labels[gardenerutils.NetworkPolicyLabel("prometheus-longterm", 9091)] = v1beta1constants.LabelNetworkPolicyAllowed
+		// If the garden is also a seed, allow access to seed-specific Prometheus instances.
+		for k, v := range seedSpecificLabels {
+			labels[k] = v
+		}
+		return labels
+	}
+
+	if p.values.ClusterType == component.ClusterTypeSeed {
+		for k, v := range seedSpecificLabels {
+			labels[k] = v
+		}
+	}
+
+	return labels
+}

--- a/pkg/component/observability/monitoring/perses/perses.go
+++ b/pkg/component/observability/monitoring/perses/perses.go
@@ -137,3 +137,20 @@ func (p *perses) getPodLabels() map[string]string {
 
 	return labels
 }
+
+func (p *perses) instanceSelector() *metav1.LabelSelector {
+	instanceName := p.persesName()
+	// In OnlyDeployDatasourcesAndDashboards mode (seed-is-garden), datasources must target the garden
+	// Perses instance since no separate seed instance is deployed.
+	if p.values.OnlyDeployDatasourcesAndDashboards {
+		instanceName = "perses-garden"
+	}
+
+	return &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "app.kubernetes.io/instance",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{instanceName},
+		}},
+	}
+}

--- a/pkg/component/observability/monitoring/perses/perses.go
+++ b/pkg/component/observability/monitoring/perses/perses.go
@@ -7,6 +7,7 @@ package perses
 import (
 	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
 	persesconfig "github.com/perses/perses/pkg/model/api/config"
+	istioapiannotation "istio.io/api/annotation"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,19 +34,6 @@ func (p *perses) perses() *persesv1alpha2.Perses {
 	labels := p.getLabels()
 	labels["app.kubernetes.io/instance"] = p.persesName()
 
-	scrapeTargetAnnotationKey := resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationPrefix +
-		v1beta1constants.LabelNetworkPolicySeedScrapeTargets +
-		resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationSuffix
-	serviceAnnotations := map[string]string{
-		scrapeTargetAnnotationKey: `[{"protocol":"TCP","port":8080}]`,
-	}
-	if p.values.IsGardenCluster {
-		gardenScrapeKey := resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationPrefix +
-			v1beta1constants.LabelNetworkPolicyGardenScrapeTargets +
-			resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationSuffix
-		serviceAnnotations[gardenScrapeKey] = `[{"protocol":"TCP","port":8080}]`
-	}
-
 	obj := &persesv1alpha2.Perses{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.persesName(),
@@ -57,7 +45,7 @@ func (p *perses) perses() *persesv1alpha2.Perses {
 				Labels: p.getPodLabels(),
 			},
 			Service: &persesv1alpha2.PersesService{
-				Annotations: serviceAnnotations,
+				Annotations: p.getServiceAnnotations(),
 			},
 			Config: persesv1alpha2.PersesConfig{
 				Config: persesconfig.Config{
@@ -93,6 +81,28 @@ func (p *perses) perses() *persesv1alpha2.Perses {
 	}
 
 	return obj
+}
+
+func (p *perses) getServiceAnnotations() map[string]string {
+	scrapeTargetAnnotationKey := resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationPrefix +
+		v1beta1constants.LabelNetworkPolicySeedScrapeTargets +
+		resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationSuffix
+	annotations := map[string]string{
+		scrapeTargetAnnotationKey: `[{"protocol":"TCP","port":8080}]`,
+	}
+	// Export the Service only to the istio ingress gateway namespace where it is consumed. When the instance is not
+	// externally exposed there is no consumer, so no export annotation is set.
+	if p.values.ExternalExposure != nil {
+		annotations[istioapiannotation.NetworkingExportTo.Name] = p.values.ExternalExposure.IstioIngressGatewayNamespace
+	}
+	if p.values.IsGardenCluster {
+		gardenScrapeKey := resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationPrefix +
+			v1beta1constants.LabelNetworkPolicyGardenScrapeTargets +
+			resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationSuffix
+		annotations[gardenScrapeKey] = `[{"protocol":"TCP","port":8080}]`
+	}
+
+	return annotations
 }
 
 func (p *perses) getLabels() map[string]string {

--- a/pkg/component/observability/monitoring/perses/perses_suite_test.go
+++ b/pkg/component/observability/monitoring/perses/perses_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package perses_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPerses(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component Observability Monitoring Perses Suite")
+}

--- a/pkg/component/observability/monitoring/perses/perses_test.go
+++ b/pkg/component/observability/monitoring/perses/perses_test.go
@@ -366,6 +366,36 @@ var _ = Describe("Perses", func() {
 							Hosts:    []string{"perses-seed.example.com"},
 							Http: []*istionetworkingv1alpha3.HTTPRoute{
 								{
+									Name: "block-debug",
+									Match: []*istionetworkingv1alpha3.HTTPMatchRequest{{
+										Uri: &istionetworkingv1alpha3.StringMatch{
+											MatchType: &istionetworkingv1alpha3.StringMatch_Prefix{Prefix: "/debug/"},
+										},
+									}},
+									DirectResponse: &istionetworkingv1alpha3.HTTPDirectResponse{Status: 403},
+								},
+								{
+									Name: "block-unsaved-proxy",
+									Match: []*istionetworkingv1alpha3.HTTPMatchRequest{{
+										Uri: &istionetworkingv1alpha3.StringMatch{
+											MatchType: &istionetworkingv1alpha3.StringMatch_Prefix{Prefix: "/proxy/unsaved"},
+										},
+									}},
+									DirectResponse: &istionetworkingv1alpha3.HTTPDirectResponse{Status: 403},
+								},
+								{
+									Name: "block-api-writes",
+									Match: []*istionetworkingv1alpha3.HTTPMatchRequest{{
+										Uri: &istionetworkingv1alpha3.StringMatch{
+											MatchType: &istionetworkingv1alpha3.StringMatch_Prefix{Prefix: "/api/v1/"},
+										},
+										Method: &istionetworkingv1alpha3.StringMatch{
+											MatchType: &istionetworkingv1alpha3.StringMatch_Regex{Regex: "POST|PUT|PATCH|DELETE"},
+										},
+									}},
+									DirectResponse: &istionetworkingv1alpha3.HTTPDirectResponse{Status: 403},
+								},
+								{
 									Route: []*istionetworkingv1alpha3.HTTPRouteDestination{{
 										Destination: &istionetworkingv1alpha3.Destination{
 											Host: "perses-seed." + namespace + ".svc.cluster.local",

--- a/pkg/component/observability/monitoring/perses/perses_test.go
+++ b/pkg/component/observability/monitoring/perses/perses_test.go
@@ -20,11 +20,13 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	istionetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -418,6 +420,56 @@ var _ = Describe("Perses", func() {
 						gateway,
 						virtualService,
 						destinationRule,
+						seedServiceMonitor,
+					))
+				})
+			})
+
+			Context("seed cluster with VPA enabled", func() {
+				BeforeEach(func() {
+					values.VPAEnabled = true
+				})
+
+				It("should include VPA resource", func() {
+					Expect(managedResource).To(consistOf(
+						persesCR,
+						dsAggregate,
+						dsSeed,
+						&vpaautoscalingv1.VerticalPodAutoscaler{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "perses-seed",
+								Namespace: namespace,
+								Labels: map[string]string{
+									"app":  "perses",
+									"role": "monitoring",
+								},
+							},
+							Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
+								TargetRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "apps/v1",
+									Kind:       "Deployment",
+									Name:       "perses-seed",
+								},
+								UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
+									UpdateMode: new(vpaautoscalingv1.UpdateModeAuto),
+								},
+								ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+									ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+										{
+											ContainerName: "perses",
+											MinAllowed: corev1.ResourceList{
+												corev1.ResourceMemory: resource.MustParse("32Mi"),
+											},
+											ControlledValues: new(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+										},
+										{
+											ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+											Mode:          new(vpaautoscalingv1.ContainerScalingModeOff),
+										},
+									},
+								},
+							},
+						},
 						seedServiceMonitor,
 					))
 				})

--- a/pkg/component/observability/monitoring/perses/perses_test.go
+++ b/pkg/component/observability/monitoring/perses/perses_test.go
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package perses_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
+	persesconfig "github.com/perses/perses/pkg/model/api/config"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	. "github.com/gardener/gardener/pkg/component/observability/monitoring/perses"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("Perses", func() {
+	var (
+		ctx context.Context
+
+		managedResourceName = "perses"
+		namespace           = "some-namespace"
+
+		image = "perses-image:latest"
+
+		fakeClient client.Client
+		deployer   Interface
+		values     Values
+
+		fakeOps   *retryfake.Ops
+		consistOf func(...client.Object) gomegatypes.GomegaMatcher
+
+		managedResource       *resourcesv1alpha1.ManagedResource
+		managedResourceSecret *corev1.Secret
+
+		persesCR           *persesv1alpha2.Perses
+		seedServiceMonitor *monitoringv1.ServiceMonitor
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		managedResourceName = "perses"
+
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+		values = Values{
+			Image:       image,
+			ClusterType: component.ClusterTypeSeed,
+			Replicas:    1,
+		}
+
+		fakeOps = &retryfake.Ops{MaxAttempts: 2}
+		DeferCleanup(test.WithVars(
+			&retry.Until, fakeOps.Until,
+			&retry.UntilTimeout, fakeOps.UntilTimeout,
+		))
+
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(fakeClient)
+
+		managedResource = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResourceName,
+				Namespace: namespace,
+			},
+		}
+		managedResourceSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "managedresource-" + managedResource.Name,
+				Namespace: namespace,
+			},
+		}
+
+		persesCR = &persesv1alpha2.Perses{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "perses-seed",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app":                        "perses",
+					"role":                       "monitoring",
+					"app.kubernetes.io/instance": "perses-seed",
+				},
+			},
+			Spec: persesv1alpha2.PersesSpec{
+				Metadata: &persesv1alpha2.Metadata{
+					Labels: map[string]string{
+						v1beta1constants.LabelObservabilityApplication:                 "perses",
+						v1beta1constants.LabelNetworkPolicyToDNS:                       v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:          v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelRole:                                     v1beta1constants.LabelMonitoring,
+						gardenerutils.NetworkPolicyLabel("prometheus-aggregate", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel("prometheus-seed", 9090):      v1beta1constants.LabelNetworkPolicyAllowed,
+					},
+				},
+				Config: persesv1alpha2.PersesConfig{
+					Config: persesconfig.Config{
+						Security: persesconfig.Security{
+							Readonly:   false,
+							EnableAuth: false,
+						},
+						Database: persesconfig.Database{
+							File: &persesconfig.File{
+								Folder: "/perses",
+							},
+						},
+						Frontend: persesconfig.Frontend{
+							Explorer: persesconfig.Explorer{
+								Enable: true,
+							},
+						},
+					},
+				},
+				Replicas:      new(int32(1)),
+				Image:         new(image),
+				ContainerPort: new(int32(8080)),
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				Service: &persesv1alpha2.PersesService{
+					Annotations: map[string]string{
+						"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8080}]`,
+					},
+				},
+				Storage: &persesv1alpha2.StorageConfiguration{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		}
+
+		seedServiceMonitor = &monitoringv1.ServiceMonitor{
+			ObjectMeta: monitoringutils.ConfigObjectMeta("perses", namespace, "seed"),
+			Spec: monitoringv1.ServiceMonitorSpec{
+				Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+					"app.kubernetes.io/instance": "perses-seed",
+				}},
+				Endpoints: []monitoringv1.Endpoint{{
+					TargetPort: new(intstr.FromInt32(8080)),
+				}},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		deployer = New(fakeClient, namespace, values)
+	})
+
+	Describe("#Deploy", func() {
+		Context("resources generation", func() {
+			BeforeEach(func() {
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: healthyManagedResourceStatus,
+				})).To(Succeed())
+			})
+
+			JustBeforeEach(func() {
+				Expect(deployer.Deploy(ctx)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+				expectedMr := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            managedResource.Name,
+						Namespace:       managedResource.Namespace,
+						ResourceVersion: "2",
+						Generation:      1,
+						Labels: map[string]string{
+							"gardener.cloud/role":                "seed-system-component",
+							"care.gardener.cloud/condition-type": "ObservabilityComponentsHealthy",
+						},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						Class:       new("seed"),
+						SecretRefs:  []corev1.LocalObjectReference{{Name: managedResource.Spec.SecretRefs[0].Name}},
+						KeepObjects: new(false),
+					},
+					Status: healthyManagedResourceStatus,
+				}
+				utilruntime.Must(references.InjectAnnotations(expectedMr))
+				Expect(managedResource).To(Equal(expectedMr))
+
+				managedResourceSecret.Name = managedResource.Spec.SecretRefs[0].Name
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+
+				Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(managedResourceSecret.Immutable).To(Equal(new(true)))
+				Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
+			})
+
+			Context("seed cluster", func() {
+				It("should successfully deploy all resources", func() {
+					Expect(managedResource).To(consistOf(
+						persesCR,
+						seedServiceMonitor,
+					))
+				})
+			})
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should successfully destroy all resources", func() {
+			Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceSecret)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+
+			Expect(deployer.Destroy(ctx)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
+		})
+	})
+
+	Context("waiting functions", func() {
+		Describe("#Wait", func() {
+			It("should fail because reading the runtime ManagedResource fails", func() {
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+			})
+
+			It("should fail because the ManagedResource is unhealthy", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should succeed because the ManagedResource is healthy and progressing", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(Succeed())
+			})
+		})
+
+		Describe("#WaitCleanup", func() {
+			It("should fail when the wait for the managed resource deletion times out", func() {
+				Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
+
+				Expect(deployer.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should not return an error when it is already removed", func() {
+				Expect(deployer.WaitCleanup(ctx)).To(Succeed())
+			})
+		})
+	})
+})
+
+var (
+	healthyManagedResourceStatus = resourcesv1alpha1.ManagedResourceStatus{
+		ObservedGeneration: 1,
+		Conditions: []gardencorev1beta1.Condition{
+			{
+				Type:   resourcesv1alpha1.ResourcesApplied,
+				Status: gardencorev1beta1.ConditionTrue,
+			},
+			{
+				Type:   resourcesv1alpha1.ResourcesHealthy,
+				Status: gardencorev1beta1.ConditionTrue,
+			},
+		},
+	}
+	unhealthyManagedResourceStatus = resourcesv1alpha1.ManagedResourceStatus{
+		ObservedGeneration: 1,
+		Conditions: []gardencorev1beta1.Condition{
+			{
+				Type:   resourcesv1alpha1.ResourcesApplied,
+				Status: gardencorev1beta1.ConditionFalse,
+			},
+			{
+				Type:   resourcesv1alpha1.ResourcesHealthy,
+				Status: gardencorev1beta1.ConditionFalse,
+			},
+		},
+	}
+)

--- a/pkg/component/observability/monitoring/perses/perses_test.go
+++ b/pkg/component/observability/monitoring/perses/perses_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/perses/spec/go/datasource"
 	persesplugin "github.com/perses/spec/go/plugin"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	istionetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +35,7 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/observability/monitoring/perses"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+	comptest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -87,7 +92,7 @@ var _ = Describe("Perses", func() {
 			&retry.UntilTimeout, fakeOps.UntilTimeout,
 		))
 
-		consistOf = NewManagedResourceConsistOfObjectsMatcher(fakeClient)
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(fakeClient, comptest.CmpOptsForIstio()...)
 
 		managedResource = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
@@ -279,6 +284,140 @@ var _ = Describe("Perses", func() {
 						persesCR,
 						dsAggregate,
 						dsSeed,
+						seedServiceMonitor,
+					))
+				})
+			})
+
+			Context("seed cluster with external exposure", func() {
+				var (
+					tlsSecret       *corev1.Secret
+					gateway         *istionetworkingv1beta1.Gateway
+					virtualService  *istionetworkingv1beta1.VirtualService
+					destinationRule *istionetworkingv1beta1.DestinationRule
+				)
+
+				BeforeEach(func() {
+					Expect(fakeClient.Create(ctx, &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: "wildcard-tls", Namespace: namespace},
+					})).To(Succeed())
+
+					values.ExternalExposure = &ExposureValues{
+						AuthSecretName:               "auth-secret",
+						AuthSecretManaged:            true,
+						Host:                         "perses-seed.example.com",
+						IstioIngressGatewayLabels:    map[string]string{"istio": "ingressgateway"},
+						IstioIngressGatewayNamespace: "istio-ingress",
+						WildcardCertSecretName:       new("wildcard-tls"),
+					}
+
+					persesCR.Spec.Service.Annotations["networking.istio.io/exportTo"] = "istio-ingress"
+
+					tlsSecret = &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      namespace + "-perses-seed-wildcard-tls",
+							Namespace: "istio-ingress",
+							Labels: map[string]string{
+								"app":  "perses",
+								"role": "monitoring",
+							},
+						},
+					}
+					gateway = &istionetworkingv1beta1.Gateway{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "perses-seed",
+							Namespace: namespace,
+							Labels: map[string]string{
+								"app":  "perses",
+								"role": "monitoring",
+							},
+						},
+						Spec: istionetworkingv1alpha3.Gateway{
+							Selector: map[string]string{"istio": "ingressgateway"},
+							Servers: []*istionetworkingv1alpha3.Server{{
+								Port: &istionetworkingv1alpha3.Port{
+									Name: "tls", Number: 443, Protocol: "HTTPS",
+								},
+								Hosts: []string{"perses-seed.example.com"},
+								Tls: &istionetworkingv1alpha3.ServerTLSSettings{
+									CredentialName: namespace + "-perses-seed-wildcard-tls",
+									Mode:           istionetworkingv1alpha3.ServerTLSSettings_SIMPLE,
+								},
+							}},
+						},
+					}
+					virtualService = &istionetworkingv1beta1.VirtualService{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "perses-seed",
+							Namespace: namespace,
+							Labels: map[string]string{
+								"app":  "perses",
+								"role": "monitoring",
+								"reference.gardener.cloud/basic-auth-secret-name":    "auth-secret",
+								"reference.gardener.cloud/basic-auth-server-name":    "istio-basic-auth-server",
+								"reference.gardener.cloud/basic-auth-secret-managed": "true",
+							},
+						},
+						Spec: istionetworkingv1alpha3.VirtualService{
+							ExportTo: []string{"istio-ingress"},
+							Gateways: []string{"perses-seed"},
+							Hosts:    []string{"perses-seed.example.com"},
+							Http: []*istionetworkingv1alpha3.HTTPRoute{
+								{
+									Route: []*istionetworkingv1alpha3.HTTPRouteDestination{{
+										Destination: &istionetworkingv1alpha3.Destination{
+											Host: "perses-seed." + namespace + ".svc.cluster.local",
+											Port: &istionetworkingv1alpha3.PortSelector{Number: 8080},
+										},
+									}},
+								},
+							},
+						},
+					}
+					destinationRule = &istionetworkingv1beta1.DestinationRule{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "perses-seed",
+							Namespace: namespace,
+							Labels: map[string]string{
+								"app":  "perses",
+								"role": "monitoring",
+							},
+						},
+						Spec: istionetworkingv1alpha3.DestinationRule{
+							Host: "perses-seed." + namespace + ".svc.cluster.local",
+							TrafficPolicy: &istionetworkingv1alpha3.TrafficPolicy{
+								LoadBalancer: &istionetworkingv1alpha3.LoadBalancerSettings{
+									LocalityLbSetting: &istionetworkingv1alpha3.LocalityLoadBalancerSetting{
+										FailoverPriority: []string{"topology.kubernetes.io/zone"},
+										Enabled:          &wrapperspb.BoolValue{Value: true},
+									},
+								},
+								ConnectionPool: &istionetworkingv1alpha3.ConnectionPoolSettings{
+									Tcp: &istionetworkingv1alpha3.ConnectionPoolSettings_TCPSettings{
+										TcpKeepalive: &istionetworkingv1alpha3.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
+											Time:     &durationpb.Duration{Seconds: 7200},
+											Interval: &durationpb.Duration{Seconds: 75},
+										},
+										MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
+									},
+								},
+								OutlierDetection: &istionetworkingv1alpha3.OutlierDetection{},
+								Tls:              &istionetworkingv1alpha3.ClientTLSSettings{},
+							},
+							ExportTo: []string{"istio-ingress"},
+						},
+					}
+				})
+
+				It("should include istio exposure resources", func() {
+					Expect(managedResource).To(consistOf(
+						persesCR,
+						dsAggregate,
+						dsSeed,
+						tlsSecret,
+						gateway,
+						virtualService,
+						destinationRule,
 						seedServiceMonitor,
 					))
 				})

--- a/pkg/component/observability/monitoring/perses/perses_test.go
+++ b/pkg/component/observability/monitoring/perses/perses_test.go
@@ -169,6 +169,36 @@ var _ = Describe("Perses", func() {
 		}
 
 		newExpectedDatasource = func(dsName, pluginKind, url string, isDefault bool, instanceName string) *persesv1alpha2.PersesDatasource {
+			var allowedEndpoints []any
+			switch pluginKind {
+			case "PrometheusDatasource":
+				for _, pattern := range []string{
+					"^/api/v1/query$",
+					"^/api/v1/query_range$",
+					"^/api/v1/labels$",
+					"^/api/v1/label/[a-zA-Z0-9_]+/values$",
+					"^/api/v1/series$",
+					"^/api/v1/metadata$",
+					"^/api/v1/parse_query$",
+				} {
+					allowedEndpoints = append(allowedEndpoints,
+						map[string]any{"endpointPattern": pattern, "method": "GET"},
+						map[string]any{"endpointPattern": pattern, "method": "POST"},
+					)
+				}
+			case "VictoriaLogsDatasource":
+				for _, pattern := range []string{
+					"^/select/logsql/query$",
+					"^/select/logsql/stats_query_range$",
+					"^/select/logsql/field_names$",
+					"^/select/logsql/field_values$",
+				} {
+					allowedEndpoints = append(allowedEndpoints,
+						map[string]any{"endpointPattern": pattern, "method": "POST"},
+					)
+				}
+			}
+
 			return &persesv1alpha2.PersesDatasource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dsName,
@@ -191,7 +221,8 @@ var _ = Describe("Perses", func() {
 									"proxy": map[string]any{
 										"kind": "HTTPProxy",
 										"spec": map[string]any{
-											"url": url,
+											"url":              url,
+											"allowedEndpoints": allowedEndpoints,
 										},
 									},
 								},

--- a/pkg/component/observability/monitoring/perses/perses_test.go
+++ b/pkg/component/observability/monitoring/perses/perses_test.go
@@ -12,6 +12,9 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
 	persesconfig "github.com/perses/perses/pkg/model/api/config"
+	persescommon "github.com/perses/spec/go/common"
+	"github.com/perses/spec/go/datasource"
+	persesplugin "github.com/perses/spec/go/plugin"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -56,7 +59,13 @@ var _ = Describe("Perses", func() {
 		managedResourceSecret *corev1.Secret
 
 		persesCR           *persesv1alpha2.Perses
+		dsAggregate        *persesv1alpha2.PersesDatasource
+		dsSeed             *persesv1alpha2.PersesDatasource
+		dsGarden           *persesv1alpha2.PersesDatasource
+		dsLongterm         *persesv1alpha2.PersesDatasource
 		seedServiceMonitor *monitoringv1.ServiceMonitor
+
+		newExpectedDatasource func(string, string, string, bool, string) *persesv1alpha2.PersesDatasource
 	)
 
 	BeforeEach(func() {
@@ -152,6 +161,52 @@ var _ = Describe("Perses", func() {
 			},
 		}
 
+		newExpectedDatasource = func(dsName, pluginKind, url string, isDefault bool, instanceName string) *persesv1alpha2.PersesDatasource {
+			return &persesv1alpha2.PersesDatasource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dsName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app":  "perses",
+						"role": "monitoring",
+					},
+				},
+				Spec: persesv1alpha2.DatasourceSpec{
+					Config: persesv1alpha2.Datasource{
+						Spec: datasource.Spec{
+							Display: &persescommon.Display{
+								Name: dsName,
+							},
+							Default: isDefault,
+							Plugin: persesplugin.Plugin{
+								Kind: pluginKind,
+								Spec: map[string]any{
+									"proxy": map[string]any{
+										"kind": "HTTPProxy",
+										"spec": map[string]any{
+											"url": url,
+										},
+									},
+								},
+							},
+						},
+					},
+					InstanceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "app.kubernetes.io/instance",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{instanceName},
+						}},
+					},
+				},
+			}
+		}
+
+		dsAggregate = newExpectedDatasource("prometheus-aggregate", "PrometheusDatasource", "http://prometheus-aggregate:80", true, "perses-seed")
+		dsSeed = newExpectedDatasource("prometheus-seed", "PrometheusDatasource", "http://prometheus-seed:80", false, "perses-seed")
+		dsGarden = newExpectedDatasource("prometheus-garden", "PrometheusDatasource", "http://prometheus-garden:80", true, "perses-garden")
+		dsLongterm = newExpectedDatasource("prometheus-longterm", "PrometheusDatasource", "http://prometheus-longterm:81", false, "perses-garden")
+
 		seedServiceMonitor = &monitoringv1.ServiceMonitor{
 			ObjectMeta: monitoringutils.ConfigObjectMeta("perses", namespace, "seed"),
 			Spec: monitoringv1.ServiceMonitorSpec{
@@ -222,7 +277,112 @@ var _ = Describe("Perses", func() {
 				It("should successfully deploy all resources", func() {
 					Expect(managedResource).To(consistOf(
 						persesCR,
+						dsAggregate,
+						dsSeed,
 						seedServiceMonitor,
+					))
+				})
+			})
+
+			Context("seed cluster with VictoriaLogs enabled", func() {
+				BeforeEach(func() {
+					values.VictoriaLogsEnabled = true
+
+					persesCR.Spec.Metadata.Labels[gardenerutils.NetworkPolicyLabel("logging-vl", 9428)] = v1beta1constants.LabelNetworkPolicyAllowed
+				})
+
+				It("should include VictoriaLogs datasource", func() {
+					Expect(managedResource).To(consistOf(
+						persesCR,
+						dsAggregate,
+						dsSeed,
+						newExpectedDatasource("victorialogs", "VictoriaLogsDatasource", "http://logging-vl."+namespace+".svc:9428", false, "perses-seed"),
+						seedServiceMonitor,
+					))
+				})
+			})
+
+			Context("garden cluster", func() {
+				BeforeEach(func() {
+					values.IsGardenCluster = true
+
+					persesCR.Name = "perses-garden"
+					persesCR.Labels["app.kubernetes.io/instance"] = "perses-garden"
+					persesCR.Spec.Service = &persesv1alpha2.PersesService{
+						Annotations: map[string]string{
+							"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports":   `[{"protocol":"TCP","port":8080}]`,
+							"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8080}]`,
+						},
+					}
+					persesCR.Spec.Metadata.Labels = map[string]string{
+						v1beta1constants.LabelObservabilityApplication:                 "perses",
+						v1beta1constants.LabelNetworkPolicyToDNS:                       v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:          v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelRole:                                     v1beta1constants.LabelMonitoring,
+						gardenerutils.NetworkPolicyLabel("prometheus-garden", 9090):    v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel("prometheus-longterm", 9091):  v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel("prometheus-aggregate", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel("prometheus-seed", 9090):      v1beta1constants.LabelNetworkPolicyAllowed,
+					}
+				})
+
+				It("should successfully deploy all resources", func() {
+					gardenServiceMonitor := &monitoringv1.ServiceMonitor{
+						ObjectMeta: monitoringutils.ConfigObjectMeta("perses", namespace, "garden"),
+						Spec: monitoringv1.ServiceMonitorSpec{
+							Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+								"app.kubernetes.io/instance": "perses-garden",
+							}},
+							Endpoints: []monitoringv1.Endpoint{{
+								TargetPort: new(intstr.FromInt32(8080)),
+							}},
+						},
+					}
+					Expect(managedResource).To(consistOf(
+						persesCR,
+						dsGarden,
+						dsLongterm,
+						gardenServiceMonitor,
+					))
+				})
+			})
+
+			Context("only datasources and dashboards", func() {
+				BeforeEach(func() {
+					values.OnlyDeployDatasourcesAndDashboards = true
+					values.VictoriaLogsEnabled = true
+
+					managedResourceName = "perses-seed-config-only"
+					managedResource = &resourcesv1alpha1.ManagedResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      managedResourceName,
+							Namespace: namespace,
+						},
+					}
+					managedResourceSecret = &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "managedresource-" + managedResourceName,
+							Namespace: namespace,
+						},
+					}
+
+					Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       managedResourceName,
+							Namespace:  namespace,
+							Generation: 1,
+						},
+						Status: healthyManagedResourceStatus,
+					})).To(Succeed())
+
+					dsAggregate = newExpectedDatasource("prometheus-aggregate", "PrometheusDatasource", "http://prometheus-aggregate:80", false, "perses-garden")
+				})
+
+				It("should only deploy seed-specific datasources", func() {
+					dsSeed = newExpectedDatasource("prometheus-seed", "PrometheusDatasource", "http://prometheus-seed:80", false, "perses-garden")
+					Expect(managedResource).To(consistOf(
+						dsAggregate,
+						dsSeed,
 					))
 				})
 			})

--- a/pkg/component/observability/monitoring/perses/servicemonitor.go
+++ b/pkg/component/observability/monitoring/perses/servicemonitor.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package perses
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+)
+
+func (p *perses) serviceMonitor() *monitoringv1.ServiceMonitor {
+	prometheusLabel := "seed"
+	if p.values.IsGardenCluster {
+		prometheusLabel = "garden"
+	}
+
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: monitoringutils.ConfigObjectMeta(labelApp, p.namespace, prometheusLabel),
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+				"app.kubernetes.io/instance": p.persesName(),
+			}},
+			Endpoints: []monitoringv1.Endpoint{{
+				TargetPort: new(intstr.FromInt32(8080)),
+			}},
+		},
+	}
+}

--- a/pkg/component/observability/monitoring/perses/vpa.go
+++ b/pkg/component/observability/monitoring/perses/vpa.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package perses
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+)
+
+func (p *perses) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
+	if !p.values.VPAEnabled {
+		return nil
+	}
+
+	return &vpaautoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.persesName(),
+			Namespace: p.namespace,
+			Labels:    p.getLabels(),
+		},
+		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
+			TargetRef: &autoscalingv1.CrossVersionObjectReference{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       "Deployment",
+				Name:       p.persesName(),
+			},
+			UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
+				UpdateMode: new(vpaautoscalingv1.UpdateModeAuto),
+			},
+			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+					{
+						ContainerName: "perses",
+						MinAllowed: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
+						ControlledValues: new(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+					},
+					{
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						Mode:          new(vpaautoscalingv1.ContainerScalingModeOff),
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/component/observability/monitoring/persesoperator/deployment.go
+++ b/pkg/component/observability/monitoring/persesoperator/deployment.go
@@ -15,6 +15,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 const (
@@ -38,8 +39,10 @@ func (p *persesOperator) deployment() *appsv1.Deployment {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
-						v1beta1constants.LabelNetworkPolicyToDNS:              v1beta1constants.LabelNetworkPolicyAllowed,
-						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToDNS:                v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:   v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel("perses-garden", 8080): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel("perses-seed", 8080):   v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/observability/monitoring/persesoperator/perses_operator_test.go
+++ b/pkg/component/observability/monitoring/persesoperator/perses_operator_test.go
@@ -118,7 +118,9 @@ var _ = Describe("PersesOperator", func() {
 						Labels: map[string]string{
 							"app":                              "perses-operator",
 							"networking.gardener.cloud/to-dns": "allowed",
-							"networking.gardener.cloud/to-runtime-apiserver": "allowed",
+							"networking.gardener.cloud/to-runtime-apiserver":                "allowed",
+							"networking.resources.gardener.cloud/to-perses-garden-tcp-8080": "allowed",
+							"networking.resources.gardener.cloud/to-perses-seed-tcp-8080":   "allowed",
 						},
 					},
 					Spec: corev1.PodSpec{

--- a/pkg/component/shared/perses.go
+++ b/pkg/component/shared/perses.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/imagevector"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/perses"
+)
+
+// NewPerses creates a new perses deployer.
+func NewPerses(c client.Client, namespace string, values perses.Values) (perses.Interface, error) {
+	imagePerses, err := imagevector.Containers().FindImage(imagevector.ContainerImageNamePerses)
+	if err != nil {
+		return nil, err
+	}
+
+	values.Image = imagePerses.String()
+
+	return perses.New(c, namespace, values), nil
+}

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -62,6 +62,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/kubestatemetrics"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/metricsserver"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/nodeexporter"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/perses"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/persesoperator"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 	aggregateprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/aggregate"
@@ -126,6 +127,7 @@ type components struct {
 	aggregatePrometheus           component.DeployWaiter
 	alertManager                  component.DeployWaiter
 	persesOperator                component.DeployWaiter
+	perses                        perses.Interface
 	victoriaOperator              component.DeployWaiter
 	openTelemetryOperator         component.DeployWaiter
 	openTelemetryCollector        component.Deployer
@@ -300,6 +302,10 @@ func (r *Reconciler) instantiateComponents(
 		return
 	}
 	c.persesOperator, err = r.newPersesOperator()
+	if err != nil {
+		return
+	}
+	c.perses, err = r.newPerses(seed, secretsManager, globalMonitoringSecretSeed, wildCardCertSecret, seedIsGarden, c.istioDefaultLabels, c.istioDefaultNamespace)
 	if err != nil {
 		return
 	}
@@ -962,6 +968,38 @@ func (r *Reconciler) newPersesOperator() (component.DeployWaiter, error) {
 		r.GardenNamespace,
 		v1beta1constants.PriorityClassNameSeedSystem600,
 	)
+}
+
+func (r *Reconciler) newPerses(seed *seedpkg.Seed, secretsManager secretsmanager.Interface, authSecret, wildcardCertSecret *corev1.Secret, seedIsGarden bool, istioIngressGatewayLabels map[string]string, istioIngressGatewayNamespace string) (perses.Interface, error) {
+	values := perses.Values{
+		ClusterType: component.ClusterTypeSeed,
+		Replicas:    1,
+		// TODO(rickardsjp): Set PriorityClassNameSeedSystem600 on the Perses pods once perses-operator supports
+		// configuring a pod priority class on the Perses resource (see github.com/perses/perses-operator/pull/456).
+		VPAEnabled:                         v1beta1helper.SeedSettingVerticalPodAutoscalerEnabled(seed.GetInfo().Spec.Settings),
+		VictoriaLogsEnabled:                gardenlethelper.IsVictoriaLogsEnabled(&r.Config),
+		OnlyDeployDatasourcesAndDashboards: seedIsGarden,
+	}
+
+	if !seedIsGarden {
+		values.ExternalExposure = &perses.ExposureValues{
+			Host:                         seed.GetIngressFQDN("perses-seed"),
+			IstioIngressGatewayLabels:    istioIngressGatewayLabels,
+			IstioIngressGatewayNamespace: istioIngressGatewayNamespace,
+			SecretsManager:               secretsManager,
+			SigningCA:                    v1beta1constants.SecretNameCASeed,
+		}
+		if authSecret != nil {
+			values.ExternalExposure.AuthSecretName = authSecret.Name
+			// The seed's global monitoring secret is referenced verbatim, not managed by the secrets manager.
+			values.ExternalExposure.AuthSecretManaged = false
+		}
+		if wildcardCertSecret != nil {
+			values.ExternalExposure.WildcardCertSecretName = new(wildcardCertSecret.GetName())
+		}
+	}
+
+	return sharedcomponent.NewPerses(r.SeedClientSet.Client(), r.GardenNamespace, values)
 }
 
 func (r *Reconciler) newVictoriaOperator() (component.DeployWaiter, error) {

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -259,10 +259,15 @@ func (r *Reconciler) runDeleteSeedFlow(
 				return gardenerutils.DeleteVPAForGardenerComponent(ctx, r.SeedClientSet.Client(), v1beta1constants.DeploymentNameGardenlet, r.GardenNamespace)
 			},
 		})
+		destroyPerses = g.Add(flow.Task{
+			Name: "Destroying Perses",
+			Fn:   component.OpDestroyAndWait(c.perses).Destroy,
+		})
 		destroyPersesOperator = g.Add(flow.Task{
-			Name:   "Destroy Perses Operator",
-			Fn:     component.OpDestroyAndWait(c.persesOperator).Destroy,
-			SkipIf: seedIsGarden,
+			Name:         "Destroy Perses Operator",
+			Fn:           component.OpDestroyAndWait(c.persesOperator).Destroy,
+			SkipIf:       seedIsGarden,
+			Dependencies: flow.NewTaskIDs(destroyPerses),
 		})
 		destroyVictoriaOperator = g.Add(flow.Task{
 			Name:         "Destroy Victoria Operator",

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -543,15 +543,25 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Deploying istio-basic-auth-server",
-			Fn:           c.istioBasicAuthServer.Deploy,
-			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents, waitUntilAggregatePrometheusReady, waitUntilPlutonoReady),
-		})
-		_ = g.Add(flow.Task{
 			Name:         "Deploying Perses Operator",
 			Fn:           c.persesOperator.Deploy,
 			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
 			SkipIf:       seedIsGarden,
+		})
+		deployPerses = g.Add(flow.Task{
+			Name:         "Deploying Perses",
+			Fn:           c.perses.Deploy,
+			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
+		})
+		waitUntilPersesReady = g.Add(flow.Task{
+			Name:         "Waiting until Perses is ready",
+			Fn:           c.perses.Wait,
+			Dependencies: flow.NewTaskIDs(deployPerses),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying istio-basic-auth-server",
+			Fn:           c.istioBasicAuthServer.Deploy,
+			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents, waitUntilAggregatePrometheusReady, waitUntilPlutonoReady, waitUntilPersesReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying Victoria Operator",

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -78,6 +78,7 @@ import (
 	gardenblackboxexporter "github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter/garden"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/gardenermetricsexporter"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/kubestatemetrics"
+	"github.com/gardener/gardener/pkg/component/observability/monitoring/perses"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/persesoperator"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 	gardenprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
@@ -154,6 +155,7 @@ type components struct {
 	prometheusLongTerm            prometheus.Interface
 	blackboxExporter              component.DeployWaiter
 	persesOperator                component.DeployWaiter
+	perses                        perses.Interface
 	victoriaOperator              component.DeployWaiter
 	victoriaLogs                  component.DeployWaiter
 	pvcAutoscaler                 component.DeployWaiter
@@ -383,6 +385,10 @@ func (r *Reconciler) instantiateComponents(
 		return
 	}
 	c.persesOperator, err = r.newPersesOperator()
+	if err != nil {
+		return
+	}
+	c.perses, err = r.newPerses(garden, secretsManager, primaryIngressDomain.Name, wildcardCertSecretName, c.istio.GetValues().IngressGateway)
 	if err != nil {
 		return
 	}
@@ -1713,6 +1719,37 @@ func (r *Reconciler) newPersesOperator() (component.DeployWaiter, error) {
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
 		v1beta1constants.PriorityClassNameGardenSystem100,
+	)
+}
+
+func (r *Reconciler) newPerses(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, ingressDomain string, wildcardCertSecretName *string, ingressGatewayValues []istio.IngressGatewayValues) (perses.Interface, error) {
+	if len(ingressGatewayValues) != 1 {
+		return nil, fmt.Errorf("exactly one Istio Ingress Gateway is required for the perses config")
+	}
+
+	return sharedcomponent.NewPerses(
+		r.RuntimeClientSet.Client(),
+		r.GardenNamespace,
+		perses.Values{
+			ClusterType: component.ClusterTypeSeed,
+			Replicas:    1,
+			// TODO(rickardsjp): Set PriorityClassNameGardenSystem100 on the Perses pods once perses-operator supports
+			// configuring a pod priority class on the Perses resource (see github.com/perses/perses-operator/pull/456).
+			IsGardenCluster:     true,
+			VPAEnabled:          vpaEnabled(garden.Spec.RuntimeCluster.Settings),
+			VictoriaLogsEnabled: features.DefaultFeatureGate.Enabled(features.VictoriaLogsBackend),
+			ExternalExposure: &perses.ExposureValues{
+				AuthSecretName:               v1beta1constants.SecretNameObservabilityIngress,
+				AuthSecretManaged:            true,
+				Host:                         "perses-garden." + ingressDomain,
+				IsGardenCluster:              true,
+				IstioIngressGatewayLabels:    ingressGatewayValues[0].Labels,
+				IstioIngressGatewayNamespace: ingressGatewayValues[0].Namespace,
+				SecretsManager:               secretsManager,
+				SigningCA:                    operatorv1alpha1.SecretNameCARuntime,
+				WildcardCertSecretName:       wildcardCertSecretName,
+			},
+		},
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -99,6 +99,10 @@ func (r *Reconciler) delete(
 			Name: "Destroying Plutono",
 			Fn:   component.OpDestroyAndWait(c.plutono).Destroy,
 		})
+		destroyPerses = g.Add(flow.Task{
+			Name: "Destroying Perses",
+			Fn:   component.OpDestroyAndWait(c.perses).Destroy,
+		})
 		_ = g.Add(flow.Task{
 			Name: "Destroying Gardener Metrics Exporter",
 			Fn:   component.OpDestroyAndWait(c.gardenerMetricsExporter).Destroy,
@@ -385,8 +389,9 @@ func (r *Reconciler) delete(
 			Dependencies: flow.NewTaskIDs(destroyFluentOperatorCustomResources),
 		})
 		destroyPersesOperator = g.Add(flow.Task{
-			Name: "Destroying perses-operator",
-			Fn:   component.OpDestroyAndWait(c.persesOperator).Destroy,
+			Name:         "Destroying perses-operator",
+			Fn:           component.OpDestroyAndWait(c.persesOperator).Destroy,
+			Dependencies: flow.NewTaskIDs(destroyPerses),
 		})
 		destroyVictoriaOperator = g.Add(flow.Task{
 			Name:         "Destroying victoria-operator",

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -773,10 +773,20 @@ func (r *Reconciler) reconcile(
 			Fn:           c.plutono.Wait,
 			Dependencies: flow.NewTaskIDs(deployPlutono),
 		})
+		deployPerses = g.Add(flow.Task{
+			Name:         "Deploying Perses",
+			Fn:           c.perses.Deploy,
+			Dependencies: flow.NewTaskIDs(generateObservabilityIngressPassword),
+		})
+		waitUntilPersesReady = g.Add(flow.Task{
+			Name:         "Waiting until Perses is ready",
+			Fn:           c.perses.Wait,
+			Dependencies: flow.NewTaskIDs(deployPerses),
+		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying istio-basic-auth-server",
 			Fn:           c.istioBasicAuthServer.Deploy,
-			Dependencies: flow.NewTaskIDs(waitUntilAlertmanagerReady, waitUntilPrometheusGardenReady, waitUntilPrometheusLongTermReady, waitUntilPlutonoReady),
+			Dependencies: flow.NewTaskIDs(waitUntilAlertmanagerReady, waitUntilPrometheusGardenReady, waitUntilPrometheusLongTermReady, waitUntilPlutonoReady, waitUntilPersesReady),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Deploying perses-operator",

--- a/test/e2e/operator/garden/garden.go
+++ b/test/e2e/operator/garden/garden.go
@@ -44,6 +44,7 @@ var gardenManagedResourceList = []string{
 	"vali",
 	"victoria-logs",
 	"plutono",
+	"perses",
 	"prometheus-operator",
 	"perses-operator",
 	"victoria-operator",

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -642,6 +642,7 @@ var _ = Describe("Seed controller tests", func() {
 					}).Should(Succeed())
 
 					patchMRHealth("plutono")
+					patchMRHealth("perses")
 				} else {
 					By("Verify that the CRDs shared with the garden cluster have not been deployed (gardener-operator deploys them)")
 					Eventually(func(g Gomega) []string {
@@ -723,6 +724,7 @@ var _ = Describe("Seed controller tests", func() {
 					}).WithTimeout(kubernetesutils.WaitTimeout).Should(Succeed())
 
 					patchMRHealth("plutono-seed-config-only")
+					patchMRHealth("perses-seed-config-only")
 				}
 				patchMRHealth("prometheus-aggregate")
 
@@ -757,6 +759,7 @@ var _ = Describe("Seed controller tests", func() {
 						"vpa",
 						"etcd-druid",
 						"plutono",
+						"perses",
 						"vali",
 						"fluent-bit",
 						"fluent-operator",
@@ -774,6 +777,7 @@ var _ = Describe("Seed controller tests", func() {
 				} else {
 					expectedManagedResources = append(expectedManagedResources,
 						"plutono-seed-config-only",
+						"perses-seed-config-only",
 					)
 				}
 				// There are additional parts in the flow that we not check here, which could take time.
@@ -1093,6 +1097,7 @@ var _ = Describe("Seed controller tests", func() {
 					}
 
 					patchMRHealth("plutono")
+					patchMRHealth("perses")
 					patchMRHealth("prometheus-aggregate")
 
 					controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{}
@@ -1117,6 +1122,7 @@ var _ = Describe("Seed controller tests", func() {
 						// Components not skipped for self-hosted shoots (only for garden):
 						"vpa",
 						"plutono",
+						"perses",
 						"vali",
 						"fluent-bit",
 						"fluent-operator",

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -585,6 +585,7 @@ spec:
 			"fluent-operator-custom-resources-garden",
 			"vali",
 			"plutono",
+			"perses",
 			"prometheus-operator",
 			"alertmanager-garden",
 			"perses-operator",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR introduces the seed and garden Perses instances and the surrounding plumbing. It does not yet add dashboards. The dashboards will be migrated in a future PR.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardener now deploys `Seed` and `Garden` Perses instances. The dashboard migration will follow later.
```
