### PR TITLE
Revert "Update go to 1.27 (#15546)"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/setup-git-identity@v1
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.27'
+          go-version: '1.26'
       - name: run-tests
         shell: bash
         run: |
@@ -225,7 +225,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.27'
+          go-version: '1.26'
       - name: import-release-commit
         if: ${{ inputs.commit-objects-artefact != '' }}
         uses: gardener/cc-utils/.github/actions/import-commit@v1

--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -47,4 +47,4 @@ spec:
 #    -machine-type=$MACHINE_TYPE
 #    -external-domain=
 
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -16,4 +16,4 @@ spec:
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/HibernateShoot.yaml
+++ b/.test-defs/HibernateShoot.yaml
@@ -17,4 +17,4 @@ spec:
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
 
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/MigrateShoot.yaml
+++ b/.test-defs/MigrateShoot.yaml
@@ -20,4 +20,4 @@ spec:
     -mr-exclude-list="$MR_EXCLUDE_LIST"
     -resources-with-generated-name="$RESOURCES_WITH_GENERATED_NAME"
     -add-test-run-taint="$ADD_TEST_RUN_TAINT"
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/ReconcileShoots.yaml
+++ b/.test-defs/ReconcileShoots.yaml
@@ -16,4 +16,4 @@ spec:
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -gardener-version=$GARDENER_VERSION
 
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/ShootKubernetesUpdateTest.yaml
+++ b/.test-defs/ShootKubernetesUpdateTest.yaml
@@ -20,4 +20,4 @@ spec:
     -project-namespace=$PROJECT_NAMESPACE
     -k8s-version-control-plane=$K8S_VERSION
     -k8s-version-worker-pools=$K8S_VERSION_WORKER_POOLS
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/ShootMachineImageUpdateTest.yaml
+++ b/.test-defs/ShootMachineImageUpdateTest.yaml
@@ -19,4 +19,4 @@ spec:
     -shoot-name=$SHOOT_NAME
     -project-namespace=$PROJECT_NAMESPACE
     -machine-image-version=$MACHINE_IMAGE_VERSION
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/TestSuiteGardenerRelease.yaml
+++ b/.test-defs/TestSuiteGardenerRelease.yaml
@@ -20,4 +20,4 @@ spec:
       -ginkgo.focus="\[RELEASE\]"
       -ginkgo.skip="\[SERIAL\]"
 
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/TestSuiteShootBeta.yaml
+++ b/.test-defs/TestSuiteShootBeta.yaml
@@ -22,4 +22,4 @@ spec:
       -ginkgo.focus="\[BETA\]"
       -ginkgo.skip="\[SERIAL\]"
 
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/TestSuiteShootBetaSerial.yaml
+++ b/.test-defs/TestSuiteShootBetaSerial.yaml
@@ -23,4 +23,4 @@ spec:
       -fenced=$FENCED
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
 
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/TestSuiteShootDefault.yaml
+++ b/.test-defs/TestSuiteShootDefault.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.skip="\[SERIAL\]"
       -ginkgo.timeout=2h
 
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/TestSuiteShootDefaultSerial.yaml
+++ b/.test-defs/TestSuiteShootDefaultSerial.yaml
@@ -24,4 +24,4 @@ spec:
       -ginkgo.focus="\[DEFAULT\].*\[SERIAL\]"
       -ginkgo.timeout=2h
 
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/TestSuiteShootRelease.yaml
+++ b/.test-defs/TestSuiteShootRelease.yaml
@@ -22,4 +22,4 @@ spec:
       -ginkgo.focus="\[RELEASE\]"
       -ginkgo.skip="\[SERIAL\]"
 
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/.test-defs/WakeUpShoot.yaml
+++ b/.test-defs/WakeUpShoot.yaml
@@ -17,4 +17,4 @@ spec:
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
 
-  image: golang:1.27.0
+  image: golang:1.26.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder
-FROM --platform=$BUILDPLATFORM golang:1.27.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7 AS builder
 ARG GOPROXY=https://proxy.golang.org,direct
 ENV GOPROXY=$GOPROXY
 WORKDIR /go/src/github.com/gardener/gardener


### PR DESCRIPTION
This reverts commit 4cd4d130091fa84f278579fe522349ba91dcf9aa.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
Reverts https://github.com/gardener/gardener/pull/15546.
With images built by the Go 1.27 compiler, the served openapi spec seems to become corrupt/include leaked struct fields...

Tested locally with @moritzfalke, that local setup works again after reverting to Go 1.26.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @timuthy 
FYI @moritzfalke 

Afterwards, we need to do more thorough testing first before updating to Go 1.27 again.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
