### PR TITLE
Force `GOTOOLCHAIN` version from `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ export SYSTEM_ARCH := $(SYSTEM_ARCH)
 
 # Use a specific Go toolchain version to ensure consistent builds across different environments.
 # renovate: datasource=golang-version depName=go
-export GOTOOLCHAIN ?= go1.26.7
+export GOTOOLCHAIN := go1.26.7
 
 #########################################
 # Tools                                 #


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Else, `local` from the Go image and GitHub Action is used instead and we would not be able to catch build errors in the update PR.

This way, we will more easily spot incompatibilities in PR checks before merging.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/15585

**Special notes for your reviewer**:
/cc @timuthy 
fyi @moritzfalke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
Add explicit `GOTOOLCHAIN` version in `Makefile` that controls and enforces the Go version used for image builds for more consistent Go version use. Extension developers are advised to do the same in their root `Makefile`s.
```
