### PR TITLE
Introduce `gardener.clusterTypes` values for extension and admission charts

### DIFF
--- a/charts/gardener/provider-local/templates/_helpers.tpl
+++ b/charts/gardener/provider-local/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "name" -}}
-{{- if .Values.gardener.runtimeCluster.enabled -}}
+{{- if .Values.gardener.runtimeCluster -}}
 gardener-extension-provider-local-runtime
 {{- else -}}
 gardener-extension-provider-local

--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -89,8 +89,8 @@ spec:
         {{- if .Values.gardener.version }}
         - --gardener-version={{ .Values.gardener.version }}
         {{- end }}
-        {{- if .Values.gardener.selfHostedShootCluster }}
-        - --self-hosted-shoot-cluster={{ .Values.gardener.selfHostedShootCluster }}
+        {{- if .Values.gardener.clusterTypes.selfHostedShootCluster }}
+        - --self-hosted-shoot-cluster={{ .Values.gardener.clusterTypes.selfHostedShootCluster }}
         {{- end }}
         - --log-level={{ .Values.logLevel | default "info"  }}
         - --log-format={{ .Values.logFormat | default "json"  }}

--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         {{- end }}
 {{ include "labels" . | indent 8 }}
     spec:
-      {{- if .Values.gardener.runtimeCluster.enabled }}
+      {{- if .Values.gardener.runtimeCluster }}
       priorityClassName: {{ .Values.gardener.runtimeCluster.priorityClassName }}
       {{- else }}
       priorityClassName: gardener-system-900
@@ -67,7 +67,7 @@ spec:
         - --backupbucket-container-mount-path={{ .Values.controllers.backupbucket.containerMountPath }}
         - --heartbeat-namespace={{ .Release.Namespace }}
         - --heartbeat-renew-interval-seconds={{ .Values.controllers.heartbeat.renewIntervalSeconds }}
-        {{- if .Values.gardener.runtimeCluster.enabled }}
+        {{- if .Values.gardener.runtimeCluster }}
         - --disable-webhooks=controlplane,networkpolicy,shoot
         - --controllers=backupbucket,backupentry,dnsrecord,local-ext-shoot
         - --extension-classes=garden

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -78,13 +78,14 @@ metrics:
 
 gardener:
   version: ""
+  clusterTypes:
+    selfHostedShootCluster: false
   gardenlet:
     featureGates: {}
   seed:
     provider: local
   runtimeCluster:
     enabled: false
-  selfHostedShootCluster: false
 
 usablePorts:
 - 8080  # metrics

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -84,8 +84,6 @@ gardener:
     featureGates: {}
   seed:
     provider: local
-  runtimeCluster:
-    enabled: false
 
 usablePorts:
 - 8080  # metrics

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -123,8 +123,9 @@ Besides the values configured in `.spec.deployment.extension.runtimeValues`, a r
 
 ```yaml
 gardener:
+  clusterTypes:
+    gardenRuntimeCluster: true # indicates the deployment targets a garden runtime cluster
   runtimeCluster:
-    enabled: true # indicates the extension is enabled for the Garden cluster, e.g. for handling `BackupBucket`, `BackupEntry`, `DNSRecord` and `Extension` objects.
     priorityClassName: gardener-garden-system-200
 ```
 
@@ -148,10 +149,11 @@ The following values are passed to the chart during reconciliation:
 
 ```yaml
 gardener:
+  clusterTypes:
+    gardenRuntimeCluster: true # indicates the deployment targets the garden runtime cluster
   runtimeCluster:
     priorityClassName: <Class to be used for extension admission>
   virtualCluster:
-    enabled: true
     namespace: <Extension Namespace name in the virtual cluster (format "extension-<extension-name>")>
 ```
 
@@ -166,8 +168,9 @@ The following values are passed to the chart during reconciliation:
 
 ```yaml
 gardener:
+  clusterTypes:
+    gardenCluster: true # indicates the deployment targets the garden cluster
   virtualCluster:
-    enabled: true
     serviceAccount:
       name: <Name of the service account used to connect to the garden cluster>
       namespace: <Namespace of the service account>

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -125,7 +125,7 @@ Besides the values configured in `.spec.deployment.extension.runtimeValues`, a r
 gardener:
   clusterTypes:
     gardenRuntimeCluster: true # indicates the deployment targets a garden runtime cluster
-  runtimeCluster:
+    selfManagedSeedCluster: false # true if this garden is also a self-hosted shoot cluster
     priorityClassName: gardener-garden-system-200
 ```
 
@@ -151,6 +151,7 @@ The following values are passed to the chart during reconciliation:
 gardener:
   clusterTypes:
     gardenRuntimeCluster: true # indicates the deployment targets the garden runtime cluster
+    selfManagedSeedCluster: false # true if this garden is also a self-hosted shoot cluster
   runtimeCluster:
     priorityClassName: <Class to be used for extension admission>
   virtualCluster:

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -125,7 +125,7 @@ Besides the values configured in `.spec.deployment.extension.runtimeValues`, a r
 gardener:
   clusterTypes:
     gardenRuntimeCluster: true # indicates the deployment targets a garden runtime cluster
-    selfManagedSeedCluster: false # true if this garden is also a self-hosted shoot cluster
+    selfHostedShootCluster: false # true if this garden is also a self-hosted shoot cluster
     priorityClassName: gardener-garden-system-200
 ```
 
@@ -151,7 +151,7 @@ The following values are passed to the chart during reconciliation:
 gardener:
   clusterTypes:
     gardenRuntimeCluster: true # indicates the deployment targets the garden runtime cluster
-    selfManagedSeedCluster: false # true if this garden is also a self-hosted shoot cluster
+    selfHostedShootCluster: false # true if this garden is also a self-hosted shoot cluster
   runtimeCluster:
     priorityClassName: <Class to be used for extension admission>
   virtualCluster:

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -126,10 +126,16 @@ gardener:
   clusterTypes:
     gardenRuntimeCluster: true # indicates the deployment targets a garden runtime cluster
     selfHostedShootCluster: false # true if this garden is also a self-hosted shoot cluster
+  runtimeCluster:
     priorityClassName: gardener-garden-system-200
 ```
 
 As soon as a `Garden` object is created and `runtimeValues` are configured, the extension is deployed in the runtime cluster.
