### PR TITLE
gardenlet/backupentry: reduce etcd load on controller restart

### DIFF
--- a/charts/gardener/gardenlet/templates/helpers.tpl
+++ b/charts/gardener/gardenlet/templates/helpers.tpl
@@ -163,6 +163,12 @@ shootClientConnection:
 controllers:
   backupBucket:
     concurrentSyncs: {{ required ".Values.config.controllers.backupBucket.concurrentSyncs is required" .Values.config.controllers.backupBucket.concurrentSyncs }}
+    {{- if .Values.config.controllers.backupBucket.syncJitterPeriod }}
+    syncJitterPeriod: {{ .Values.config.controllers.backupBucket.syncJitterPeriod }}
+    {{- end }}
+    {{- if .Values.config.controllers.backupBucket.jitterUpdates }}
+    jitterUpdates: {{ .Values.config.controllers.backupBucket.jitterUpdates }}
+    {{- end }}
   backupEntry:
     concurrentSyncs: {{ required ".Values.config.controllers.backupEntry.concurrentSyncs is required" .Values.config.controllers.backupEntry.concurrentSyncs }}
     {{- if .Values.config.controllers.backupEntry.deletionGracePeriodHours }}
@@ -171,6 +177,12 @@ controllers:
     {{- if .Values.config.controllers.backupEntry.deletionGracePeriodShootPurposes }}
     deletionGracePeriodShootPurposes:
 {{ toYaml .Values.config.controllers.backupEntry.deletionGracePeriodShootPurposes | indent 4 }}
+    {{- end }}
+    {{- if .Values.config.controllers.backupEntry.syncJitterPeriod }}
+    syncJitterPeriod: {{ .Values.config.controllers.backupEntry.syncJitterPeriod }}
+    {{- end }}
+    {{- if .Values.config.controllers.backupEntry.jitterUpdates }}
+    jitterUpdates: {{ .Values.config.controllers.backupEntry.jitterUpdates }}
     {{- end }}
   bastion:
     concurrentSyncs: {{ required ".Values.config.controllers.bastion.concurrentSyncs is required" .Values.config.controllers.bastion.concurrentSyncs }}

--- a/charts/gardener/gardenlet/test/chart_test.go
+++ b/charts/gardener/gardenlet/test/chart_test.go
@@ -331,13 +331,13 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				validateKubeconfigSecret(ctx, c, secret, bootstrapKubeconfigContent, expectedLabels, "gardenlet-kubeconfig-bootstrap")
 			}
 		},
-		Entry("verify the default values for the Gardenlet chart & the Gardenlet component config", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-e03f6438"}),
+		Entry("verify the default values for the Gardenlet chart & the Gardenlet component config", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-d392f02b"}),
 		Entry("verify Gardenlet with component config having the Garden client connection kubeconfig set", new("dummy garden kubeconfig"), nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{
-			"gardenlet-configmap":         "gardenlet-configmap-b09359e9",
+			"gardenlet-configmap":         "gardenlet-configmap-ea1c57ee",
 			"gardenlet-kubeconfig-garden": "gardenlet-kubeconfig-garden-8c9ae097",
 		}),
 		Entry("verify Gardenlet with component config having the Seed client connection kubeconfig set", nil, new("dummy seed kubeconfig"), nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{
-			"gardenlet-configmap":       "gardenlet-configmap-916a9d6b",
+			"gardenlet-configmap":       "gardenlet-configmap-fb858ee2",
 			"gardenlet-kubeconfig-seed": "gardenlet-kubeconfig-seed-662d92ae",
 		}),
 		Entry("verify Gardenlet with component config having a Bootstrap kubeconfig set", nil, nil, &corev1.SecretReference{
@@ -347,7 +347,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 			Name:      "gardenlet-kubeconfig",
 			Namespace: v1beta1constants.GardenNamespace,
 		}, new("dummy bootstrap kubeconfig"), nil, nil, nil, nil, nil, map[string]string{
-			"gardenlet-configmap": "gardenlet-configmap-452f30b5",
+			"gardenlet-configmap": "gardenlet-configmap-59ffddff",
 		}),
 		Entry("verify that the SeedConfig is set in the component config Config Map", nil, nil, nil, nil, nil,
 			&gardenletconfigv1alpha1.SeedConfig{
@@ -359,7 +359,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 						Provider: gardencorev1beta1.SeedProvider{},
 					},
 				},
-			}, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-f3c6b5a9"}),
+			}, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-508850cc"}),
 		Entry("verify deployment with two replica and three zones", nil, nil, nil, nil, nil,
 			&gardenletconfigv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
@@ -374,7 +374,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				},
 			}, &seedmanagement.GardenletDeployment{
 				ReplicaCount: new(int32(2)),
-			}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-7ce49ea8"}),
+			}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-5da1b92c"}),
 		Entry("verify deployment with only one replica", nil, nil, nil, nil, nil,
 			&gardenletconfigv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
@@ -389,7 +389,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				},
 			}, &seedmanagement.GardenletDeployment{
 				ReplicaCount: new(int32(1)),
-			}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-7ce49ea8"}),
+			}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-5da1b92c"}),
 		Entry("verify deployment with only one zone", nil, nil, nil, nil, nil,
 			&gardenletconfigv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
@@ -402,23 +402,23 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 						},
 					},
 				},
