### PR TITLE
Prevent migration of a ManagedSeed's shoot to its own seed

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -44,6 +44,8 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	securityinformers "github.com/gardener/gardener/pkg/client/security/informers/externalversions"
 	securityv1alpha1listers "github.com/gardener/gardener/pkg/client/security/listers/security/v1alpha1"
+	seedmanagementinformers "github.com/gardener/gardener/pkg/client/seedmanagement/informers/externalversions"
+	seedmanagementv1alpha1listers "github.com/gardener/gardener/pkg/client/seedmanagement/listers/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/features"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
@@ -75,6 +77,7 @@ type ValidateShoot struct {
 	projectLister                gardencorev1beta1listers.ProjectLister
 	secretBindingLister          gardencorev1beta1listers.SecretBindingLister
 	credentialsBindingLister     securityv1alpha1listers.CredentialsBindingLister
+	managedSeedLister            seedmanagementv1alpha1listers.ManagedSeedLister
 	readyFunc                    admission.ReadyFunc
 }
 
@@ -83,6 +86,7 @@ var (
 	_ = admissioninitializer.WantsKubeInformerFactory(&ValidateShoot{})
 	_ = admissioninitializer.WantsAuthorizer(&ValidateShoot{})
 	_ = admissioninitializer.WantsSecurityInformerFactory(&ValidateShoot{})
+	_ = admissioninitializer.WantsSeedManagementInformerFactory(&ValidateShoot{})
 
 	readyFuncs []admission.ReadyFunc
 )
@@ -144,6 +148,14 @@ func (v *ValidateShoot) SetSecurityInformerFactory(f securityinformers.SharedInf
 	readyFuncs = append(readyFuncs, credentialsBindingInformer.Informer().HasSynced)
 }
 
+// SetSeedManagementInformerFactory gets Lister from SharedInformerFactory.
+func (v *ValidateShoot) SetSeedManagementInformerFactory(f seedmanagementinformers.SharedInformerFactory) {
+	managedSeedInformer := f.Seedmanagement().V1alpha1().ManagedSeeds()
+	v.managedSeedLister = managedSeedInformer.Lister()
+
+	readyFuncs = append(readyFuncs, managedSeedInformer.Informer().HasSynced)
+}
+
 // SetKubeInformerFactory gets Lister from SharedInformerFactory.
 func (v *ValidateShoot) SetKubeInformerFactory(f kubeinformers.SharedInformerFactory) {
 	configMapInformer := f.Core().V1().ConfigMaps()
@@ -183,6 +195,9 @@ func (v *ValidateShoot) ValidateInitialization() error {
 	}
 	if v.credentialsBindingLister == nil {
 		return errors.New("missing credentials binding lister")
+	}
+	if v.managedSeedLister == nil {
+		return errors.New("missing managed seed lister")
 	}
 	return nil
 }
