### PR TITLE
Deflake integration tests

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -20,10 +20,10 @@ if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ] ; then
   trap "report-collector \"$ARTIFACTS/junit.xml\"" EXIT
   test_flags="--ginkgo.junit-report=junit.xml"
   # Use Ginkgo timeout in Prow to print everything that is buffered in GinkgoWriter.
-  test_flags+=" --ginkgo.timeout=5m"
+  test_flags+=" --ginkgo.timeout=10m"
 else
   # We don't want Ginkgo's timeout flag locally because it causes skipping the test cache.
-  timeout_flag=-timeout=5m
+  timeout_flag=-timeout=10m
 fi
 
 GO111MODULE=on go test ${timeout_flag:-} $@ $test_flags | grep -v 'no test files'

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -827,16 +827,14 @@ var _ = Describe("Seed controller tests", func() {
 				Expect(client.IgnoreNotFound(testClient.Delete(ctx, seedControllerInst))).To(Succeed())
 
 				if seedIsGarden {
-					// The CRDs are cleaned up by the Destroy function of GRM. In case the seed is garden, the Destroy is called by the gardener-operator and since it's
-					// not running in this test, we can safely assert the below-mentioned. But if the seed is not garden, it might so happen that, before we fetch the
-					// ManagedResourceList and expect it to be empty, the CRDs are already gone. Since the gardener-resource-manager is deleted only after all the
-					// managedresources are gone, we don't need to assert it separately.
+					// The ManagedResource CRD is cleaned up by the Destroy function of GRM. In case the seed is garden, the Destroy is called by the gardener-operator and since it's
+					// not running in this test, we can safely assert the below-mentioned.
 					By("Verify that the seed system components have been deleted")
 					Eventually(func(g Gomega) []resourcesv1alpha1.ManagedResource {
 						managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 						g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
 						return managedResourceList.Items
-					}).Should(BeEmpty())
+					}).WithTimeout(kubernetesutils.WaitTimeout).Should(BeEmpty())
 				} else {
 					By("Verify that gardener-resource-manager has been deleted")
 					// This step might take longer because it has to wait for CRDs to be deleted.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Deflakes integration tests - see individual commits for more information.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Increased CRD deletions (up to `1m 30s`):
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15582/pull-gardener-integration/2092280716535533568
  ```
  {"level":"debug","ts":"2026-08-25T16:07:33.667Z","msg":"Finished","controller":"seed","namespace":"","name":"seed-garden-zb8xc","reconcileID":"d84e741a-5c49-43c4-a3f3-094322b7b80b","flow":"Seed deletion","task":"Destroying Perses Operator custom resource definitions","duration":"1m29.188064622s"}
  {"level":"debug","ts":"2026-08-25T16:07:33.702Z","msg":"Finished","controller":"seed","namespace":"","name":"seed-garden-zb8xc","reconcileID":"d84e741a-5c49-43c4-a3f3-094322b7b80b","flow":"Seed deletion","task":"Destroy OpenTelemetry custom resource definitions","duration":"1m29.223073109s"}
  ```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