-			}, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-3a4b364a"}),
+			}, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-8e5c55ee"}),
 		Entry("verify deployment with image vector override", nil, nil, nil, nil, nil, nil, nil, new("dummy-override-content"), nil, nil, map[string]string{
-			"gardenlet-configmap":             "gardenlet-configmap-e03f6438",
+			"gardenlet-configmap":             "gardenlet-configmap-d392f02b",
 			"gardenlet-imagevector-overwrite": "gardenlet-imagevector-overwrite-32ecb769",
 		}),
 		Entry("verify deployment with component image vector override", nil, nil, nil, nil, nil, nil, nil, nil, new("dummy-override-content"), nil, map[string]string{
-			"gardenlet-configmap":                        "gardenlet-configmap-e03f6438",
+			"gardenlet-configmap":                        "gardenlet-configmap-d392f02b",
 			"gardenlet-imagevector-overwrite-components": "gardenlet-imagevector-overwrite-components-53f94952",
 		}),
 
 		Entry("verify deployment with custom replica count", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			ReplicaCount: new(int32(3)),
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-e03f6438"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-d392f02b"}),
 
 		Entry("verify deployment with service account", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			ServiceAccountName: new("ax"),
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-e03f6438"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-d392f02b"}),
 
 		Entry("verify deployment with resources", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			Resources: &corev1.ResourceRequirements{
@@ -430,19 +430,19 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					corev1.ResourceMemory: resource.MustParse("25Mi"),
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-e03f6438"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-d392f02b"}),
 
 		Entry("verify deployment with pod labels", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			PodLabels: map[string]string{
 				"x": "y",
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-e03f6438"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-d392f02b"}),
 
 		Entry("verify deployment with pod annotations", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			PodAnnotations: map[string]string{
 				"x": "y",
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-e03f6438"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-d392f02b"}),
 
 		Entry("verify deployment with additional volumes", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			AdditionalVolumes: []corev1.Volume{
@@ -451,7 +451,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					VolumeSource: corev1.VolumeSource{},
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-e03f6438"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-d392f02b"}),
 
 		Entry("verify deployment with additional volume mounts", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			AdditionalVolumeMounts: []corev1.VolumeMount{
@@ -459,7 +459,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					Name: "a",
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-e03f6438"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-d392f02b"}),
 
 		Entry("verify deployment with env variables", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			Env: []corev1.EnvVar{
@@ -468,7 +468,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					Value: "XY",
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-e03f6438"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-d392f02b"}),
 	)
 })
 

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -671,10 +671,18 @@ func ComputeExpectedGardenletConfiguration(
 			CacheSyncTimeout: &metav1.Duration{Duration: 2 * time.Minute},
 			BackupBucket: &gardenletconfigv1alpha1.BackupBucketControllerConfiguration{
 				ConcurrentSyncs: &twenty,
+				JitterUpdates:   new(false),
+				SyncJitterPeriod: &metav1.Duration{
+					Duration: 300000000000,
+				},
 			},
 			BackupEntry: &gardenletconfigv1alpha1.BackupEntryControllerConfiguration{
 				ConcurrentSyncs:          &twenty,
 				DeletionGracePeriodHours: &zero,
+				JitterUpdates:            new(false),
+				SyncJitterPeriod: &metav1.Duration{
+					Duration: 300000000000,
+				},
 			},
 			Bastion: &gardenletconfigv1alpha1.BastionControllerConfiguration{
 				ConcurrentSyncs: &twenty,

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -71,11 +71,15 @@ config:
   controllers:
     backupBucket:
       concurrentSyncs: 20
+      syncJitterPeriod: 5m
+      jitterUpdates: false
     backupEntry:
       concurrentSyncs: 20
     # deletionGracePeriodHours: 24
     # deletionGracePeriodShootPurposes:
     # - production
+      syncJitterPeriod: 5m
+      jitterUpdates: false
     bastion:
       concurrentSyncs: 20
     gardenlet:

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -214,6 +214,9 @@ The status from the reconciliation is reported in the `.status.lastOperation` fi
 
 If the `core.gardener.cloud/v1beta1.BackupBucket` is deleted, the controller deletes the generated secret in the garden cluster and the `extensions.gardener.cloud/v1alpha1.BackupBucket` resource in the seed cluster and it waits for the respective extension controller to remove its finalizers from the `extensions.gardener.cloud/v1alpha1.BackupBucket`. Then it deletes the secret in the seed cluster and finally removes the finalizers from the `core.gardener.cloud/v1beta1.BackupBucket` and the referred secret.
 
+On gardenlet restart, existing `BackupBucket`s are spread across a random delay up to `.controllers.backupBucket.syncJitterPeriod` (default: `5m`) before being enqueued, to avoid overloading the gardener-apiserver.
+When `.controllers.backupBucket.jitterUpdates` is `true` (default: `false`), spec-update events are also delayed by a random duration within `syncJitterPeriod` instead of being enqueued immediately.
+
 ### [`BackupEntry` Controller](../../pkg/gardenlet/controller/backupentry)
 
 The `BackupEntry` controller reconciles those `core.gardener.cloud/v1beta1.BackupEntry` resources whose `.spec.seedName` value is equal to the name of a `Seed` the respective gardenlet is responsible for.
@@ -240,6 +243,9 @@ Additionally, you can limit the [shoot purposes](../usage/shoot/shoot_purposes.m
 For example, if you set it to `[production]` then only the `BackupEntry`s for `Shoot`s with `.spec.purpose=production` will be deleted after the configured grace period. All others will be deleted immediately after the `Shoot` deletion.
 
 In case a `BackupEntry` is scheduled for future deletion but you want to delete it immediately, add the annotation `backupentry.core.gardener.cloud/force-deletion=true`.
+
+On gardenlet restart, existing `BackupEntry`s are spread across a random delay up to `.controllers.backupEntry.syncJitterPeriod` (default: `5m`) before being enqueued, to avoid overloading the gardener-apiserver.
+When `.controllers.backupEntry.jitterUpdates` is `true` (default: `false`), spec-update events are also delayed by a random duration within `syncJitterPeriod` instead of being enqueued immediately.
 
 ### [`Bastion` Controller](../../pkg/gardenlet/controller/bastion)
 
@@ -346,6 +352,9 @@ On `ManagedSeed` deletion, the controller first deletes the corresponding `Seed`
 Subsequently, it deletes the `gardenlet` instance within the shoot cluster.
 The controller also ensures the deletion of related `Seed` secrets.
 Finally, the dedicated `garden` namespace within the shoot cluster is deleted.
+
+On gardenlet restart, existing `ManagedSeed`s are spread across a random delay up to `.controllers.managedSeed.syncJitterPeriod` (default: `5m`) before being enqueued, to avoid overloading the gardener-apiserver.
+When `.controllers.managedSeed.jitterUpdates` is `true` (default: `false`), spec-update events are also delayed by a random duration within `syncJitterPeriod` instead of being enqueued immediately.
 
 ### [`NetworkPolicy` Controller](../../pkg/gardenlet/controller/networkpolicy)
 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -20,11 +20,15 @@ controllers:
     concurrentSyncs: 20
   backupBucket:
     concurrentSyncs: 20
+    syncJitterPeriod: 5m
+  # jitterUpdates: false
   backupEntry:
     concurrentSyncs: 20
     deletionGracePeriodHours: 0
   # deletionGracePeriodShootPurposes:
   # - production
+    syncJitterPeriod: 5m
+  # jitterUpdates: false
   controllerInstallation:
     concurrentSyncs: 20
   controllerInstallationCare:

--- a/pkg/apis/config/gardenlet/v1alpha1/defaults.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/defaults.go
@@ -218,6 +218,15 @@ func SetDefaults_BackupBucketControllerConfiguration(obj *BackupBucketController
 		v := DefaultControllerConcurrentSyncs
 		obj.ConcurrentSyncs = &v
 	}
+
+	if obj.SyncJitterPeriod == nil {
+		v := metav1.Duration{Duration: 5 * time.Minute}
+		obj.SyncJitterPeriod = &v
+	}
+
+	if obj.JitterUpdates == nil {
+		obj.JitterUpdates = new(false)
+	}
 }
 
 // SetDefaults_BackupEntryControllerConfiguration sets defaults for the backup entry controller.
@@ -230,6 +239,15 @@ func SetDefaults_BackupEntryControllerConfiguration(obj *BackupEntryControllerCo
 	if obj.DeletionGracePeriodHours == nil || *obj.DeletionGracePeriodHours < 0 {
 		v := DefaultBackupEntryDeletionGracePeriodHours
 		obj.DeletionGracePeriodHours = &v
+	}
+
+	if obj.SyncJitterPeriod == nil {
+		v := metav1.Duration{Duration: 5 * time.Minute}
+		obj.SyncJitterPeriod = &v
+	}
+
+	if obj.JitterUpdates == nil {
+		obj.JitterUpdates = new(false)
 	}
 }
 

--- a/pkg/apis/config/gardenlet/v1alpha1/defaults_test.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/defaults_test.go
@@ -178,15 +178,23 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			Expect(obj.Controllers.BackupBucket.ConcurrentSyncs).To(PointTo(Equal(20)))
+			Expect(obj.Controllers.BackupBucket.SyncJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
+			Expect(obj.Controllers.BackupBucket.JitterUpdates).To(PointTo(BeFalse()))
 		})
 
 		It("should not overwrite already set values for the backup bucket controller configuration", func() {
 			obj.Controllers = &GardenletControllerConfiguration{
-				BackupBucket: &BackupBucketControllerConfiguration{ConcurrentSyncs: new(10)},
+				BackupBucket: &BackupBucketControllerConfiguration{
+					ConcurrentSyncs:  new(10),
+					SyncJitterPeriod: &metav1.Duration{Duration: 2 * time.Minute},
+					JitterUpdates:    new(true),
+				},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			Expect(obj.Controllers.BackupBucket.ConcurrentSyncs).To(PointTo(Equal(10)))
+			Expect(obj.Controllers.BackupBucket.SyncJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 2 * time.Minute})))
+			Expect(obj.Controllers.BackupBucket.JitterUpdates).To(PointTo(BeTrue()))
 		})
 	})
 
