### PR TITLE
Increase buffer for `istio-client-certificate` to be renewed when L7 load balancing is used.

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/sni.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni.go
@@ -537,8 +537,8 @@ func (s *sni) reconcileIstioTLSSecrets(ctx context.Context, ownerNamespace *core
 		CommonName:                  "system:istio-gateway",
 		CertType:                    secretsutils.ClientCert,
 		SkipPublishingCACertificate: true,
-		Validity:                    new(time.Hour * 24 * 30),
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAFrontProxy), secretsmanager.Rotate(secretsmanager.InPlace), secretsmanager.RenewAfterValidityPercentage(50))
+		Validity:                    new(time.Hour * 24 * 45),
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAFrontProxy), secretsmanager.Rotate(secretsmanager.InPlace), secretsmanager.RenewAfterValidityPercentage(33))
 	if err != nil {
 		return fmt.Errorf("failed to generate kube-apiserver client certificate for istio: %w", err)
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/area crypto
/area control-plane
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Increase buffer for `istio-client-certificate` to be renewed when L7 load balancing is used.

With #15490, the certificate rotation was triggered earlier, i.e. 15 days before expiration instead of 10 days. However, this is still a relatively short period of time. Clusters, may be in a failed state for more than two weeks, especially during holiday seasons. Therefore, this change increases the overall validity of the corresponding certificate from 30 to 45 days and still rotates it after 15 days. This means there now is a 30 day period in which a cluster needs to be broken to eventually end up in a broken state with regards to an invalid `istio-client-certificate`. The problem is not resolved, but even less likely to occur.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`istio-client-certificate` is now valid for 45 days, but still renewed every 15 days.
```

/cc @oliver-goetz @rfranzke 