### PR TITLE
[GEP-28] `gardenadm restore`: Delete the prior Node and its Pods before running the init flow

### DIFF
--- a/pkg/gardenadm/botanist/restore.go
+++ b/pkg/gardenadm/botanist/restore.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/gardenadm/botanist/restore.go
+++ b/pkg/gardenadm/botanist/restore.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/api/indexer"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -28,7 +29,7 @@ func (b *GardenadmBotanist) DeletePriorNode(ctx context.Context, priorNodeName s
 // that was lost during the disaster.
 func (b *GardenadmBotanist) ForceDeletePriorNodePods(ctx context.Context, priorNodeName string) error {
 	podList := &corev1.PodList{}
-	if err := b.SeedClientSet.Client().List(ctx, podList, client.MatchingFields{"spec.nodeName": priorNodeName}); err != nil {
+	if err := b.SeedClientSet.Client().List(ctx, podList, client.MatchingFields{indexer.PodNodeName: priorNodeName}); err != nil {
 		return fmt.Errorf("failed listing Pods: %w", err)
 	}
 

--- a/pkg/gardenadm/botanist/restore.go
+++ b/pkg/gardenadm/botanist/restore.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+// DeletePriorNode deletes the Node object of the prior control plane Node that was lost during the disaster.
+func (b *GardenadmBotanist) DeletePriorNode(ctx context.Context, priorNodeName string) error {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: priorNodeName}}
+	b.Logger.Info("Deleting prior Node", "node", client.ObjectKeyFromObject(node))
+
+	return kubernetesutils.DeleteObject(ctx, b.SeedClientSet.Client(), node)
+}
+
+// ForceDeletePriorNodePods force-deletes all Pods that were running on the prior control plane Node
+// that was lost during the disaster.
+func (b *GardenadmBotanist) ForceDeletePriorNodePods(ctx context.Context, priorNodeName string) error {
+	podList := &corev1.PodList{}
+	if err := b.SeedClientSet.Client().List(ctx, podList, client.MatchingFields{"spec.nodeName": priorNodeName}); err != nil {
+		return fmt.Errorf("failed listing Pods: %w", err)
+	}
+
+	forceDeleteOptions := &client.DeleteOptions{
+		GracePeriodSeconds: new(int64(0)),
+		PropagationPolicy:  new(metav1.DeletePropagationBackground),
+	}
+	for _, pod := range podList.Items {
+		b.Logger.Info("Force deleting Pod", "pod", client.ObjectKeyFromObject(&pod), "nodeName", pod.Spec.NodeName)
+		if err := b.SeedClientSet.Client().Delete(ctx, &pod, forceDeleteOptions); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("failed force deleting Pod %s: %w", client.ObjectKeyFromObject(&pod), err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/gardenadm/botanist/restore.go
+++ b/pkg/gardenadm/botanist/restore.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
@@ -31,16 +32,24 @@ func (b *GardenadmBotanist) ForceDeletePriorNodePods(ctx context.Context, priorN
 		return fmt.Errorf("failed listing Pods: %w", err)
 	}
 
-	forceDeleteOptions := &client.DeleteOptions{
-		GracePeriodSeconds: new(int64(0)),
-		PropagationPolicy:  new(metav1.DeletePropagationBackground),
-	}
-	for _, pod := range podList.Items {
-		b.Logger.Info("Force deleting Pod", "pod", client.ObjectKeyFromObject(&pod), "nodeName", pod.Spec.NodeName)
-		if err := b.SeedClientSet.Client().Delete(ctx, &pod, forceDeleteOptions); client.IgnoreNotFound(err) != nil {
-			return fmt.Errorf("failed force deleting Pod %s: %w", client.ObjectKeyFromObject(&pod), err)
+	var (
+		taskFns []flow.TaskFn
+
+		forceDeleteOptions = &client.DeleteOptions{
+			GracePeriodSeconds: new(int64(0)),
+			PropagationPolicy:  new(metav1.DeletePropagationBackground),
 		}
+	)
+	for _, pod := range podList.Items {
+		taskFns = append(taskFns, func(ctx context.Context) error {
+			b.Logger.Info("Force deleting Pod", "pod", client.ObjectKeyFromObject(&pod), "nodeName", pod.Spec.NodeName)
+			if err := b.SeedClientSet.Client().Delete(ctx, &pod, forceDeleteOptions); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("failed force deleting Pod %s: %w", client.ObjectKeyFromObject(&pod), err)
+			}
+
+			return nil
+		})
 	}
 
-	return nil
+	return flow.ParallelN(5, taskFns...)(ctx)
 }

--- a/pkg/gardenadm/botanist/restore_test.go
+++ b/pkg/gardenadm/botanist/restore_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: Contributors to the Gardener project
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/gardenadm/botanist/restore_test.go
+++ b/pkg/gardenadm/botanist/restore_test.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/api/indexer"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("Restore", func() {
+	const priorNodeName = "prior-node"
+
+	var (
+		b *GardenadmBotanist
+
+		fakeClient client.Client
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(kubernetes.SeedScheme).
+			WithIndex(&corev1.Pod{}, indexer.PodNodeName, indexer.PodNodeNameIndexerFunc).
+			Build()
+		fakeClientSet := fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build()
+
+		b = &GardenadmBotanist{
+			Botanist: &botanistpkg.Botanist{
+				Operation: &operation.Operation{
+					Logger:        logr.Discard(),
+					SeedClientSet: fakeClientSet,
+				},
+			},
+		}
+	})
+
+	Describe("#DeletePriorNode", func() {
+		It("should not fail if the prior Node does not exist", func(ctx SpecContext) {
+			Expect(b.DeletePriorNode(ctx, priorNodeName)).To(Succeed())
+		})
+
+		It("should delete the prior Node", func(ctx SpecContext) {
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: priorNodeName}}
+			other := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "other-node"}}
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+			Expect(fakeClient.Create(ctx, other)).To(Succeed())
+
+			Expect(b.DeletePriorNode(ctx, priorNodeName)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(node), node)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(other), other)).To(Succeed())
+		})
+	})
+
+	Describe("#ForceDeletePriorNodePods", func() {
+		podOnNode := func(name, namespace, nodeName string) *corev1.Pod {
+			return &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec:       corev1.PodSpec{NodeName: nodeName},
+			}
+		}
+
+		It("should not fail if there are no Pods running on the prior Node", func(ctx SpecContext) {
+			Expect(b.ForceDeletePriorNodePods(ctx, priorNodeName)).To(Succeed())
+		})
+
+		It("should delete all Pods running on the prior Node", func(ctx SpecContext) {
+			pod1 := podOnNode("pod-1", "kube-system", priorNodeName)
+			pod2 := podOnNode("pod-2", "default", priorNodeName)
+			pod3 := podOnNode("pod-3", "some-namespace", priorNodeName)
+			pod4 := podOnNode("pod-4", "kube-system", "other-node")
+			pod5 := podOnNode("pod-5", "kube-system", "")
+			Expect(fakeClient.Create(ctx, pod1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, pod2)).To(Succeed())
+			Expect(fakeClient.Create(ctx, pod3)).To(Succeed())
+			Expect(fakeClient.Create(ctx, pod4)).To(Succeed())
+			Expect(fakeClient.Create(ctx, pod5)).To(Succeed())
+
+			Expect(b.ForceDeletePriorNodePods(ctx, priorNodeName)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(pod1), pod1)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(pod2), pod2)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(pod3), pod3)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(pod4), pod4)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(pod5), pod5)).To(Succeed())
+		})
+	})
+})