+
+> [!IMPORTANT]
+> The `.gardener.clusterTypes` values identify the roles of the cluster the extension is being deployed to. It does not reflect the deployment target.
+> This mainly helps avoid resource conflicts in case a cluster serves multiple roles at the same time, e.g., the garden runtime cluster also acting as a seed.
+> Whether the extension controller is being deployed to the garden runtime cluster, a seed cluster, or a self-hosted shoot must be derived from `.gardener.runtimeCluster`, `.gardener.seedCluster`, and `.gardener.shoot`.
 
 ##### Extension Registration
 

--- a/docs/extensions/registration.md
+++ b/docs/extensions/registration.md
@@ -289,6 +289,7 @@ In order to allow extension controller deployments to get information about the 
     clusterTypes:
       gardenRuntimeCluster: false # true if this seed is also serving as the garden runtime cluster
       seedCluster: true
+      shootCluster: false # true for managed seeds
     version: <gardener-version>
     garden:
       clusterIdentity: <uuid-of-gardener-installation>

--- a/docs/extensions/registration.md
+++ b/docs/extensions/registration.md
@@ -288,6 +288,7 @@ In order to allow extension controller deployments to get information about the 
   gardener:
     clusterTypes:
       gardenRuntimeCluster: false # true if this seed is also serving as the garden runtime cluster
+      seedCluster: true
     version: <gardener-version>
     garden:
       clusterIdentity: <uuid-of-gardener-installation>

--- a/docs/extensions/registration.md
+++ b/docs/extensions/registration.md
@@ -277,14 +277,17 @@ In order to allow extension controller deployments to get information about the 
 - Additional properties for garden deployment
   ```yaml
     gardener:
+      clusterTypes:
+        gardenRuntimeCluster: true
       runtimeCluster:
-        enabled: true
         priorityClassName: <priority-class-name-for-extension>
   ```
 
 - Additional properties for seed deployment
   ```yaml
   gardener:
+    clusterTypes:
+      gardenRuntimeCluster: false # true if this seed is also serving as the garden runtime cluster
     version: <gardener-version>
     garden:
       clusterIdentity: <uuid-of-gardener-installation>

--- a/docs/extensions/registration.md
+++ b/docs/extensions/registration.md
@@ -318,6 +318,9 @@ In order to allow extension controller deployments to get information about the 
   In addition, a `.gardener.shoot` section is populated with `name`, `namespace`, `labels`, `annotations`, `spec`, and (if available) `clusterIdentity`.
   If the self-hosted shoot has not yet been promoted to a `Seed`, the `.gardener.seed` section is omitted entirely.
   Extension charts should handle this gracefully (e.g., `{{ if .Values.gardener.seed }}`).
+- The `.gardener.clusterTypes` values identify the roles of the cluster the extension is being deployed to.
+  This mainly helps avoid resource conflicts in case a cluster serves multiple roles at the same time, e.g., the garden runtime cluster also acting as a seed.
+  **IMPORTANT:** `.gardener.clusterTypes` does not reflect the deployment target, i.e., whether the extension controller is being deployed to the garden runtime cluster, a seed cluster, or a self-hosted shoot. This information must instead be derived from `.gardener.runtimeCluster`, `.gardener.seedCluster`, and `.gardener.shoot`.
 
 Extension controller deployments can use this information in their Helm chart in case they require knowledge about the garden and the seed environment.
 The list might be extended in the future.

--- a/docs/extensions/registration.md
+++ b/docs/extensions/registration.md
@@ -279,6 +279,7 @@ In order to allow extension controller deployments to get information about the 
     gardener:
       clusterTypes:
         gardenRuntimeCluster: true
+        selfHostedShootCluster: false # true if this garden is also a self-hosted shoot cluster
       runtimeCluster:
         priorityClassName: <priority-class-name-for-extension>
   ```

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -1178,4 +1178,15 @@ const (
 	// that contains a label selector for shoots. The static manifests will only be propagated for shoots matching the
 	// selector.
 	AnnotationStaticManifestsShootSelector = "static-manifests.shoot.gardener.cloud/selector"
+
+	// ClusterTypeGardenCluster is the type value indicating that the cluster is a garden cluster.
+	ClusterTypeGardenCluster = "gardenCluster"
+	// ClusterTypeGardenRuntimeCluster is the type value indicating that the cluster is a garden runtime cluster.
+	ClusterTypeGardenRuntimeCluster = "gardenRuntimeCluster"
+	// ClusterTypeSeedCluster is the type value indicating that the cluster is a seed cluster.
+	ClusterTypeSeedCluster = "seedCluster"
+	// ClusterTypeSelfHostedShootCluster is the type value indicating that the cluster is a self-hosted shoot cluster.
+	ClusterTypeSelfHostedShootCluster = "selfHostedShootCluster"
+	// ClusterTypeShootCluster is the type value indicating that the cluster is a shoot cluster.
+	ClusterTypeShootCluster = "shootCluster"
 )

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -292,10 +292,10 @@ func (r *Reconciler) reconcile(
 	}
 
 	clusterTypes := map[string]bool{
-		"gardenRuntimeCluster":   isGarden,
-		"seedCluster":            isSeed,
-		"selfHostedShootCluster": r.SelfHostedShootMeta != nil,
-		"shootCluster":           isShoot,
+		v1beta1constants.ClusterTypeGardenRuntimeCluster:   isGarden,
+		v1beta1constants.ClusterTypeSeedCluster:            isSeed,
+		v1beta1constants.ClusterTypeSelfHostedShootCluster: r.SelfHostedShootMeta != nil,
+		v1beta1constants.ClusterTypeShootCluster:           isShoot,
 	}
 
 	// Mix-in some standard values for garden and seed.

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -281,9 +281,14 @@ func (r *Reconciler) reconcile(
 		featureToEnabled[feature] = features.DefaultFeatureGate.Enabled(feature)
 	}
 
