### PR TITLE
Deflake integration tests

### DIFF
--- a/pkg/component/crddeployer/crd.go
+++ b/pkg/component/crddeployer/crd.go
@@ -120,9 +120,12 @@ func (c *crdDeployer) Wait(ctx context.Context) error {
 	return kubernetesutils.WaitUntilCRDManifestsReady(ctx, c.client, slices.Collect(maps.Keys(c.crdNameToCRD))...)
 }
 
+// WaitUntilCRDManifestsDestroyed is the default wait function for CRD destruction. Exposed for testing.
+var WaitUntilCRDManifestsDestroyed = kubernetesutils.WaitUntilCRDManifestsDestroyed
+
 // WaitCleanup waits for destruction to finish and CRDs to be fully removed.
 func (c *crdDeployer) WaitCleanup(ctx context.Context) error {
-	return kubernetesutils.WaitUntilCRDManifestsDestroyed(ctx, c.client, slices.Collect(maps.Keys(c.crdNameToCRD))...)
+	return WaitUntilCRDManifestsDestroyed(ctx, c.client, slices.Collect(maps.Keys(c.crdNameToCRD))...)
 }
 
 // generateCRDNameToCRDMap returns a map that has the name of the resource as key, and the corresponding CRD as value.

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/autoscaling/vpa"
+	"github.com/gardener/gardener/pkg/component/crddeployer"
 	extensionscrds "github.com/gardener/gardener/pkg/component/extensions/crds"
 	"github.com/gardener/gardener/pkg/component/extensions/dnsrecord"
 	"github.com/gardener/gardener/pkg/component/extensions/extension"
@@ -55,6 +56,7 @@ import (
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	kubernetestestutils "github.com/gardener/gardener/test/utils/kubernetes"
 	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 )
 