@@ -336,7 +351,7 @@ func (v *ValidateShoot) Validate(ctx context.Context, a admission.Attributes, _ 
 	if err := validationContext.validateProjectMembership(a); err != nil {
 		return err
 	}
-	if err := validationContext.validateScheduling(ctx, a, v.authorizer, v.shootLister, v.seedLister); err != nil {
+	if err := validationContext.validateScheduling(ctx, a, v.authorizer, v.shootLister, v.seedLister, v.managedSeedLister); err != nil {
 		return err
 	}
 	if err := validationContext.validateDeletion(a); err != nil {
@@ -434,7 +449,7 @@ func (c *validationContext) validateSeedSelectionForMultiZonalShoot() error {
 	return nil
 }
 
-func (c *validationContext) validateScheduling(ctx context.Context, a admission.Attributes, authorizer authorizer.Authorizer, shootLister gardencorev1beta1listers.ShootLister, seedLister gardencorev1beta1listers.SeedLister) error {
+func (c *validationContext) validateScheduling(ctx context.Context, a admission.Attributes, authorizer authorizer.Authorizer, shootLister gardencorev1beta1listers.ShootLister, seedLister gardencorev1beta1listers.SeedLister, managedSeedLister seedmanagementv1alpha1listers.ManagedSeedLister) error {
 	var (
 		shootIsBeingScheduled          = c.oldShoot.Spec.SeedName == nil && c.shoot.Spec.SeedName != nil
 		shootIsBeingRescheduled        = c.oldShoot.Spec.SeedName != nil && c.shoot.Spec.SeedName != nil && *c.shoot.Spec.SeedName != *c.oldShoot.Spec.SeedName
@@ -528,6 +543,14 @@ func (c *validationContext) validateScheduling(ctx context.Context, a admission.
 	}
 
 	if shootIsBeingRescheduled {
+		managedSeed, err := managedSeedLister.ManagedSeeds(v1beta1constants.GardenNamespace).Get(*c.shoot.Spec.SeedName)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return apierrors.NewInternalError(fmt.Errorf("could not get managed seed %q: %w", *c.shoot.Spec.SeedName, err))
+		}
+		if err == nil && managedSeed.Spec.Shoot != nil && managedSeed.Spec.Shoot.Name == c.shoot.Name {
+			return admission.NewForbidden(a, fmt.Errorf("managed seed %q is backed by shoot %q and the shoot cannot be migrated to its own managed seed", *c.shoot.Spec.SeedName, c.shoot.Name))
+		}
+
 		oldSeed, err := seedLister.Get(*c.oldShoot.Spec.SeedName)
 		if err != nil {
 			return apierrors.NewInternalError(fmt.Errorf("could not find referenced seed: %+v", err.Error()))

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -28,8 +28,10 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	securityinformers "github.com/gardener/gardener/pkg/client/security/informers/externalversions"
+	seedmanagementinformers "github.com/gardener/gardener/pkg/client/seedmanagement/informers/externalversions"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -40,22 +42,23 @@ import (
 var _ = Describe("validator", func() {
 	Describe("#Validate", func() {
 		var (
-			ctx                     context.Context
-			admissionHandler        *ValidateShoot
-			ctrl                    *gomock.Controller
-			auth                    *mockauthorizer.MockAuthorizer
-			kubeInformerFactory     kubeinformers.SharedInformerFactory
-			coreInformerFactory     gardencoreinformers.SharedInformerFactory
-			securityInformerFactory securityinformers.SharedInformerFactory
-			cloudProfile            gardencorev1beta1.CloudProfile
-			namespacedCloudProfile  gardencorev1beta1.NamespacedCloudProfile
-			seed                    gardencorev1beta1.Seed
-			secretBinding           gardencorev1beta1.SecretBinding
-			credentialsBinding      securityv1alpha1.CredentialsBinding
-			project                 gardencorev1beta1.Project
-			shoot                   core.Shoot
-			shootWithoutSeed        core.Shoot
-			versionedShoot          gardencorev1beta1.Shoot
+			ctx                           context.Context
+			admissionHandler              *ValidateShoot
+			ctrl                          *gomock.Controller
+			auth                          *mockauthorizer.MockAuthorizer
+			kubeInformerFactory           kubeinformers.SharedInformerFactory
+			coreInformerFactory           gardencoreinformers.SharedInformerFactory
+			securityInformerFactory       securityinformers.SharedInformerFactory
+			seedManagementInformerFactory seedmanagementinformers.SharedInformerFactory
+			cloudProfile                  gardencorev1beta1.CloudProfile
+			namespacedCloudProfile        gardencorev1beta1.NamespacedCloudProfile
+			seed                          gardencorev1beta1.Seed
+			secretBinding                 gardencorev1beta1.SecretBinding
+			credentialsBinding            securityv1alpha1.CredentialsBinding
+			project                       gardencorev1beta1.Project
+			shoot                         core.Shoot
+			shootWithoutSeed              core.Shoot
+			versionedShoot                gardencorev1beta1.Shoot
 
 			userInfo            = &user.DefaultInfo{Name: "foo"}
 			authorizeAttributes authorizer.AttributesRecord
@@ -353,6 +356,8 @@ var _ = Describe("validator", func() {
 			admissionHandler.SetCoreInformerFactory(coreInformerFactory)
 			securityInformerFactory = securityinformers.NewSharedInformerFactory(nil, 0)
 			admissionHandler.SetSecurityInformerFactory(securityInformerFactory)
+			seedManagementInformerFactory = seedmanagementinformers.NewSharedInformerFactory(nil, 0)
+			admissionHandler.SetSeedManagementInformerFactory(seedManagementInformerFactory)
 
 			authorizeAttributes = authorizer.AttributesRecord{
 				User:            userInfo,
@@ -5877,6 +5882,54 @@ var _ = Describe("validator", func() {
 					seed.Spec.Provider.Type = "gcp"
 					newSeed.Spec.Provider.Type = "aws"
 
+					attrs := admission.NewAttributesRecord(&shoot, &oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "binding", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should reject migration of shoot to the seed it represents as a managed seed", func() {
+					managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      newSeedName,
+							Namespace: v1beta1constants.GardenNamespace,
+						},
+						Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+							Shoot: &seedmanagementv1alpha1.Shoot{
+								Name: shoot.Name,
+							},
+						},
+					}
+					Expect(seedManagementInformerFactory.Seedmanagement().V1alpha1().ManagedSeeds().Informer().GetStore().Add(managedSeed)).To(Succeed())
+
+					attrs := admission.NewAttributesRecord(&shoot, &oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "binding", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("managed seed %q is backed by shoot %q and the shoot cannot be migrated to its own managed seed", newSeedName, shoot.Name)))
+				})
+
+				It("should allow migration of shoot to a seed that is not its own managed seed", func() {
+					managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      newSeedName,
+							Namespace: v1beta1constants.GardenNamespace,
+						},
+						Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+							Shoot: &seedmanagementv1alpha1.Shoot{
+								Name: "other-shoot",
+							},
+						},
+					}
+					Expect(seedManagementInformerFactory.Seedmanagement().V1alpha1().ManagedSeeds().Informer().GetStore().Add(managedSeed)).To(Succeed())
+
+					attrs := admission.NewAttributesRecord(&shoot, &oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "binding", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should allow migration when no managed seed exists for the destination seed", func() {
 					attrs := admission.NewAttributesRecord(&shoot, &oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "binding", admission.Update, &metav1.UpdateOptions{}, false, nil)
 					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

A shoot registered as a `ManagedSeed `cannot be control-plane migrated to the seed that the `ManagedSeed` represents, as this would create a circular dependency: the shoot depends on the seed it is supposed to back.

This change adds a validation in the `Shoot Validator` admission plugin that blocks rescheduling when the destination seed is backed by the shoot being migrated.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @adenitiu @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