+	clusterTypes := map[string]bool{
+		"gardenRuntimeCluster": seedIsGarden,
+	}
+
 	// Mix-in some standard values for garden and seed.
 	gardenerMap := map[string]any{
-		"version": r.Identity.Version,
+		"version":      r.Identity.Version,
+		"clusterTypes": clusterTypes,
 		"garden": map[string]any{
 			"clusterIdentity": r.GardenClusterIdentity,
 		},

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -282,8 +282,9 @@ func (r *Reconciler) reconcile(
 	}
 
 	clusterTypes := map[string]bool{
-		"gardenRuntimeCluster": seedIsGarden,
-		"seedCluster":          true,
+		"gardenRuntimeCluster":   seedIsGarden,
+		"seedCluster":            true,
+		"selfHostedShootCluster": r.SelfHostedShootMeta != nil,
 	}
 
 	// Mix-in some standard values for garden and seed.
@@ -336,8 +337,6 @@ func (r *Reconciler) reconcile(
 	}
 
 	if r.SelfHostedShootMeta != nil {
-		gardenerMap["selfHostedShootCluster"] = true
-
 		shootValues := map[string]any{
 			"name":        shoot.Name,
 			"namespace":   shoot.Namespace,

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -283,6 +283,7 @@ func (r *Reconciler) reconcile(
 
 	clusterTypes := map[string]bool{
 		"gardenRuntimeCluster": seedIsGarden,
+		"seedCluster":          true,
 	}
 
 	// Mix-in some standard values for garden and seed.

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -210,6 +210,11 @@ func (r *Reconciler) reconcile(
 		return reconcile.Result{}, fmt.Errorf("failed checking whether the seed is the garden cluster at the same time: %w", err)
 	}
 
+	seedIsShoot, err := gardenletutils.ClusterIsShoot(seedCtx, r.SeedClientSet.Client())
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed checking whether the seed is a shoot cluster: %w", err)
+	}
+
 	namespace := getNamespaceForControllerInstallation(controllerInstallation)
 	if _, err := controllerutils.GetAndCreateOrMergePatch(seedCtx, r.SeedClientSet.Client(), namespace, func() error {
 		metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.GardenRole, v1beta1constants.GardenRoleExtension)
@@ -285,6 +290,7 @@ func (r *Reconciler) reconcile(
 		"gardenRuntimeCluster":   seedIsGarden,
 		"seedCluster":            true,
 		"selfHostedShootCluster": r.SelfHostedShootMeta != nil,
+		"shootCluster":           seedIsShoot,
 	}
 
 	// Mix-in some standard values for garden and seed.

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -205,14 +205,19 @@ func (r *Reconciler) reconcile(
 		return reconcile.Result{}, err
 	}
 
-	seedIsGarden, err := gardenletutils.ClusterIsGarden(seedCtx, r.SeedClientSet.Client())
+	isGarden, err := gardenletutils.ClusterIsGarden(seedCtx, r.SeedClientSet.Client())
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed checking whether the seed is the garden cluster at the same time: %w", err)
+		return reconcile.Result{}, fmt.Errorf("failed checking whether the cluster is a garden runtime cluster: %w", err)
 	}
 
-	seedIsShoot, err := gardenletutils.ClusterIsShoot(seedCtx, r.SeedClientSet.Client())
+	isSeed, err := gardenletutils.ClusterIsSeed(seedCtx, r.SeedClientSet.Client())
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed checking whether the seed is a shoot cluster: %w", err)
+		return reconcile.Result{}, fmt.Errorf("failed checking whether the cluster is a seed cluster: %w", err)
+	}
+
+	isShoot, err := gardenletutils.ClusterIsShoot(seedCtx, r.SeedClientSet.Client())
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed checking whether the cluster is a shoot cluster: %w", err)
 	}
 
 	namespace := getNamespaceForControllerInstallation(controllerInstallation)
@@ -234,7 +239,7 @@ func (r *Reconciler) reconcile(
 			}
 		}
 
-		if seedIsGarden {
+		if isGarden {
 			metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.LabelNetworkPolicyAccessTargetAPIServer, "allowed")
 		}
 
@@ -287,10 +292,10 @@ func (r *Reconciler) reconcile(
 	}
 
 	clusterTypes := map[string]bool{
-		"gardenRuntimeCluster":   seedIsGarden,
-		"seedCluster":            true,
+		"gardenRuntimeCluster":   isGarden,
+		"seedCluster":            isSeed,
 		"selfHostedShootCluster": r.SelfHostedShootMeta != nil,
-		"shootCluster":           seedIsShoot,
+		"shootCluster":           isShoot,
 	}
 
 	// Mix-in some standard values for garden and seed.

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -63,17 +63,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	var seedIsShoot bool
-	if err := r.SeedClientSet.Client().Get(ctx, client.ObjectKey{
-		Namespace: metav1.NamespaceSystem,
-		Name:      v1beta1constants.ConfigMapNameShootInfo,
-	}, &corev1.ConfigMap{}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return reconcile.Result{}, fmt.Errorf("failed to check if this seed is a shoot: %w", err)
-		}
-		seedIsShoot = false
-	} else {
-		seedIsShoot = true
+	seedIsShoot, err := gardenletutils.ClusterIsShoot(ctx, r.SeedClientSet.Client())
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check if this seed is a shoot: %w", err)
 	}
 
 	operationType := gardencorev1beta1.LastOperationTypeReconcile

--- a/pkg/operator/controller/extension/extension/admission/admission.go
+++ b/pkg/operator/controller/extension/extension/admission/admission.go
@@ -115,7 +115,7 @@ func (d *deployment) createOrUpdateAdmissionRuntimeClusterResources(ctx context.
 				"priorityClassName": v1beta1constants.PriorityClassNameGardenSystem400,
 			},
 			"virtualCluster": map[string]any{
-				// TODO(timuthy): Remove this field after Gardener v1.153.0 has been released. There is no replacement as a virtual cluster is always involved in an admission deployment.
+				// TODO(timuthy): Remove this field after Gardener v1.159.0 has been released. There is no replacement as a virtual cluster is always involved in an admission deployment.
 				"enabled":   true,
 				"namespace": virtualNamespace(extension).GetName(),
 			},