@@ -197,6 +205,8 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Controllers.BackupEntry.ConcurrentSyncs).To(PointTo(Equal(20)))
 			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodHours).To(PointTo(Equal(0)))
 			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodShootPurposes).To(BeEmpty())
+			Expect(obj.Controllers.BackupEntry.SyncJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
+			Expect(obj.Controllers.BackupEntry.JitterUpdates).To(PointTo(BeFalse()))
 		})
 
 		It("should not overwrite already set values for the backup entry controller configuration", func() {
@@ -206,6 +216,8 @@ var _ = Describe("Defaults", func() {
 					ConcurrentSyncs:                  new(10),
 					DeletionGracePeriodHours:         new(1),
 					DeletionGracePeriodShootPurposes: deletionGracePeriodShootPurposes,
+					SyncJitterPeriod:                 &metav1.Duration{Duration: 2 * time.Minute},
+					JitterUpdates:                    new(true),
 				},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
@@ -213,6 +225,8 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Controllers.BackupEntry.ConcurrentSyncs).To(PointTo(Equal(10)))
 			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodHours).To(PointTo(Equal(1)))
 			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodShootPurposes).To(Equal(deletionGracePeriodShootPurposes))
+			Expect(obj.Controllers.BackupEntry.SyncJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 2 * time.Minute})))
+			Expect(obj.Controllers.BackupEntry.JitterUpdates).To(PointTo(BeTrue()))
 		})
 	})
 