--- a/pkg/gardenadm/cmd/restore/restore.go
+++ b/pkg/gardenadm/cmd/restore/restore.go
@@ -89,7 +89,7 @@ func run(ctx context.Context, opts *Options) error {
 			Fn: func(ctx context.Context) error {
 				return b.ForceDeletePriorNodePods(ctx, opts.PriorNodeName)
 			},
-			Dependencies: flow.NewTaskIDs(deletePriorNode),
+			Dependencies: flow.NewTaskIDs(bootstrapControlPlane),
 		})
 		// TODO(ialidzhikov): Implement the required cleanups before running the init flow.
 		// For more details, see https://github.com/gardener/gardener/issues/15279.

--- a/pkg/gardenadm/cmd/restore/restore.go
+++ b/pkg/gardenadm/cmd/restore/restore.go
@@ -77,6 +77,20 @@ func run(ctx context.Context, opts *Options) error {
 				return err
 			},
 		})
+		deletePriorNode = g.Add(flow.Task{
+			Name: "Deleting prior Node",
+			Fn: func(ctx context.Context) error {
+				return b.DeletePriorNode(ctx, opts.PriorNodeName)
+			},
+			Dependencies: flow.NewTaskIDs(bootstrapControlPlane),
+		})
+		forceDeletePriorNodePods = g.Add(flow.Task{
+			Name: "Force deleting Pods running on prior Node",
+			Fn: func(ctx context.Context) error {
+				return b.ForceDeletePriorNodePods(ctx, opts.PriorNodeName)
+			},
+			Dependencies: flow.NewTaskIDs(deletePriorNode),
+		})
 		// TODO(ialidzhikov): Implement the required cleanups before running the init flow.
 		// For more details, see https://github.com/gardener/gardener/issues/15279.
 		_ = g.Add(flow.Task{
@@ -84,7 +98,7 @@ func run(ctx context.Context, opts *Options) error {
 			Fn: func(ctx context.Context) error {
 				return initcmd.RunInitFlow(ctx, b, initOpts)
 			},
-			Dependencies: flow.NewTaskIDs(bootstrapControlPlane),
+			Dependencies: flow.NewTaskIDs(deletePriorNode, forceDeletePriorNodePods),
 		})
 	)
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area disaster-recovery control-plane ipcei
/kind enhancement