@@ -208,7 +208,7 @@ func (d *deployment) createOrUpdateAdmissionVirtualClusterResources(ctx context.
 				"gardenCluster": true,
 			},
 			"virtualCluster": map[string]any{
-				// TODO(timuthy): Remove this field after Gardener v1.153.0 has been released.
+				// TODO(timuthy): Remove this field after Gardener v1.159.0 has been released.
 				"enabled": true,
 				"serviceAccount": map[string]any{
 					"name":      accessSecret.ServiceAccountName,

--- a/pkg/operator/controller/extension/extension/admission/admission.go
+++ b/pkg/operator/controller/extension/extension/admission/admission.go
@@ -100,10 +100,16 @@ func (d *deployment) createOrUpdateAdmissionRuntimeClusterResources(ctx context.
 		return fmt.Errorf("failed reconciling access secret: %w", err)
 	}
 
+	isSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, d.runtimeClientSet.Client())
+	if err != nil {
+		return fmt.Errorf("failed checking whether the runtime cluster is a self-hosted shoot: %w", err)
+	}
+
 	gardenerValues := map[string]any{
 		"gardener": map[string]any{
 			"clusterTypes": map[string]bool{
 				"gardenRuntimeCluster": true,
+				"selfHostedShoot":      isSelfHostedShoot,
 			},
 			"runtimeCluster": map[string]any{
 				"priorityClassName": v1beta1constants.PriorityClassNameGardenSystem400,

--- a/pkg/operator/controller/extension/extension/admission/admission.go
+++ b/pkg/operator/controller/extension/extension/admission/admission.go
@@ -102,10 +102,14 @@ func (d *deployment) createOrUpdateAdmissionRuntimeClusterResources(ctx context.
 
 	gardenerValues := map[string]any{
 		"gardener": map[string]any{
+			"clusterTypes": map[string]bool{
+				"gardenRuntimeCluster": true,
+			},
 			"runtimeCluster": map[string]any{
 				"priorityClassName": v1beta1constants.PriorityClassNameGardenSystem400,
 			},
 			"virtualCluster": map[string]any{
+				// TODO(timuthy): Remove this field after Gardener v1.153.0 has been released. There is no replacement as a virtual cluster is always involved in an admission deployment.
 				"enabled":   true,
 				"namespace": virtualNamespace(extension).GetName(),
 			},
@@ -194,7 +198,11 @@ func (d *deployment) createOrUpdateAdmissionVirtualClusterResources(ctx context.
 
 	gardenerValues := map[string]any{
 		"gardener": map[string]any{
+			"clusterTypes": map[string]bool{
+				"gardenCluster": true,
+			},
 			"virtualCluster": map[string]any{
+				// TODO(timuthy): Remove this field after Gardener v1.153.0 has been released.
 				"enabled": true,
 				"serviceAccount": map[string]any{
 					"name":      accessSecret.ServiceAccountName,

--- a/pkg/operator/controller/extension/extension/admission/admission.go
+++ b/pkg/operator/controller/extension/extension/admission/admission.go
@@ -108,8 +108,8 @@ func (d *deployment) createOrUpdateAdmissionRuntimeClusterResources(ctx context.
 	gardenerValues := map[string]any{
 		"gardener": map[string]any{
 			"clusterTypes": map[string]bool{
-				"gardenRuntimeCluster": true,
-				"selfHostedShoot":      isSelfHostedShoot,
+				"gardenRuntimeCluster":   true,
+				"selfHostedShootCluster": isSelfHostedShoot,
 			},
 			"runtimeCluster": map[string]any{
 				"priorityClassName": v1beta1constants.PriorityClassNameGardenSystem400,

--- a/pkg/operator/controller/extension/extension/admission/admission.go
+++ b/pkg/operator/controller/extension/extension/admission/admission.go
@@ -108,8 +108,8 @@ func (d *deployment) createOrUpdateAdmissionRuntimeClusterResources(ctx context.
 	gardenerValues := map[string]any{
 		"gardener": map[string]any{
 			"clusterTypes": map[string]bool{
-				"gardenRuntimeCluster":   true,
-				"selfHostedShootCluster": isSelfHostedShoot,
+				v1beta1constants.ClusterTypeGardenRuntimeCluster:   true,
+				v1beta1constants.ClusterTypeSelfHostedShootCluster: isSelfHostedShoot,
 			},
 			"runtimeCluster": map[string]any{
 				"priorityClassName": v1beta1constants.PriorityClassNameGardenSystem400,
@@ -205,7 +205,7 @@ func (d *deployment) createOrUpdateAdmissionVirtualClusterResources(ctx context.
 	gardenerValues := map[string]any{
 		"gardener": map[string]any{
 			"clusterTypes": map[string]bool{
-				"gardenCluster": true,
+				v1beta1constants.ClusterTypeGardenCluster: true,
 			},
 			"virtualCluster": map[string]any{
 				// TODO(timuthy): Remove this field after Gardener v1.159.0 has been released.

--- a/pkg/operator/controller/extension/extension/admission/admission_test.go
+++ b/pkg/operator/controller/extension/extension/admission/admission_test.go
@@ -158,8 +158,8 @@ var _ = Describe("Admission", func() {
 				"foo": "bar",
 				"gardener": map[string]any{
 					"clusterTypes": map[string]bool{
-						"gardenRuntimeCluster": true,
-						"selfHostedShoot":      false,
+						"gardenRuntimeCluster":   true,
+						"selfHostedShootCluster": false,
 					},
 					"runtimeCluster": map[string]any{
 						"priorityClassName": "gardener-garden-system-400",
@@ -183,7 +183,7 @@ var _ = Describe("Admission", func() {
 			Expect(runtimeClient.Get(ctx, client.ObjectKey{Name: "extension-admission-runtime-" + extensionName, Namespace: "garden"}, &resourcesv1alpha1.ManagedResource{})).To(Succeed())
 		})
 
-		It("should set selfHostedShoot=true in clusterTypes when runtime cluster is a self-hosted shoot", func() {
+		It("should set selfHostedShootCluster=true in clusterTypes when runtime cluster is a self-hosted shoot", func() {
 			kubeSystemNamespace := &corev1.Namespace{}
 			Expect(runtimeClient.Get(ctx, client.ObjectKey{Name: metav1.NamespaceSystem}, kubeSystemNamespace)).To(Succeed())
 			patch := client.MergeFrom(kubeSystemNamespace.DeepCopy())
@@ -196,8 +196,8 @@ var _ = Describe("Admission", func() {
 			expectedRuntimeValues := map[string]any{
 				"gardener": map[string]any{
 					"clusterTypes": map[string]bool{
-						"gardenRuntimeCluster": true,
-						"selfHostedShoot":      true,
+						"gardenRuntimeCluster":   true,
+						"selfHostedShootCluster": true,
 					},
 					"runtimeCluster": map[string]any{
 						"priorityClassName": "gardener-garden-system-400",

--- a/pkg/operator/controller/extension/extension/admission/admission_test.go
+++ b/pkg/operator/controller/extension/extension/admission/admission_test.go
@@ -75,6 +75,9 @@ var _ = Describe("Admission", func() {
 
 		admission = New(runtimeClientSet, &events.FakeRecorder{}, "garden", ociRegistry)
 
+		kubeSystemNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem}}
+		Expect(runtimeClient.Create(ctx, kubeSystemNamespace)).To(Succeed())
+
 		extensionName = "test-extension"
 		extension = &operatorv1alpha1.Extension{
 			ObjectMeta: metav1.ObjectMeta{
@@ -156,6 +159,7 @@ var _ = Describe("Admission", func() {
 				"gardener": map[string]any{
 					"clusterTypes": map[string]bool{
 						"gardenRuntimeCluster": true,
+						"selfHostedShoot":      false,
 					},
 					"runtimeCluster": map[string]any{
 						"priorityClassName": "gardener-garden-system-400",
@@ -177,6 +181,42 @@ var _ = Describe("Admission", func() {
 			Expect(admission.Reconcile(ctx, log, virtualClientSet, genericKubeconfigSecretName, extension)).To(Succeed())
 			Expect(runtimeClient.Get(ctx, client.ObjectKey{Name: "extension-admission-virtual-" + extensionName, Namespace: "garden"}, &resourcesv1alpha1.ManagedResource{})).To(Succeed())
 			Expect(runtimeClient.Get(ctx, client.ObjectKey{Name: "extension-admission-runtime-" + extensionName, Namespace: "garden"}, &resourcesv1alpha1.ManagedResource{})).To(Succeed())
+		})
+
+		It("should set selfHostedShoot=true in clusterTypes when runtime cluster is a self-hosted shoot", func() {
+			kubeSystemNamespace := &corev1.Namespace{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKey{Name: metav1.NamespaceSystem}, kubeSystemNamespace)).To(Succeed())
+			patch := client.MergeFrom(kubeSystemNamespace.DeepCopy())
+			metav1.SetMetaDataLabel(&kubeSystemNamespace.ObjectMeta, "gardener.cloud/role", "shoot")
+			Expect(runtimeClient.Patch(ctx, kubeSystemNamespace, patch)).To(Succeed())
+
+			ociRegistry.AddArtifact(&gardencorev1.OCIRepository{Ref: &ociRefApplication}, []byte("virtual-chart"))
+			ociRegistry.AddArtifact(&gardencorev1.OCIRepository{Ref: &ociRefRuntime}, []byte("runtime-chart"))
+
+			expectedRuntimeValues := map[string]any{
+				"gardener": map[string]any{
+					"clusterTypes": map[string]bool{
+						"gardenRuntimeCluster": true,
+						"selfHostedShoot":      true,
+					},
+					"runtimeCluster": map[string]any{
+						"priorityClassName": "gardener-garden-system-400",
+					},
+					"virtualCluster": map[string]any{
+						"enabled":   true,
+						"namespace": "extension-" + extensionName,
+					},
+				},
+			}
+
+			chartRenderer.EXPECT().RenderArchive([]byte("virtual-chart"), extension.Name, fmt.Sprintf("extension-%s", extension.Name), gomock.Any()).Return(&chartrenderer.RenderedChart{}, nil)
+			chartRenderer.EXPECT().RenderArchive([]byte("runtime-chart"), extension.Name, "garden", expectedRuntimeValues).Return(&chartrenderer.RenderedChart{}, nil)
+
+			defer test.WithVar(&retry.Until, func(_ context.Context, _ time.Duration, _ retry.Func) error {
+				return nil
+			})()
+
+			Expect(admission.Reconcile(ctx, log, virtualClientSet, genericKubeconfigSecretName, extension)).To(Succeed())
 		})
 
 		It("should succeed if admission deployment is not defined", func() {

--- a/pkg/operator/controller/extension/extension/admission/admission_test.go
+++ b/pkg/operator/controller/extension/extension/admission/admission_test.go
@@ -139,6 +139,9 @@ var _ = Describe("Admission", func() {
 			expectedVirtualValues := map[string]any{
 				"foo": "bar",
 				"gardener": map[string]any{
+					"clusterTypes": map[string]bool{
+						"gardenCluster": true,
+					},
 					"virtualCluster": map[string]any{
 						"enabled": true,
 						"serviceAccount": map[string]any{
@@ -151,6 +154,9 @@ var _ = Describe("Admission", func() {
 			expectedRuntimeValues := map[string]any{
 				"foo": "bar",
 				"gardener": map[string]any{
+					"clusterTypes": map[string]bool{
+						"gardenRuntimeCluster": true,
+					},
 					"runtimeCluster": map[string]any{
 						"priorityClassName": "gardener-garden-system-400",
 					},

--- a/pkg/operator/controller/extension/extension/runtime/runtime.go
+++ b/pkg/operator/controller/extension/extension/runtime/runtime.go
@@ -101,8 +101,8 @@ func (d *deployer) createOrUpdateResources(ctx context.Context, extension *opera
 	gardenerValues := map[string]any{
 		"gardener": map[string]any{
 			"clusterTypes": map[string]any{
-				"gardenRuntimeCluster":   true,
-				"selfHostedShootCluster": isSelfHostedShoot,
+				v1beta1constants.ClusterTypeGardenRuntimeCluster:   true,
+				v1beta1constants.ClusterTypeSelfHostedShootCluster: isSelfHostedShoot,
 			},
 			"runtimeCluster": map[string]any{
 				// TODO(timuthy): Remove this field after Gardener v1.159.0 has been released.

--- a/pkg/operator/controller/extension/extension/runtime/runtime.go
+++ b/pkg/operator/controller/extension/extension/runtime/runtime.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
 	chartutils "github.com/gardener/gardener/pkg/utils/chart"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/gardener/operator"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
@@ -92,10 +93,16 @@ func (d *deployer) createOrUpdateResources(ctx context.Context, extension *opera
 		return fmt.Errorf("failed pulling Helm chart from OCI repository %q: %w", extension.Spec.Deployment.ExtensionDeployment.Helm.OCIRepository.GetURL(), err)
 	}
 
+	isSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, d.runtimeClientSet.Client())
+	if err != nil {
+		return fmt.Errorf("failed checking whether the runtime cluster is a self-hosted shoot: %w", err)
+	}
+
 	gardenerValues := map[string]any{
 		"gardener": map[string]any{
 			"clusterTypes": map[string]any{
-				"gardenRuntimeCluster": "true",
+				"gardenRuntimeCluster": true,
+				"selfHostedShoot":      isSelfHostedShoot,
 			},
 			"runtimeCluster": map[string]any{
 				// TODO(timuthy): Remove this field after Gardener v1.153.0 has been released.

--- a/pkg/operator/controller/extension/extension/runtime/runtime.go
+++ b/pkg/operator/controller/extension/extension/runtime/runtime.go
@@ -105,7 +105,7 @@ func (d *deployer) createOrUpdateResources(ctx context.Context, extension *opera
 				"selfHostedShoot":      isSelfHostedShoot,
 			},
 			"runtimeCluster": map[string]any{
-				// TODO(timuthy): Remove this field after Gardener v1.153.0 has been released.
+				// TODO(timuthy): Remove this field after Gardener v1.159.0 has been released.
 				"enabled":           "true",
 				"priorityClassName": priorityClassName,
 			},

--- a/pkg/operator/controller/extension/extension/runtime/runtime.go
+++ b/pkg/operator/controller/extension/extension/runtime/runtime.go
@@ -94,7 +94,11 @@ func (d *deployer) createOrUpdateResources(ctx context.Context, extension *opera
 
 	gardenerValues := map[string]any{
 		"gardener": map[string]any{
+			"clusterTypes": map[string]any{
+				"gardenRuntimeCluster": "true",
+			},
 			"runtimeCluster": map[string]any{
+				// TODO(timuthy): Remove this field after Gardener v1.153.0 has been released.
 				"enabled":           "true",
 				"priorityClassName": priorityClassName,
 			},

--- a/pkg/operator/controller/extension/extension/runtime/runtime.go
+++ b/pkg/operator/controller/extension/extension/runtime/runtime.go
@@ -101,8 +101,8 @@ func (d *deployer) createOrUpdateResources(ctx context.Context, extension *opera
 	gardenerValues := map[string]any{
 		"gardener": map[string]any{
 			"clusterTypes": map[string]any{
-				"gardenRuntimeCluster": true,
-				"selfHostedShoot":      isSelfHostedShoot,
+				"gardenRuntimeCluster":   true,
+				"selfHostedShootCluster": isSelfHostedShoot,
 			},
 			"runtimeCluster": map[string]any{
 				// TODO(timuthy): Remove this field after Gardener v1.159.0 has been released.

--- a/pkg/operator/controller/extension/extension/runtime/runtime_test.go
+++ b/pkg/operator/controller/extension/extension/runtime/runtime_test.go
@@ -132,8 +132,8 @@ var _ = Describe("Runtime", func() {
 				"foo": "bar",
 				"gardener": map[string]any{
 					"clusterTypes": map[string]any{
-						"gardenRuntimeCluster": true,
-						"selfHostedShoot":      false,
+						"gardenRuntimeCluster":   true,
+						"selfHostedShootCluster": false,
 					},
 					"runtimeCluster": map[string]any{
 						"enabled":           "true",
@@ -160,7 +160,7 @@ var _ = Describe("Runtime", func() {
 			Expect(namespace.Annotations).To(HaveKeyWithValue("high-availability-config.resources.gardener.cloud/zones", "eu-west-1a,eu-west-1b"))
 		})
 
-		It("should set selfHostedShoot=true in clusterTypes when runtime cluster is a self-hosted shoot", func() {
+		It("should set selfHostedShootCluster=true in clusterTypes when runtime cluster is a self-hosted shoot", func() {
 			kubeSystemNamespace := &corev1.Namespace{}
 			Expect(runtimeClient.Get(ctx, client.ObjectKey{Name: metav1.NamespaceSystem}, kubeSystemNamespace)).To(Succeed())
 			patch := client.MergeFrom(kubeSystemNamespace.DeepCopy())
@@ -172,8 +172,8 @@ var _ = Describe("Runtime", func() {
 			expectedValues := map[string]any{
 				"gardener": map[string]any{
 					"clusterTypes": map[string]any{
-						"gardenRuntimeCluster": true,
-						"selfHostedShoot":      true,
+						"gardenRuntimeCluster":   true,
+						"selfHostedShootCluster": true,
 					},
 					"runtimeCluster": map[string]any{
 						"enabled":           "true",

--- a/pkg/operator/controller/extension/extension/runtime/runtime_test.go
+++ b/pkg/operator/controller/extension/extension/runtime/runtime_test.go
@@ -105,6 +105,9 @@ var _ = Describe("Runtime", func() {
 
 		priorityClass := &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "gardener-garden-system-200"}}
 		Expect(runtimeClient.Create(ctx, priorityClass)).To(Succeed())
+
+		kubeSystemNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem}}
+		Expect(runtimeClient.Create(ctx, kubeSystemNamespace)).To(Succeed())
 	})
 
 	AfterEach(func() {
@@ -129,7 +132,8 @@ var _ = Describe("Runtime", func() {
 				"foo": "bar",
 				"gardener": map[string]any{
 					"clusterTypes": map[string]any{
-						"gardenRuntimeCluster": "true",
+						"gardenRuntimeCluster": true,
+						"selfHostedShoot":      false,
 					},
 					"runtimeCluster": map[string]any{
 						"enabled":           "true",
@@ -154,6 +158,38 @@ var _ = Describe("Runtime", func() {
 			Expect(namespace.Labels).To(HaveKeyWithValue("networking.gardener.cloud/access-target-apiserver", "allowed"))
 			Expect(namespace.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/enforce", "baseline"))
 			Expect(namespace.Annotations).To(HaveKeyWithValue("high-availability-config.resources.gardener.cloud/zones", "eu-west-1a,eu-west-1b"))
+		})
+
+		It("should set selfHostedShoot=true in clusterTypes when runtime cluster is a self-hosted shoot", func() {
+			kubeSystemNamespace := &corev1.Namespace{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKey{Name: metav1.NamespaceSystem}, kubeSystemNamespace)).To(Succeed())
+			patch := client.MergeFrom(kubeSystemNamespace.DeepCopy())
+			metav1.SetMetaDataLabel(&kubeSystemNamespace.ObjectMeta, "gardener.cloud/role", "shoot")
+			Expect(runtimeClient.Patch(ctx, kubeSystemNamespace, patch)).To(Succeed())
+
+			ociRegistry.AddArtifact(&gardencorev1.OCIRepository{Ref: &ociRef}, []byte("extension-chart"))
+
+			expectedValues := map[string]any{
+				"gardener": map[string]any{
+					"clusterTypes": map[string]any{
+						"gardenRuntimeCluster": true,
+						"selfHostedShoot":      true,
+					},
+					"runtimeCluster": map[string]any{
+						"enabled":           "true",
+						"priorityClassName": "gardener-garden-system-200",
+					},
+				},
+			}
+
+			chartRenderer.EXPECT().RenderArchive([]byte("extension-chart"), extension.Name, "runtime-extension-test-extension", expectedValues).Return(&chartrenderer.RenderedChart{}, nil)
+
+			defer test.WithVar(&retry.Until, func(_ context.Context, _ time.Duration, _ retry.Func) error {
+				return nil
+			})()
+
+			_, err := runtime.Reconcile(ctx, log, extension)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should succeed if extension deployment is not defined", func() {

--- a/pkg/operator/controller/extension/extension/runtime/runtime_test.go
+++ b/pkg/operator/controller/extension/extension/runtime/runtime_test.go
@@ -128,6 +128,9 @@ var _ = Describe("Runtime", func() {
 			expectedValues := map[string]any{
 				"foo": "bar",
 				"gardener": map[string]any{
+					"clusterTypes": map[string]any{
+						"gardenRuntimeCluster": "true",
+					},
 					"runtimeCluster": map[string]any{
 						"enabled":           "true",
 						"priorityClassName": "gardener-garden-system-200",

--- a/pkg/utils/gardener/gardenlet/gardenlet.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
@@ -27,6 +29,18 @@ import (
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 )
+
+// ClusterIsShoot returns 'true' if the cluster is a shoot cluster, determined by the presence of the shoot-info
+// ConfigMap in the kube-system namespace.
+func ClusterIsShoot(ctx context.Context, seedClient client.Reader) (bool, error) {
+	if err := seedClient.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: v1beta1constants.ConfigMapNameShootInfo}, &corev1.ConfigMap{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
 
 // ClusterIsGarden returns 'true' if the cluster is registered as a Garden cluster.
 func ClusterIsGarden(ctx context.Context, seedClient client.Reader) (bool, error) {

--- a/pkg/utils/gardener/gardenlet/gardenlet.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +23,7 @@ import (
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
@@ -52,6 +54,19 @@ func ClusterIsGarden(ctx context.Context, seedClient client.Reader) (bool, error
 		seedIsGarden = false
 	}
 	return seedIsGarden, nil
+}
+
+// ClusterIsSeed returns 'true' if the cluster is registered as a Seed cluster.
+func ClusterIsSeed(ctx context.Context, seedClient client.Reader) (bool, error) {
+	clustersCRD := &metav1.PartialObjectMetadata{}
+	clustersCRD.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+	if err := seedClient.Get(ctx, client.ObjectKey{Name: extensionsv1alpha1.SchemeGroupVersion.WithResource("clusters").GroupResource().String()}, clustersCRD); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // SetDefaultGardenClusterAddress sets the default garden cluster address in the given gardenlet configuration if it is not already set.

--- a/pkg/utils/gardener/gardenlet/gardenlet_test.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,6 +24,7 @@ import (
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	. "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
@@ -69,6 +71,35 @@ var _ = Describe("Gardenlet", func() {
 				Build()
 
 			Expect(ClusterIsGarden(ctx, fakeClient)).To(BeFalse())
+		})
+	})
+
+	Describe("#ClusterIsSeed", func() {
+		var (
+			ctx        context.Context
+			fakeClient client.Client
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.SeedScheme).
+				Build()
+		})
+
+		It("should return that the cluster is a seed cluster", func() {
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "clusters.extensions.gardener.cloud",
+				},
+			}
+			Expect(fakeClient.Create(ctx, crd)).To(Succeed())
+
+			Expect(ClusterIsSeed(ctx, fakeClient)).To(BeTrue())
+		})
+
+		It("should return that the cluster is not a seed cluster because the clusters CRD is not found", func() {
+			Expect(ClusterIsSeed(ctx, fakeClient)).To(BeFalse())
 		})
 	})
 

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
@@ -88,6 +88,7 @@ var _ = BeforeSuite(func() {
 				Paths: []string{
 					filepath.Join("..", "..", "..", "..", "..", "example", "resource-manager", "10-crd-resources.gardener.cloud_managedresources.yaml"),
 					filepath.Join("..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_gardens.yaml"),
+					filepath.Join("..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_clusters.yaml"),
 				},
 			},
 			ErrorIfCRDPathMissing: true,

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -1058,7 +1058,7 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 			}).Should(ContainCondition(OfType(gardencorev1beta1.ControllerInstallationInstalled), WithStatus(gardencorev1beta1.ConditionTrue)))
 		})
 
-		Context("when seed is garden at the same time", func() {
+		When("seed is garden at the same time", func() {
 			BeforeEach(func() {
 				garden := &operatorv1alpha1.Garden{
 					ObjectMeta: metav1.ObjectMeta{GenerateName: "garden-"},

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -302,6 +302,7 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 			Expect(string(valuesBytes)).To(Equal(`gardener:
   clusterTypes:
     gardenRuntimeCluster: false
+    seedCluster: true
   garden:
     clusterIdentity: ` + gardenClusterIdentity + `
     genericKubeconfigSecretName: ` + genericKubeconfigSecret.Name + `

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -300,6 +300,8 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(string(valuesBytes)).To(Equal(`gardener:
+  clusterTypes:
+    gardenRuntimeCluster: false
   garden:
     clusterIdentity: ` + gardenClusterIdentity + `
     genericKubeconfigSecretName: ` + genericKubeconfigSecret.Name + `
@@ -1100,6 +1102,29 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 					namespace := &corev1.Namespace{}
 					g.Expect(testClient.Get(ctx, client.ObjectKey{Name: "extension-" + controllerInstallation.Name}, namespace)).To(Succeed())
 					g.Expect(namespace.Labels).To(HaveKeyWithValue("networking.gardener.cloud/access-target-apiserver", "allowed"))
+				}).Should(Succeed())
+			})
+
+			It("should set gardener.garden.runtimeCluster.enabled=true in Helm values", func() {
+				By("Ensure chart was deployed with runtimeCluster enabled")
+				Eventually(func(g Gomega) {
+					managedResource := &resourcesv1alpha1.ManagedResource{}
+					g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: "garden", Name: controllerInstallation.Name}, managedResource)).To(Succeed())
+
+					secret := &corev1.Secret{}
+					g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: managedResource.Namespace, Name: managedResource.Spec.SecretRefs[0].Name}, secret)).To(Succeed())
+
+					configMap := &corev1.ConfigMap{}
+					g.Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_config.yaml"], configMap)).To(Succeed())
+
+					values := make(map[string]any)
+					g.Expect(yaml.Unmarshal([]byte(configMap.Data["values"]), &values)).To(Succeed())
+
+					gardenerValues, ok := values["gardener"].(map[string]any)
+					g.Expect(ok).To(BeTrue())
+					clusterTypes, ok := gardenerValues["clusterTypes"].(map[string]any)
+					g.Expect(ok).To(BeTrue())
+					g.Expect(clusterTypes).To(HaveKeyWithValue("gardenRuntimeCluster", true))
 				}).Should(Succeed())
 			})
 		})

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -303,6 +303,7 @@ var _ = Describe("ControllerInstallation controller tests", func() {
   clusterTypes:
     gardenRuntimeCluster: false
     seedCluster: true
+    selfHostedShootCluster: false
   garden:
     clusterIdentity: ` + gardenClusterIdentity + `
     genericKubeconfigSecretName: ` + genericKubeconfigSecret.Name + `
@@ -832,10 +833,12 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 				Expect(yaml.Unmarshal([]byte(configMap.Data["values"]), &values)).To(Succeed())
 
 				gardenerValues := values["gardener"].(map[string]any)
-				Expect(gardenerValues).To(HaveKeyWithValue("selfHostedShootCluster", true))
 				Expect(gardenerValues).To(HaveKeyWithValue("version", "1.2.3"))
 				Expect(gardenerValues).NotTo(HaveKey("seed"))
 				Expect(gardenerValues).To(HaveKey("shoot"))
+				clusterTypes, ok := gardenerValues["clusterTypes"].(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(clusterTypes).To(HaveKeyWithValue("selfHostedShootCluster", true))
 
 				By("Ensure deployment has SHOOT_NAME and SHOOT_NAMESPACE env vars but no SEED_NAME")
 				deployment := &appsv1.Deployment{}

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -304,6 +304,7 @@ var _ = Describe("ControllerInstallation controller tests", func() {
     gardenRuntimeCluster: false
     seedCluster: true
     selfHostedShootCluster: false
+    shootCluster: false
   garden:
     clusterIdentity: ` + gardenClusterIdentity + `
     genericKubeconfigSecretName: ` + genericKubeconfigSecret.Name + `
@@ -1129,6 +1130,42 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 					clusterTypes, ok := gardenerValues["clusterTypes"].(map[string]any)
 					g.Expect(ok).To(BeTrue())
 					g.Expect(clusterTypes).To(HaveKeyWithValue("gardenRuntimeCluster", true))
+				}).Should(Succeed())
+			})
+		})
+
+		Context("when seed is a shoot cluster at the same time", func() {
+			BeforeEach(func() {
+				shootInfoConfigMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      v1beta1constants.ConfigMapNameShootInfo,
+						Namespace: metav1.NamespaceSystem,
+					},
+				}
+				Expect(testClient.Create(ctx, shootInfoConfigMap)).To(Succeed())
+				DeferCleanup(func() { Expect(testClient.Delete(ctx, shootInfoConfigMap)).To(Succeed()) })
+			})
+
+			It("should set shootCluster=true in Helm values", func() {
+				By("Ensure chart was deployed with shootCluster enabled")
+				Eventually(func(g Gomega) {
+					managedResource := &resourcesv1alpha1.ManagedResource{}
+					g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: "garden", Name: controllerInstallation.Name}, managedResource)).To(Succeed())
+
+					secret := &corev1.Secret{}
+					g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: managedResource.Namespace, Name: managedResource.Spec.SecretRefs[0].Name}, secret)).To(Succeed())
+
+					configMap := &corev1.ConfigMap{}
+					g.Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_config.yaml"], configMap)).To(Succeed())
+
+					values := make(map[string]any)
+					g.Expect(yaml.Unmarshal([]byte(configMap.Data["values"]), &values)).To(Succeed())
+
+					gardenerValues, ok := values["gardener"].(map[string]any)
+					g.Expect(ok).To(BeTrue())
+					clusterTypes, ok := gardenerValues["clusterTypes"].(map[string]any)
+					g.Expect(ok).To(BeTrue())
+					g.Expect(clusterTypes).To(HaveKeyWithValue("shootCluster", true))
 				}).Should(Succeed())
 			})
 		})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR introduces cluster type values, allowing extension and admission charts to deploy or skip resources depending on the cluster setup - e.g. to avoid conflicts with global resources.

- `ControllerInstallation` controller passes the following values:
```
gardener:
  clusterTypes:
    gardenCluster: {true|false}
    gardenRuntimeCluster: {true|false}
    seedCluster: {true|false}
    shootCluster: {true|false}
    selfHostedShootCluster: {true|false}
```

- `Extension/Admission` controller passed the following values:
```
gardener:
  clusterTypes:
    gardenCluster: {true|false}
    gardenRuntimeCluster: {true|false}
    selfHostedShootCluster: {true|false}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke @kon-angelo

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature dependency
The `ControllerInstallation` controller as well as the `Extension` and `Admission` controller of the Gardener Operator now pass `gardener.clusterTypes` values to the Helm chart based deployments, allowing them to deploy or skip resources depending on the cluster setup. Read more about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md) and [here](https://github.com/gardener/gardener/blob/master/docs/extensions/registration.md).
```
```breaking dependency
The following extension and admission chart value have been deprecated and will be removed soon:
- `gardener.runtimeCluster.enabled` (replaced by two new cases: `.gardener.runtimeCluster` is set if deployment targets the garden runtime cluster, `gardener.clusterTypes.runtimeGardenCluster` is `true` if cluster is a garden runtime cluster - read more about [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)).
- `gardener.virtualCluster.enabled` (no substitution since non virtual garden clusters are not supported anymore)
```