--- a/pkg/apis/config/gardenlet/v1alpha1/types.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/types.go
@@ -220,11 +220,11 @@ type BackupBucketControllerConfiguration struct {
 	// +optional
 	ConcurrentSyncs *int `json:"concurrentSyncs,omitempty"`
 	// SyncJitterPeriod is a jitter duration for the reconciler sync that can be used to distribute the syncs randomly.
-	// If its value is greater than 0 then the managed seeds will not be enqueued immediately but only after a random
+	// If its value is greater than 0 then the backup buckets will not be enqueued immediately but only after a random
 	// duration between 0 and the configured value. It is defaulted to 5m.
 	// +optional
 	SyncJitterPeriod *metav1.Duration `json:"syncJitterPeriod,omitempty"`
-	// JitterUpdates enables enqueuing managed seeds with a random duration(jitter) in case of an update to the spec.
+	// JitterUpdates enables enqueuing backup buckets with a random duration(jitter) in case of an update to the spec.
 	// The applied jitterPeriod is taken from SyncJitterPeriod.
 	// +optional
 	JitterUpdates *bool `json:"jitterUpdates,omitempty"`
@@ -245,11 +245,11 @@ type BackupEntryControllerConfiguration struct {
 	// +optional
 	DeletionGracePeriodShootPurposes []gardencorev1beta1.ShootPurpose `json:"deletionGracePeriodShootPurposes,omitempty"`
 	// SyncJitterPeriod is a jitter duration for the reconciler sync that can be used to distribute the syncs randomly.
-	// If its value is greater than 0 then the managed seeds will not be enqueued immediately but only after a random
+	// If its value is greater than 0 then the backup entries will not be enqueued immediately but only after a random
 	// duration between 0 and the configured value. It is defaulted to 5m.
 	// +optional
 	SyncJitterPeriod *metav1.Duration `json:"syncJitterPeriod,omitempty"`
-	// JitterUpdates enables enqueuing managed seeds with a random duration(jitter) in case of an update to the spec.
+	// JitterUpdates enables enqueuing backup entries with a random duration(jitter) in case of an update to the spec.
 	// The applied jitterPeriod is taken from SyncJitterPeriod.
 	// +optional
 	JitterUpdates *bool `json:"jitterUpdates,omitempty"`

--- a/pkg/apis/config/gardenlet/v1alpha1/types.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/types.go
@@ -219,6 +219,15 @@ type BackupBucketControllerConfiguration struct {
 	// ConcurrentSyncs is the number of workers used for the controller to work on events.
 	// +optional
 	ConcurrentSyncs *int `json:"concurrentSyncs,omitempty"`
+	// SyncJitterPeriod is a jitter duration for the reconciler sync that can be used to distribute the syncs randomly.
+	// If its value is greater than 0 then the managed seeds will not be enqueued immediately but only after a random
+	// duration between 0 and the configured value. It is defaulted to 5m.
+	// +optional
+	SyncJitterPeriod *metav1.Duration `json:"syncJitterPeriod,omitempty"`
+	// JitterUpdates enables enqueuing managed seeds with a random duration(jitter) in case of an update to the spec.
+	// The applied jitterPeriod is taken from SyncJitterPeriod.
+	// +optional
+	JitterUpdates *bool `json:"jitterUpdates,omitempty"`
 }
 
 // BackupEntryControllerConfiguration defines the configuration of the BackupEntry
@@ -235,6 +244,15 @@ type BackupEntryControllerConfiguration struct {
 	// BackupEntries corresponding to Shoots with different purposes will be deleted immediately.
 	// +optional
 	DeletionGracePeriodShootPurposes []gardencorev1beta1.ShootPurpose `json:"deletionGracePeriodShootPurposes,omitempty"`
+	// SyncJitterPeriod is a jitter duration for the reconciler sync that can be used to distribute the syncs randomly.
+	// If its value is greater than 0 then the managed seeds will not be enqueued immediately but only after a random
+	// duration between 0 and the configured value. It is defaulted to 5m.
+	// +optional
+	SyncJitterPeriod *metav1.Duration `json:"syncJitterPeriod,omitempty"`
+	// JitterUpdates enables enqueuing managed seeds with a random duration(jitter) in case of an update to the spec.
+	// The applied jitterPeriod is taken from SyncJitterPeriod.
+	// +optional
+	JitterUpdates *bool `json:"jitterUpdates,omitempty"`
 }
 
 // BastionControllerConfiguration defines the configuration of the Bastion

--- a/pkg/apis/config/gardenlet/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/zz_generated.deepcopy.go
@@ -25,6 +25,16 @@ func (in *BackupBucketControllerConfiguration) DeepCopyInto(out *BackupBucketCon
 		*out = new(int)
 		**out = **in
 	}
+	if in.SyncJitterPeriod != nil {
+		in, out := &in.SyncJitterPeriod, &out.SyncJitterPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.JitterUpdates != nil {
+		in, out := &in.JitterUpdates, &out.JitterUpdates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -96,6 +106,16 @@ func (in *BackupEntryControllerConfiguration) DeepCopyInto(out *BackupEntryContr
 		in, out := &in.DeletionGracePeriodShootPurposes, &out.DeletionGracePeriodShootPurposes
 		*out = make([]v1beta1.ShootPurpose, len(*in))
 		copy(*out, *in)
+	}
+	if in.SyncJitterPeriod != nil {
+		in, out := &in.SyncJitterPeriod, &out.SyncJitterPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.JitterUpdates != nil {
+		in, out := &in.JitterUpdates, &out.JitterUpdates
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }

--- a/pkg/controllerutils/source.go
+++ b/pkg/controllerutils/source.go
@@ -73,7 +73,7 @@ func EnqueueWithJitterDelay(
 				return
 			}
 
-			// Objects with deletion timestamp and newly created managed seed will be enqueued immediately.
+			// Objects with deletion timestamp and newly created objects will be enqueued immediately.
 			// Generation is 1 for newly created objects.
 			if e.Object.GetDeletionTimestamp() != nil || e.Object.GetGeneration() == 1 {
 				q.Add(reconcileRequest(e.Object))

--- a/pkg/controllerutils/source.go
+++ b/pkg/controllerutils/source.go
@@ -7,12 +7,17 @@ package controllerutils
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 // EnqueueOnce is a source.Source that simply triggers the reconciler once by directly enqueueing an empty
@@ -38,3 +43,76 @@ func (h *HandleOnce[object, request]) Start(ctx context.Context, q workqueue.Typ
 var EnqueueAnonymously = handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {
 	return []reconcile.Request{{}}
 })
+
+// RandomDurationWithMetaDuration is an alias for `utils.RandomDurationWithMetaDuration`. Exposed for unit tests.
+var RandomDurationWithMetaDuration = utils.RandomDurationWithMetaDuration
+
+// EnqueueWithJitterDelay returns an EventHandler that enqueues objects with an optional jitter delay.
+// getObservedGeneration must return the object's ObservedGeneration and true, or 0 and false if the object type is unexpected.
+func EnqueueWithJitterDelay(
+	getObservedGeneration func(client.Object) (int64, bool),
+	jitterUpdates *bool,
+	syncJitterPeriod *metav1.Duration,
+) handler.EventHandler {
+	reconcileRequest := func(obj client.Object) reconcile.Request {
+		return reconcile.Request{NamespacedName: types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}}
+	}
+
+	addWithJitter := func(obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request], jitter bool) {
+		if jitter {
+			q.AddAfter(reconcileRequest(obj), RandomDurationWithMetaDuration(syncJitterPeriod))
+		} else {
+			q.Add(reconcileRequest(obj))
+		}
+	}
+
+	return &handler.Funcs{
+		CreateFunc: func(_ context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			observedGeneration, ok := getObservedGeneration(e.Object)
+			if !ok {
+				return
+			}
+
+			// Objects with deletion timestamp and newly created managed seed will be enqueued immediately.
+			// Generation is 1 for newly created objects.
+			if e.Object.GetDeletionTimestamp() != nil || e.Object.GetGeneration() == 1 {
+				q.Add(reconcileRequest(e.Object))
+				return
+			}
+
+			if e.Object.GetGeneration() != observedGeneration {
+				addWithJitter(e.Object, q, ptr.Deref(jitterUpdates, false))
+				return
+			}
+
+			// Spread reconciliation of  across the configured sync jitter
+			// period to avoid overloading the gardener-apiserver
+			addWithJitter(e.Object, q, true)
+		},
+		UpdateFunc: func(_ context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			observedGeneration, ok := getObservedGeneration(e.ObjectNew)
+			if !ok {
+				return
+			}
+
+			if e.ObjectNew.GetGeneration() == observedGeneration {
+				return
+			}
+
+			// Objects with deletion timestamp and newly created objects will be enqueued immediately.
+			// Generation is 1 for newly created objects.
+			if e.ObjectNew.GetDeletionTimestamp() != nil || e.ObjectNew.GetGeneration() == 1 {
+				q.Add(reconcileRequest(e.ObjectNew))
+				return
+			}
+
+			addWithJitter(e.ObjectNew, q, ptr.Deref(jitterUpdates, false))
+		},
+		DeleteFunc: func(_ context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			if e.Object == nil {
+				return
+			}
+			q.Add(reconcileRequest(e.Object))
+		},
+	}
+}

--- a/pkg/controllerutils/source_test.go
+++ b/pkg/controllerutils/source_test.go
@@ -6,16 +6,22 @@ package controllerutils_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	. "github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Source", func() {
@@ -78,6 +84,169 @@ var _ = Describe("Source", func() {
 				EnqueueAnonymously.Generic(ctx, event.GenericEvent{Object: obj}, queue)
 				assert()
 			})
+		})
+	})
+
+	Describe("#EnqueueWithJitterDelay", func() {
+		var (
+			hdlr             handler.EventHandler
+			queue            *test.FakeQueue[reconcile.Request]
+			obj              *seedmanagementv1alpha1.ManagedSeed
+			req              reconcile.Request
+			randomDuration   = 10 * time.Millisecond
+			syncJitterPeriod *metav1.Duration
+		)
+
+		BeforeEach(func() {
+			syncJitterPeriod = &metav1.Duration{Duration: 50 * time.Millisecond}
+
+			queue = &test.FakeQueue[reconcile.Request]{}
+			obj = &seedmanagementv1alpha1.ManagedSeed{ObjectMeta: metav1.ObjectMeta{Name: "managedseed", Namespace: "namespace"}}
+			hdlr = EnqueueWithJitterDelay(
+				func(obj client.Object) (int64, bool) {
+					ms, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
+					if !ok {
+						return 0, false
+					}
+					return ms.Status.ObservedGeneration, true
+				},
+				new(true),
+				syncJitterPeriod,
+			)
+			req = reconcile.Request{NamespacedName: types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}}
+
+			DeferCleanup(func() {
+				test.WithVar(&RandomDurationWithMetaDuration, func(_ *metav1.Duration) time.Duration { return randomDuration })
+			})
+		})
+
+		It("should enqueue the object without delay for Create events when deletion timestamp is set", func() {
+			now := metav1.Now()
+			obj.SetDeletionTimestamp(&now)
+			hdlr.Create(ctx, event.CreateEvent{Object: obj}, queue)
+
+			Expect(queue.Added).To(ConsistOf(req))
+		})
+
+		It("should enqueue the object without delay for Create events when generation is set to 1", func() {
+			obj.Generation = 1
+			hdlr.Create(ctx, event.CreateEvent{Object: obj}, queue)
+
+			Expect(queue.Added).To(ConsistOf(req))
+		})
+
+		It("should enqueue the object without delay for Create events when generation changed and jitterudpates is set to false", func() {
+			obj.Generation = 2
+			obj.Status.ObservedGeneration = 1
+			hdlr = EnqueueWithJitterDelay(
+				func(obj client.Object) (int64, bool) {
+					ms, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
+					if !ok {
+						return 0, false
+					}
+					return ms.Status.ObservedGeneration, true
+				},
+				new(false),
+				syncJitterPeriod,
+			)
+			hdlr.Create(ctx, event.CreateEvent{Object: obj}, queue)
+
+			Expect(queue.Added).To(ConsistOf(req))
+		})
+
+		It("should enqueue the object with random delay for Create events when generation changed and  jitterUpdates is set to true", func() {
+			obj.Generation = 2
+			obj.Status.ObservedGeneration = 1
+			hdlr.Create(ctx, event.CreateEvent{Object: obj}, queue)
+
+			Expect(queue.AddedAfter).To(ConsistOf(test.AddAfterArgs[reconcile.Request]{Item: req, Duration: randomDuration}))
+		})
+
+		It("should enqueue the object with random delay for Create events when there is no change in generation", func() {
+			obj.Generation = 2
+			obj.Status.ObservedGeneration = 2
+			hdlr = EnqueueWithJitterDelay(
+				func(obj client.Object) (int64, bool) {
+					ms, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
+					if !ok {
+						return 0, false
+					}
+					return ms.Status.ObservedGeneration, true
+				},
+				new(false),
+				syncJitterPeriod,
+			)
+			hdlr.Create(ctx, event.CreateEvent{Object: obj}, queue)
+
+			Expect(queue.AddedAfter).To(ConsistOf(test.AddAfterArgs[reconcile.Request]{Item: req, Duration: randomDuration}))
+		})
+
+		It("should not enqueue the object for Update events when generation and observedGeneration are equal", func() {
+			obj.Generation = 1
+			obj.Status.ObservedGeneration = 1
+			hdlr.Update(ctx, event.UpdateEvent{ObjectNew: obj, ObjectOld: obj}, queue)
+
+			Expect(queue.Added).To(BeEmpty())
+			Expect(queue.AddedAfter).To(BeEmpty())
+		})
+
+		It("should enqueue the object for Update events when deletion timestamp is set", func() {
+			obj.Generation = 2
+			obj.Status.ObservedGeneration = 1
+			now := metav1.Now()
+			obj.SetDeletionTimestamp(&now)
+			hdlr.Update(ctx, event.UpdateEvent{ObjectNew: obj, ObjectOld: obj}, queue)
+
+			Expect(queue.Added).To(ConsistOf(req))
+		})
+
+		It("should enqueue the object for Update events when generation is 1", func() {
+			obj.Generation = 1
+			obj.Status.ObservedGeneration = 0
+			hdlr.Update(ctx, event.UpdateEvent{ObjectNew: obj, ObjectOld: obj}, queue)
+
+			Expect(queue.Added).To(ConsistOf(req))
+		})
+
+		It("should enqueue the object for Update events when jitterUpdates is set to false", func() {
+			obj.Generation = 2
+			obj.Status.ObservedGeneration = 1
+			hdlr = EnqueueWithJitterDelay(
+				func(obj client.Object) (int64, bool) {
+					ms, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
+					if !ok {
+						return 0, false
+					}
+					return ms.Status.ObservedGeneration, true
+				},
+				new(false),
+				syncJitterPeriod,
+			)
+
+			hdlr.Update(ctx, event.UpdateEvent{ObjectNew: obj, ObjectOld: obj}, queue)
+
+			Expect(queue.Added).To(ConsistOf(req))
+		})
+
+		It("should enqueue the object with random delay for Update events when jitterUpdates is set to true", func() {
+			obj.Generation = 2
+			obj.Status.ObservedGeneration = 1
+			hdlr.Update(ctx, event.UpdateEvent{ObjectNew: obj, ObjectOld: obj}, queue)
+
+			Expect(queue.AddedAfter).To(ConsistOf(test.AddAfterArgs[reconcile.Request]{Item: req, Duration: randomDuration}))
+		})
+
+		It("should enqueue the object for Delete events", func() {
+			hdlr.Delete(ctx, event.DeleteEvent{Object: obj}, queue)
+
+			Expect(queue.Added).To(ConsistOf(req))
+		})
+
+		It("should not enqueue the object for Generic events", func() {
+			hdlr.Generic(ctx, event.GenericEvent{Object: obj}, queue)
+
+			Expect(queue.Added).To(BeEmpty())
+			Expect(queue.AddedAfter).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/gardenlet/controller/backupbucket/add.go
+++ b/pkg/gardenlet/controller/backupbucket/add.go
@@ -60,7 +60,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Clu
 		WatchesRawSource(source.Kind[client.Object](
 			gardenCluster.GetCache(),
 			&gardencorev1beta1.BackupBucket{},
-			&handler.EnqueueRequestForObject{},
+			r.EnqueueWithJitterDelay(),
 			&predicate.GenerationChangedPredicate{},
 			r.SeedNamePredicate(),
 		)).
@@ -71,6 +71,22 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Clu
 			predicateutils.LastOperationChanged(predicateutils.GetExtensionLastOperation),
 		)).
 		Complete(r)
+}
+
+// EnqueueWithJitterDelay returns handler.Funcs which enqueues the object with a random Jitter duration when the JitterUpdate
+// is enabled in BackupBucket controller configuration. All other events are normally enqueued.
+func (r *Reconciler) EnqueueWithJitterDelay() handler.EventHandler {
+	return controllerutils.EnqueueWithJitterDelay(
+		func(obj client.Object) (int64, bool) {
+			bb, ok := obj.(*gardencorev1beta1.BackupBucket)
+			if !ok {
+				return 0, false
+			}
+			return bb.Status.ObservedGeneration, true
+		},
+		r.Config.JitterUpdates,
+		r.Config.SyncJitterPeriod,
+	)
 }
 
 // SeedNamePredicate returns a predicate which returns true when the object belongs to this seed.

--- a/pkg/gardenlet/controller/backupentry/add.go
+++ b/pkg/gardenlet/controller/backupentry/add.go
@@ -65,7 +65,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 		WatchesRawSource(source.Kind[client.Object](
 			gardenCluster.GetCache(),
 			&gardencorev1beta1.BackupEntry{},
-			&handler.EnqueueRequestForObject{},
+			r.EnqueueWithJitterDelay(),
 			&predicate.GenerationChangedPredicate{},
 			predicate.NewPredicateFuncs(r.BackupEntryPredicate),
 		)).
@@ -82,6 +82,22 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 			predicateutils.LastOperationChanged(predicateutils.GetExtensionLastOperation),
 		)).
 		Complete(r)