**What this PR does / why we need it**:
`gardenadm restore` recovers a lost control plane by bootstrapping from an etcd backup and re-running the init flow.
The backup still contains the prior control plane `Node` and its `Pods`.
The prior node is gone, but its restored `Node` object keeps its pre-disaster status — a phantom node  that still "looks" `Ready`.

This breaks for example the init flow's Pod network setup.
Before configuring the Pod network, the init flow calls  `IsPodNetworkAvailable`, which looks up the node checks its `NetworkUnavailable` condition.
When restoring the control plane Node on a new machine with the same hostname the  lookup resolves to the phantom node, whose restored status still has `NetworkUnavailable=False`.
The flow concludes the Pod network is already set up and skips configuring it for the new node.
Additionally, such a "healthy" control plane Node confuses the kube-scheduler and it might schedule Pods on it which will be never picked up by kubelet.

This PR also force deletes the Pods on the prior Node because they are also phantom. The motivation is again to prevent any such phantom state to confuse the init flow or to make it early exit without waiting properly for the desired condition.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/15279

**Special notes for your reviewer**:
To test this change in local setup, use the disaster recovery scripts in the [Unmanaged infrastructure PoC](https://github.com/Kostov6/gardener/tree/poc/local-gapi-unmanaged-same-node) branch.

```bash
# Prerequisite
./hack/dr-kind-connect-up.sh

# Restore the control plane Node
./hack/dr-unmanaged-same-node.sh
```

The init flow triggered by `gardenadm restore` as expected fails with:
```
2026-08-26T14:21:44.096Z	ERROR	Error	{"flow": "restore", "task": "Running init flow", "error": "1 error occurred:\n\t* task \"Waiting until gardener-resource-manager reports readiness\" failed: 2 errors occurred:\n\t* retry failed with context deadline exceeded, last error: ReplicaSet \"gardener-resource-manager-76fb9d56db\" is progressing.\n\t* retry failed with context deadline exceeded, last error: ReplicaSet \"gardener-resource-manager-6776b96884\" is progressing.\n\n\n\n"}
github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func2
	github.com/gardener/gardener/pkg/utils/flow/flow.go:251
2026-08-26T14:21:44.097Z	INFO	Finished	{"flow": "restore"}
Error: 1 error occurred:
	* task "Running init flow" failed: 1 error occurred:
	* task "Waiting until gardener-resource-manager reports readiness" failed: 2 errors occurred:
	* retry failed with context deadline exceeded, last error: ReplicaSet "gardener-resource-manager-76fb9d56db" is progressing.
	* retry failed with context deadline exceeded, last error: ReplicaSet "gardener-resource-manager-6776b96884" is progressing.
```

Compared to the failure in https://github.com/gardener/gardener/pull/15487#issue-5128597347, GRM Pods are now as expected in Pending state and wait for a control plane Node to be scheduled there. The `IsPodNetworkAvailable` now correctly works for the to be restored Node - with this PR GRM gets deployed with `hostNetwork: true` as expected. Previously, GRM Pods were wrongly deployed in the Pod network and were scheduled on the phantom and stale control plane Node.
The next failure in the flow: GNA on the to be restored Node fails waiting its CSR to be approved. This will be tackled as part of a new issue and PR (briefly mentioned in https://github.com/gardener/gardener/issues/15279).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardenadm restore` now deletes the prior control plane `Node` and its `Pods` (restored from the etcd backup) before running the init flow, preventing phantom/stale objects from confusing the flow (e.g. Pod network setup) or the kube-scheduler.
```
