### PR TITLE
Silence `go list` error in `hack/tools.mk` when g/g is not a dependency

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -9,15 +9,15 @@
 # as needed. If the required tool (version) is not built/installed yet, make will make sure to build/install it.
 # The *_VERSION variables in this file contain the "default" values, but can be overwritten in the top level make file.
 
-IS_GARDENER := $(shell go list -f '{{.Main}}' -m github.com/gardener/gardener)
+# dependency on github.com/gardener/gardener is optional.
+# If other repos don't use it and the project doesn't depend on the package, silence the error to minimize confusion.
+IS_GARDENER := $(shell go list -f '{{.Main}}' -m github.com/gardener/gardener 2>/dev/null)
 
 ifeq ($(IS_GARDENER),true)
 GARDENER_HACK_DIR          := ./hack
 GARDENER_TOOL_DIR          := ./hack/tools
 GARDENER_LOGCHECK_DIR      := ./hack/tools/logcheck
 else
-# dependency on github.com/gardener/gardener is optional.
-# If other repos don't use it and the project doesn't depend on the package, silence the error to minimize confusion.
 GARDENER_HACK_DIR          := $(shell go list -m -f "{{.Dir}}" github.com/gardener/gardener 2>/dev/null)/hack
 GARDENER_TOOL_DIR          := $(shell go list -m -f "{{.Dir}}" github.com/gardener/gardener/hack/tools 2>/dev/null)
 GARDENER_LOGCHECK_DIR      := $(GARDENER_TOOL_DIR)/logcheck


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

In a repo that does not depend on `github.com/gardener/gardener`, running `go list -m github.com/gardener/gardener` results in an error.
For some reason, this error has been silenced for `GARDENER_HACK_DIR` and `GARDENER_TOOL_DIR`, but not for `IS_GARDENER`. As a result, for repositories that do not depend on g/g, the error `go: module github.com/gardener/gardener: not a known dependency` will be printed out.

This PR solves this by redirecting anything written to stderr for `IS_GARDENER` to `/dev/null`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Including `hack/tools.mk` in a repository that does not depend on `github.com/gardener/gardener` no longer prints an error on every `make` invocation.
```