+}
+
+// EnqueueWithJitterDelay returns handler.Funcs which enqueues the object with a random Jitter duration when the JitterUpdate
+// is enabled in BackupEntry controller configuration. All other events are normally enqueued.
+func (r *Reconciler) EnqueueWithJitterDelay() handler.EventHandler {
+	return controllerutils.EnqueueWithJitterDelay(
+		func(obj client.Object) (int64, bool) {
+			be, ok := obj.(*gardencorev1beta1.BackupEntry)
+			if !ok {
+				return 0, false
+			}
+			return be.Status.ObservedGeneration, true
+		},
+		r.Config.JitterUpdates,
+		r.Config.SyncJitterPeriod,
+	)
 }
 
 // MapBackupBucketToBackupEntry is a handler.MapFunc for mapping a core.gardener.cloud/v1beta1.BackupBucket to the

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -396,7 +396,7 @@ func (r *Reconciler) deleteBackupEntry(
 		return reconcile.Result{}, nil
 	}
 
-	scheduledFor := backupEntry.DeletionTimestamp.Time.Add(gracePeriod)
+	scheduledFor := backupEntry.DeletionTimestamp.Add(gracePeriod)
 	pendingMsg := fmt.Sprintf("Deletion of backup entry is scheduled for %s", scheduledFor)
 
 	if backupEntry.Status.LastOperation == nil || backupEntry.Status.LastOperation.State != gardencorev1beta1.LastOperationStatePending || backupEntry.Status.LastOperation.Description != pendingMsg {

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -309,6 +309,7 @@ func (r *Reconciler) deleteBackupEntry(
 
 	gracePeriod := computeGracePeriod(*r.Config.DeletionGracePeriodHours, r.Config.DeletionGracePeriodShootPurposes, gardencorev1beta1.ShootPurpose(backupEntry.Annotations[v1beta1constants.ShootPurpose]))
 	present, _ := strconv.ParseBool(backupEntry.Annotations[gardencorev1beta1.BackupEntryForceDeletion])
+
 	if present || r.Clock.Since(backupEntry.DeletionTimestamp.Local()) > gracePeriod {
 		operationType := v1beta1helper.ComputeOperationType(backupEntry.ObjectMeta, backupEntry.Status.LastOperation)
 		if updateErr := r.updateBackupEntryStatusOperationStart(gardenCtx, backupEntry, operationType); updateErr != nil {
@@ -395,11 +396,16 @@ func (r *Reconciler) deleteBackupEntry(
 		return reconcile.Result{}, nil
 	}
 
-	if updateErr := r.updateBackupEntryStatusPending(gardenCtx, backupEntry, fmt.Sprintf("Deletion of backup entry is scheduled for %s", backupEntry.DeletionTimestamp.Add(gracePeriod))); updateErr != nil {
-		return reconcile.Result{}, fmt.Errorf("could not update status after deletion success: %w", updateErr)
+	scheduledFor := backupEntry.DeletionTimestamp.Time.Add(gracePeriod)
+	pendingMsg := fmt.Sprintf("Deletion of backup entry is scheduled for %s", scheduledFor)
+
+	if backupEntry.Status.LastOperation == nil || backupEntry.Status.LastOperation.State != gardencorev1beta1.LastOperationStatePending || backupEntry.Status.LastOperation.Description != pendingMsg {
+		if updateErr := r.updateBackupEntryStatusPending(gardenCtx, backupEntry, pendingMsg); updateErr != nil {
+			return reconcile.Result{}, fmt.Errorf("could not update status after deletion pending: %w", updateErr)
+		}
 	}
 
-	requeueAfter := backupEntry.DeletionTimestamp.Time.Add(gracePeriod).Sub(r.Clock.Now())
+	requeueAfter := scheduledFor.Sub(r.Clock.Now())
 	if requeueAfter < 0 {
 		return reconcile.Result{}, fmt.Errorf("the backupentry should have been deleted by now")
 	}

--- a/pkg/gardenlet/controller/managedseed/add.go
+++ b/pkg/gardenlet/controller/managedseed/add.go
@@ -9,14 +9,12 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -26,7 +24,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/controllerutils"
 )
 
 // ControllerName is the name of this controller.
@@ -114,77 +112,19 @@ func (r *Reconciler) MapSeedToManagedSeed(_ context.Context, obj client.Object) 
 	return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: r.GardenNamespaceGarden, Name: obj.GetName()}}}
 }
 
