### PR TITLE
Deflake shoot care integration test

### DIFF
--- a/test/integration/gardenlet/shoot/care/care_suite_test.go
+++ b/test/integration/gardenlet/shoot/care/care_suite_test.go
@@ -124,7 +124,7 @@ var _ = BeforeSuite(func() {
 			ErrorIfCRDPathMissing: true,
 		},
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
-			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator,ShootMutator"},
+			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionLabels,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator,ShootMutator"},
 		},
 	}
 

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -749,6 +749,11 @@ var _ = Describe("Shoot Care controller tests (self-hosted shoot)", func() {
 				By("Create BackupBucket")
 				Expect(testClient.Create(ctx, backupBucket)).To(Succeed())
 
+				By("Wait until the manager cache observes the backup bucket")
+				Eventually(func() error {
+					return mgrClient.Get(ctx, client.ObjectKeyFromObject(backupBucket), backupBucket)
+				}).Should(Succeed())
+
 				backupEntry := &gardencorev1beta1.BackupEntry{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      backupEntryName,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind flake

**What this PR does / why we need it**:
That test creates a `BackupBucket`,
https://github.com/gardener/gardener/blob/aae370c7235536b232629a8f299e9c6b42fb5cc7/test/integration/gardenlet/shoot/care/care_test.go#L749-L750
then immediately creates a `BackupEntry` referencing it, hitting https://github.com/gardener/gardener/blob/f69798b8b417ab92f9f2b2140e892c9b9fa02e0d/plugin/pkg/global/extensionlabels/admission.go#L233-L236 where the informer cache may not have synced the BackupBucket yet.

This PR disables the `ExtensionLabels` plugin in the test and also adds a wait until the manager cache observes the bucket 
ensuring that the manager cache is also warm before the `BackupEntry` is created.


**Which issue(s) this PR fixes**:
Fixes https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15568/pull-gardener-integration/2092590436282535936#1:build-log.txt%3A1016-1049

**Special notes for your reviewer**:

I was unable to reproduce this flake locally though, on `master`:
```
❯ stress -p 64 test/integration/gardenlet/shoot/care/care.test
...
4m20s: 462 runs so far, 0 failures, 64 active
4m25s: 465 runs so far, 0 failures, 64 active
4m30s: 478 runs so far, 0 failures, 64 active
4m35s: 489 runs so far, 0 failures, 64 active
4m40s: 498 runs so far, 0 failures, 64 active
4m45s: 508 runs so far, 0 failures, 64 active
4m50s: 517 runs so far, 0 failures, 64 active
4m55s: 527 runs so far, 0 failures, 64 active
5m0s: 536 runs so far, 0 failures, 64 active
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
