### PR TITLE
Set `GOTOOLCHAIN` explicitly to catch Go update incompatibilities early

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,6 +83,16 @@
       ],
       datasourceTemplate: 'docker',
     },
+    {
+      // Detection for GOTOOLCHAIN in Makefile (does not match the _VERSION pattern of the ci-infra preset).
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^Makefile$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)\\s+export GOTOOLCHAIN\\s*\\??=\\s*go(?<currentValue>[^\\s]+)',
+      ],
+    },
   ],
   separateMinorPatch: true,
   packageRules: [

--- a/.github/workflows/golang-test-images.yaml
+++ b/.github/workflows/golang-test-images.yaml
@@ -24,10 +24,6 @@ jobs:
           {
             "images": [
               {
-                "version": "1.25",
-                "image": "golang:1.25.14-bookworm"
-              },
-              {
                 "version": "1.26",
                 "image": "golang:1.26.7-bookworm"
               }

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ SHELL=/usr/bin/env bash -o pipefail
 
 export SYSTEM_ARCH := $(SYSTEM_ARCH)
 
+# Use a specific Go toolchain version to ensure consistent builds across different environments.
+# renovate: datasource=golang-version depName=go
+# TODO(LucaBernstein): Revert to `?=`
+export GOTOOLCHAIN := go1.27.0
+
 #########################################
 # Tools                                 #
 #########################################

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,7 @@ export SYSTEM_ARCH := $(SYSTEM_ARCH)
 
 # Use a specific Go toolchain version to ensure consistent builds across different environments.
 # renovate: datasource=golang-version depName=go
-# TODO(LucaBernstein): Revert to `?=`
-export GOTOOLCHAIN := go1.27.0
+export GOTOOLCHAIN ?= go1.26.5
 
 #########################################
 # Tools                                 #

--- a/hack/tools/image/Dockerfile
+++ b/hack/tools/image/Dockerfile
@@ -13,6 +13,7 @@ RUN echo "Installing Packages ..." \
 # builder
 FROM base AS builder
 WORKDIR /go/src/github.com/gardener/gardener
+ENV GOTOOLCHAIN=local
 COPY . .
 RUN make create-tools-bin TOOLS_BIN_DIR=hack/tools/bin && \
     rm -rf /go/src/github.com/gardener/gardener/hack/tools/bin/work

--- a/hack/tools/image/Dockerfile
+++ b/hack/tools/image/Dockerfile
@@ -1,7 +1,6 @@
 # base
 ARG image
 FROM ${image} AS base
-ENV GOTOOLCHAIN=auto
 RUN echo "Installing Packages ..." \
 		&& apt-get update \
 		&& apt-get install -y --no-install-recommends \


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery dev-productivity
/kind bug

**What this PR does / why we need it**:
We saw a problem where GitHub Actions updated their Go version, but the checks were not executed. In Prow, the old version was used. Errors with the new Go version and golangci-lint were not discovered. By explicitly setting this GOTOOLCHAIN version, the new Go version will already be used in Prow, uncovering problems early.

**Which issue(s) this PR fixes**:
- Example failure: https://github.com/gardener/gardener-landscape-kit/actions/runs/32725066701/job/97424382640
- Not executed for gardener/gardener, would have failed upon release: https://github.com/gardener/gardener/actions/runs/32702976743/job/97358120720

**Special notes for your reviewer**:
/cc @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