-func reconcileRequest(obj client.Object) reconcile.Request {
-	return reconcile.Request{NamespacedName: types.NamespacedName{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-	}}
-}
-
-// RandomDurationWithMetaDuration is an alias for `utils.RandomDurationWithMetaDuration`. Exposed for unit tests.
-var RandomDurationWithMetaDuration = utils.RandomDurationWithMetaDuration
-
 // EnqueueWithJitterDelay returns handler.Funcs which enqueues the object with a random Jitter duration when the JitterUpdate
 // is enabled in ManagedSeed controller configuration.
 // All other events are normally enqueued.
 func (r *Reconciler) EnqueueWithJitterDelay() handler.EventHandler {
-	return &handler.Funcs{
-		CreateFunc: func(_ context.Context, evt event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			managedSeed, ok := evt.Object.(*seedmanagementv1alpha1.ManagedSeed)
+	return controllerutils.EnqueueWithJitterDelay(
+		func(obj client.Object) (int64, bool) {
+			ms, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
 			if !ok {
-				return
+				return 0, false
 			}
-
-			generationChanged := managedSeed.Generation != managedSeed.Status.ObservedGeneration
-
-			// Managed seed with deletion timestamp and newly created managed seed will be enqueued immediately.
-			// Generation is 1 for newly created objects.
-			if managedSeed.DeletionTimestamp != nil || managedSeed.Generation == 1 {
-				q.Add(reconcileRequest(evt.Object))
-				return
-			}
-
-			if generationChanged {
-				if *r.Config.Controllers.ManagedSeed.JitterUpdates {
-					q.AddAfter(reconcileRequest(evt.Object), RandomDurationWithMetaDuration(r.Config.Controllers.ManagedSeed.SyncJitterPeriod))
-				} else {
-					q.Add(reconcileRequest(evt.Object))
-				}
-				return
-			}
-			// Spread reconciliation of managed seeds (including gardenlet updates/rollouts) across the configured sync jitter
-			// period to avoid overloading the gardener-apiserver if all gardenlets in all managed seeds are (re)starting
-			// roughly at the same time.
-			q.AddAfter(reconcileRequest(evt.Object), RandomDurationWithMetaDuration(r.Config.Controllers.ManagedSeed.SyncJitterPeriod))
+			return ms.Status.ObservedGeneration, true
 		},
-		UpdateFunc: func(_ context.Context, evt event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			managedSeed, ok := evt.ObjectNew.(*seedmanagementv1alpha1.ManagedSeed)
-			if !ok {
-				return
-			}
-
-			if managedSeed.Generation == managedSeed.Status.ObservedGeneration {
-				return
-			}
-
-			// Managed seed with deletion timestamp and newly created managed seed will be enqueued immediately.
-			// Generation is 1 for newly created objects.
-			if managedSeed.DeletionTimestamp != nil || managedSeed.Generation == 1 {
-				q.Add(reconcileRequest(evt.ObjectNew))
-				return
-			}
-
-			if ptr.Deref(r.Config.Controllers.ManagedSeed.JitterUpdates, false) {
-				q.AddAfter(reconcileRequest(evt.ObjectNew), RandomDurationWithMetaDuration(r.Config.Controllers.ManagedSeed.SyncJitterPeriod))
-			} else {
-				q.Add(reconcileRequest(evt.ObjectNew))
-			}
-		},
-		DeleteFunc: func(_ context.Context, evt event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			if evt.Object == nil {
-				return
-			}
-			q.Add(reconcileRequest(evt.Object))
-		},
-	}
+		r.Config.Controllers.ManagedSeed.JitterUpdates,
+		r.Config.Controllers.ManagedSeed.SyncJitterPeriod,
+	)
 }

--- a/pkg/gardenlet/controller/managedseed/add_test.go
+++ b/pkg/gardenlet/controller/managedseed/add_test.go
@@ -5,32 +5,21 @@
 package managedseed_test
 
 import (
-	"context"
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/managedseed"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Add", func() {
 	var (
-		ctx        = context.TODO()
 		fakeClient client.Client
 		reconciler *Reconciler
 		p          predicate.Predicate
@@ -83,141 +72,6 @@ var _ = Describe("Add", func() {
 			Expect(p.Update(event.TypedUpdateEvent[client.Object]{ObjectNew: seed})).To(BeFalse())
 			Expect(p.Delete(event.TypedDeleteEvent[client.Object]{Object: seed})).To(BeFalse())
 			Expect(p.Generic(event.TypedGenericEvent[client.Object]{Object: seed})).To(BeFalse())
-		})
-	})
-
-	Describe("#EnqueueWithJitterDelay", func() {
-		var (
-			hdlr           handler.EventHandler
-			queue          *test.FakeQueue[reconcile.Request]
-			obj            *seedmanagementv1alpha1.ManagedSeed
-			req            reconcile.Request
-			cfg            gardenletconfigv1alpha1.GardenletConfiguration
-			randomDuration = 10 * time.Millisecond
-		)
-
-		BeforeEach(func() {
-			cfg = gardenletconfigv1alpha1.GardenletConfiguration{
-				Controllers: &gardenletconfigv1alpha1.GardenletControllerConfiguration{
-					ManagedSeed: &gardenletconfigv1alpha1.ManagedSeedControllerConfiguration{
-						SyncJitterPeriod: &metav1.Duration{Duration: 50 * time.Millisecond},
-					},
-				},
-			}
-
-			hdlr = (&Reconciler{Config: cfg}).EnqueueWithJitterDelay()
-			queue = &test.FakeQueue[reconcile.Request]{}
-			obj = &seedmanagementv1alpha1.ManagedSeed{ObjectMeta: metav1.ObjectMeta{Name: "managedseed", Namespace: "namespace"}}
-			req = reconcile.Request{NamespacedName: types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}}
-
-			DeferCleanup(func() {
-				test.WithVar(&RandomDurationWithMetaDuration, func(_ *metav1.Duration) time.Duration { return randomDuration })
-			})
-		})
-
-		It("should enqueue the object without delay for Create events when deletion timestamp is set", func() {
-			now := metav1.Now()
-			obj.SetDeletionTimestamp(&now)
-			hdlr.Create(ctx, event.CreateEvent{Object: obj}, queue)
-
-			Expect(queue.Added).To(ConsistOf(req))
-		})
-
-		It("should enqueue the object without delay for Create events when generation is set to 1", func() {
-			obj.Generation = 1
-			hdlr.Create(ctx, event.CreateEvent{Object: obj}, queue)
-
-			Expect(queue.Added).To(ConsistOf(req))
-		})
-
-		It("should enqueue the object without delay for Create events when generation changed and jitterudpates is set to false", func() {
-			cfg.Controllers.ManagedSeed.JitterUpdates = new(false)
-			obj.Generation = 2
-			obj.Status.ObservedGeneration = 1
-			hdlr = (&Reconciler{Config: cfg}).EnqueueWithJitterDelay()
-			hdlr.Create(ctx, event.CreateEvent{Object: obj}, queue)
-
-			Expect(queue.Added).To(ConsistOf(req))
-		})
-
-		It("should enqueue the object with random delay for Create events when generation changed and  jitterUpdates is set to true", func() {
-			cfg.Controllers.ManagedSeed.JitterUpdates = new(true)
-			obj.Generation = 2
-			obj.Status.ObservedGeneration = 1
-			hdlr = (&Reconciler{Config: cfg}).EnqueueWithJitterDelay()
-			hdlr.Create(ctx, event.CreateEvent{Object: obj}, queue)
-
-			Expect(queue.AddedAfter).To(ConsistOf(test.AddAfterArgs[reconcile.Request]{Item: req, Duration: randomDuration}))
-		})
-
-		It("should enqueue the object with random delay for Create events when there is no change in generation", func() {
-			cfg.Controllers.ManagedSeed.JitterUpdates = new(false)
-			obj.Generation = 2
-			obj.Status.ObservedGeneration = 2
-			hdlr = (&Reconciler{Config: cfg}).EnqueueWithJitterDelay()
-			hdlr.Create(ctx, event.CreateEvent{Object: obj}, queue)
-
-			Expect(queue.AddedAfter).To(ConsistOf(test.AddAfterArgs[reconcile.Request]{Item: req, Duration: randomDuration}))
-		})
-
-		It("should not enqueue the object for Update events when generation and observedGeneration are equal", func() {
-			obj.Generation = 1
-			obj.Status.ObservedGeneration = 1
-			hdlr.Update(ctx, event.UpdateEvent{ObjectNew: obj, ObjectOld: obj}, queue)
-
-			Expect(queue.Added).To(BeEmpty())
-			Expect(queue.AddedAfter).To(BeEmpty())
-		})
-
-		It("should enqueue the object for Update events when deletion timestamp is set", func() {
-			obj.Generation = 2
-			obj.Status.ObservedGeneration = 1
-			now := metav1.Now()
-			obj.SetDeletionTimestamp(&now)
-			hdlr.Update(ctx, event.UpdateEvent{ObjectNew: obj, ObjectOld: obj}, queue)
-
-			Expect(queue.Added).To(ConsistOf(req))
-		})
-
-		It("should enqueue the object for Update events when generation is 1", func() {
-			obj.Generation = 1
-			obj.Status.ObservedGeneration = 0
-			hdlr.Update(ctx, event.UpdateEvent{ObjectNew: obj, ObjectOld: obj}, queue)
-
-			Expect(queue.Added).To(ConsistOf(req))
-		})
-
-		It("should enqueue the object for Update events when jitterUpdates is set to false", func() {
-			cfg.Controllers.ManagedSeed.JitterUpdates = new(false)
-			obj.Generation = 2
-			obj.Status.ObservedGeneration = 1
-			hdlr = (&Reconciler{Config: cfg}).EnqueueWithJitterDelay()
-			hdlr.Update(ctx, event.UpdateEvent{ObjectNew: obj, ObjectOld: obj}, queue)
-
-			Expect(queue.Added).To(ConsistOf(req))
-		})
-
-		It("should enqueue the object with random delay for Update events when jitterUpdates is set to true", func() {
-			cfg.Controllers.ManagedSeed.JitterUpdates = new(true)
-			obj.Generation = 2
-			obj.Status.ObservedGeneration = 1
-			hdlr = (&Reconciler{Config: cfg}).EnqueueWithJitterDelay()
-			hdlr.Update(ctx, event.UpdateEvent{ObjectNew: obj, ObjectOld: obj}, queue)
-
-			Expect(queue.AddedAfter).To(ConsistOf(test.AddAfterArgs[reconcile.Request]{Item: req, Duration: randomDuration}))
-		})
-
-		It("should enqueue the object for Delete events", func() {
-			hdlr.Delete(ctx, event.DeleteEvent{Object: obj}, queue)
-
-			Expect(queue.Added).To(ConsistOf(req))
-		})
-
-		It("should not enqueue the object for Generic events", func() {
-			hdlr.Generic(ctx, event.GenericEvent{Object: obj}, queue)
-
-			Expect(queue.Added).To(BeEmpty())
-			Expect(queue.AddedAfter).To(BeEmpty())
 		})
 	})
 })