@@ -192,6 +194,11 @@ var _ = Describe("Seed controller tests", func() {
 		DeferCleanup(test.WithVars(
 			&secretsutils.GenerateKey, secretsutils.FakeGenerateKey,
 			&resourcemanager.SkipWebhookDeployment, true,
+
+			// It can happen that the storage layer needs to recover, as some CRDs might end up in a stuck terminating state,
+			// with error: "InstanceDeletionFailed could not list instances: storage is (re)initializing}"
+			// Hence, we are only checking if the CRD is marked for deletion, not that it is actually gone.
+			&crddeployer.WaitUntilCRDManifestsDestroyed, kubernetestestutils.VerifyCRDDeletionByDeletionTimestamp,
 		))
 
 		By("Create DNS provider secret in garden namespace")
@@ -839,20 +846,17 @@ var _ = Describe("Seed controller tests", func() {
 					}).Should(BeEmpty())
 				} else {
 					By("Verify that gardener-resource-manager has been deleted")
-					// This step might take longer because it has to wait for CRDs to be deleted.
-					// It can happen that the storage layer needs to recover, as some CRDs might end up in a stuck terminating state,
-					// with error: "InstanceDeletionFailed could not list instances: storage is (re)initializing}"
 					Eventually(func() error {
 						deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager", Namespace: testNamespace.Name}}
 						return testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)
-					}).WithTimeout(4 * time.Minute).Should(BeNotFoundError())
+					}).Should(Succeed())
 
 					// We should wait for the CRD to be deleted since it is a cluster-scoped resource so that we do not interfere
 					// with other test cases.
 					By("Verify that CRD has been deleted")
 					Eventually(func() error {
 						return testClient.Get(ctx, client.ObjectKey{Name: "managedresources.resources.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})
-					}).Should(BeNotFoundError())
+					}).WithTimeout(4 * time.Minute).Should(BeNotFoundError())
 				}
 
 				By("Ensure Seed is gone")

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -7,6 +7,7 @@ package garden_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -44,6 +45,7 @@ import (
 	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/crddeployer"
 	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	extensioncomponent "github.com/gardener/gardener/pkg/component/extensions/extension"
 	gardeneraccess "github.com/gardener/gardener/pkg/component/gardener/access"
@@ -62,6 +64,7 @@ import (
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	kubernetestestutils "github.com/gardener/gardener/test/utils/kubernetes"
 	"github.com/gardener/gardener/test/utils/managedresource"
 	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 	"github.com/gardener/gardener/test/utils/operationannotation"
@@ -110,6 +113,7 @@ var _ = Describe("Garden controller tests", func() {
 			&shared.IntervalWaitForGardenerResourceManagerBootstrapping, 500*time.Millisecond,
 			&managedresources.IntervalWait, 100*time.Millisecond,
 			&kubernetesutils.IntervalWait, 100*time.Millisecond,
+			&crddeployer.WaitUntilCRDManifestsDestroyed, kubernetestestutils.VerifyCRDDeletionByDeletionTimestamp,
 		))
 
 		By("Create test Namespace")
@@ -944,11 +948,19 @@ spec:
 		// Deleting these resources can take a long time, especially under load.
 		// It can happen that the storage layer needs to recover, as some CRDs might end up in a stuck terminating state,
 		// with error: "InstanceDeletionFailed could not list instances: storage is (re)initializing}"
-		Eventually(func(g Gomega) []string {
+		// Hence, we are only checking if the CRD is marked for deletion, not that it is actually gone.
+		Eventually(func(g Gomega) {
 			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 			g.Expect(mgrClient.List(ctx, crdList)).To(Succeed())
-			return test.ObjectNames(crdList)
-		}).WithTimeout(4 * time.Minute).ShouldNot(ContainAnyOf(deployedCRDs...))
+
+			for _, deployedCRD := range deployedCRDs {
+				if i := slices.IndexFunc(crdList.Items, func(crd apiextensionsv1.CustomResourceDefinition) bool {
+					return crd.Name == deployedCRD
+				}); i != -1 {
+					g.Expect(crdList.Items[i].DeletionTimestamp).NotTo(BeNil(), "CRD %s should be marked for deletion", deployedCRD)
+				}
+			}
+		}).Should(Succeed())
 
 		By("Verify that secrets have been deleted")
 		Eventually(func(g Gomega) []corev1.Secret {

--- a/test/utils/kubernetes/crd.go
+++ b/test/utils/kubernetes/crd.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/gardener/gardener/pkg/utils/retry"
+)
+
+// VerifyCRDDeletionByDeletionTimestamp verifies that the given CRDs are deleted by checking the deletion timestamp is present.
+func VerifyCRDDeletionByDeletionTimestamp(ctx context.Context, c client.Client, crdNames ...string) error {
+	var taskFns []flow.TaskFn
+	for _, crdName := range crdNames {
+		taskFns = append(taskFns, func(ctx context.Context) error {
+			return retry.Until(ctx, 200*time.Millisecond, func(ctx context.Context) (done bool, err error) {
+				crd := &metav1.PartialObjectMetadata{}
+				crd.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+				if err := c.Get(ctx, client.ObjectKey{Name: crdName}, crd); err != nil {
+					if apierrors.IsNotFound(err) {
+						return retry.Ok()
+					}
+					return retry.MinorError(err)
+				}
+				if crd.GetDeletionTimestamp().IsZero() {
+					return retry.MinorError(fmt.Errorf("CRD %s is not deleted yet", crdName))
+				}
+				return retry.Ok()
+			})
+		})
+	}
+	return flow.Parallel(taskFns...)(ctx)
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Deflakes the integration tests by not waiting for all CRDs to be gone. Instead the tests checks if the deletion timestamp is set which should be sufficient in an integration test.

It's already known the CRD deletion can take a considerable amount of time to complete, esp. under load, and with more and more CRDs added (lately `Perses` and `OpenTelemetry`) the test suite increasingly ran into timeouts.

**Example timeout runs**:
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15582/pull-gardener-integration/2092280716535533568
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15568/pull-gardener-integration/2092511326864674816
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15583/pull-gardener-integration/2092521644626022400

**Example long deletion times**:
-   `{"level":"debug","ts":"2026-08-25T16:07:33.702Z","msg":"Finished","controller":"seed","namespace":"","name":"seed-garden-zb8xc","reconcileID":"d84e741a-5c49-43c4-a3f3-094322b7b80b","flow":"Seed deletion","task":"Destroy OpenTelemetry custom resource definitions","duration":"1m29.223073109s"}`
-   `{"level":"debug","ts":"2026-08-25T16:07:33.667Z","msg":"Finished","controller":"seed","namespace":"","name":"seed-garden-zb8xc","reconcileID":"d84e741a-5c49-43c4-a3f3-094322b7b80b","flow":"Seed deletion","task":"Destroying Perses Operator custom resource definitions","duration":"1m29.188064622s"}`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