--- a/test/integration/gardenlet/backupentry/backupentry_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry_test.go
@@ -588,11 +588,11 @@ var _ = Describe("BackupEntry controller tests", func() {
 				g.Expect(backupEntry.DeletionTimestamp).NotTo(BeNil())
 				g.Expect(backupEntry.Status.LastOperation).NotTo(BeNil())
 				g.Expect(backupEntry.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStatePending))
-				g.Expect(backupEntry.Status.LastOperation.Description).To(Equal(fmt.Sprintf("Deletion of backup entry is scheduled for %s", backupEntry.DeletionTimestamp.Time.Add(time.Duration(deletionGracePeriodHours)*time.Hour))))
+				g.Expect(backupEntry.Status.LastOperation.Description).To(Equal(fmt.Sprintf("Deletion of backup entry is scheduled for %s", backupEntry.DeletionTimestamp.Add(time.Duration(deletionGracePeriodHours)*time.Hour))))
 			}).Should(Succeed())
 
 			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(backupEntry), backupEntry)).To(Succeed())
-			scheduledTime := backupEntry.DeletionTimestamp.Time.Add(time.Duration(deletionGracePeriodHours) * time.Hour)
+			scheduledTime := backupEntry.DeletionTimestamp.Add(time.Duration(deletionGracePeriodHours) * time.Hour)
 			lastUpdateTime := backupEntry.Status.LastOperation.LastUpdateTime
 
 			By("Step the clock but don't pass the grace period")

--- a/test/integration/gardenlet/backupentry/backupentry_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry_test.go
@@ -572,10 +572,43 @@ var _ = Describe("BackupEntry controller tests", func() {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(BeNotFoundError())
 			}).Should(Succeed())
 
-			By("Ensure finalizers are removed and BackupBucket is released")
+			By("Ensure finalizers are removed and BackupEntry is released")
 			Eventually(func() error {
 				return testClient.Get(ctx, client.ObjectKeyFromObject(backupEntry), backupEntry)
 			}).Should(BeNotFoundError())
+		})
+
+		It("should  not update the pending status on re-reconcile within the grace period", func() {
+			By("Delete the BackupEntry")
+			Expect(testClient.Delete(ctx, backupEntry)).To(Succeed())
+
+			By("Ensure the BackupEntry is not deleted till the grace period is passed")
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(backupEntry), backupEntry)).To(Succeed())
+				g.Expect(backupEntry.DeletionTimestamp).NotTo(BeNil())
+				g.Expect(backupEntry.Status.LastOperation).NotTo(BeNil())
+				g.Expect(backupEntry.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStatePending))
+				g.Expect(backupEntry.Status.LastOperation.Description).To(Equal(fmt.Sprintf("Deletion of backup entry is scheduled for %s", backupEntry.DeletionTimestamp.Time.Add(time.Duration(deletionGracePeriodHours)*time.Hour))))
+			}).Should(Succeed())
+
+			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(backupEntry), backupEntry)).To(Succeed())
+			scheduledTime := backupEntry.DeletionTimestamp.Time.Add(time.Duration(deletionGracePeriodHours) * time.Hour)
+			lastUpdateTime := backupEntry.Status.LastOperation.LastUpdateTime
+
+			By("Step the clock but don't pass the grace period")
+			fakeClock.Step((time.Duration(deletionGracePeriodHours)*time.Hour - time.Hour))
+			patch := client.MergeFrom(backupEntry.DeepCopy())
+			metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+			Expect(testClient.Patch(ctx, backupEntry, patch)).To(Succeed())
+
+			By("Ensure the BackupEntry lastOperation timestamp has not changed")
+			Consistently(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(backupEntry), backupEntry)).To(Succeed())
+				g.Expect(backupEntry.Status.LastOperation).NotTo(BeNil())
+				g.Expect(backupEntry.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStatePending))
+				g.Expect(backupEntry.Status.LastOperation.Description).To(Equal(fmt.Sprintf("Deletion of backup entry is scheduled for %s", scheduledTime)))
+				g.Expect(backupEntry.Status.LastOperation.LastUpdateTime).To(Equal(lastUpdateTime))
+			}).Should(Succeed())
 		})
 	})
 })

--- a/test/integration/gardenlet/backupentry/backupentry_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry_test.go
@@ -578,7 +578,7 @@ var _ = Describe("BackupEntry controller tests", func() {
 			}).Should(BeNotFoundError())
 		})
 
-		It("should  not update the pending status on re-reconcile within the grace period", func() {
+		It("should not update the pending status on re-reconcile within the grace period", func() {
 			By("Delete the BackupEntry")
 			Expect(testClient.Delete(ctx, backupEntry)).To(Succeed())
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:

When a large number of BackupEntries are waiting for their deletion grace period to expire, gardenlet restarts cause two sources of unnecessary etcd load:

- Redundant status patches: Every BackupEntry with a `DeletionTimestamp` in its grace period unconditionally wrote a Pending status patch on every reconcile, even when the status was already correct. On restart, with N entries waiting, this produced N writes. Fixed by skipping the patch when the entry is already in the expected Pending state with the same message.

- `Create` events on restart: Controller-runtime re-enqueues all objects as `Create` events on restart. Now `EnqueueWithJitterDelay` handler delays enqueue by a random duration up to 5 minutes which is configurable in gardenlet config, spreading the reconciliation burst across a window rather than hitting etcd all at once. Real new creates are enqueued immediately without jitter.

- Backup buckets are also enqueued with a jitter on controller restart because we watch for them in the backup entry reconciler when it's status changes.
https://github.com/gardener/gardener/blob/ddf32354da5c4fbb8dbf057460d98765844c2125/pkg/gardenlet/controller/backupentry/add.go#L72-L77

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @dguendisch @ashwani2k 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
On gardenlet restart, BackupEntries pending deletion no longer cause a burst of redundant etcd writes. The reconciler now skips status updates when the entry is already in the correct pending state, also, `Create` events for pre-existing objects are spread over a configurable jitter window instead of being processed all at once.
```
