### PR TITLE
Improve memory consumption for `gardener-admission-controller`

### DIFF
--- a/cmd/gardener-admission-controller/app/app.go
+++ b/cmd/gardener-admission-controller/app/app.go
@@ -139,6 +139,9 @@ func addAllFieldIndexes(ctx context.Context, i client.FieldIndexer) error {
 		indexer.AddBackupBucketShootRefNamespace,
 		indexer.AddBackupEntryShootRefName,
 		indexer.AddBackupEntryShootRefNamespace,
+		indexer.AddShootAuditPolicyConfigMapName,
+		indexer.AddShootAuthenticationConfigMapName,
+		indexer.AddShootAuthorizationConfigMapName,
 	} {
 		if err := fn(ctx, i); err != nil {
 			return err

--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/add.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/add.go
@@ -50,7 +50,8 @@ func NewHandler(apiReader, c client.Reader, decoder admission.Decoder) admission
 		GetConfigMapNameFromShoot: func(shoot *gardencore.Shoot) string {
 			return gardencorehelper.GetShootAuditPolicyConfigMapName(shoot.Spec.Kubernetes.KubeAPIServer)
 		},
-		AdmitConfig: admitConfig,
+		ShootFieldSelector: gardencore.ShootAuditPolicyConfigMapName,
+		AdmitConfig:        admitConfig,
 	}
 }
 

--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/add_test.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/add_test.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/auditpolicy"
+	"github.com/gardener/gardener/pkg/api/indexer"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
@@ -123,7 +125,10 @@ rules:
 	BeforeEach(func() {
 		testEncoder = &jsonserializer.Serializer{}
 
-		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(kubernetes.GardenScheme).
+			WithIndex(&gardencorev1beta1.Shoot{}, gardencore.ShootAuditPolicyConfigMapName, indexer.ShootAuditPolicyConfigMapNameIndexerFunc).
+			Build()
 
 		decoder = admission.NewDecoder(kubernetes.GardenScheme)
 
@@ -354,7 +359,9 @@ rules:
 					shootInDifferentNamespaceAndReferencing.Namespace = shootNamespace + "other"
 					Expect(fakeClient.Create(ctx, shootInDifferentNamespaceAndReferencing)).To(Succeed())
 
-					test(admissionv1.Update, cm, cm, true, statusCodeAllowed, "ConfigMap is not referenced by a Shoot", "")
+					newCm := cm.DeepCopy()
+					newCm.Data["policy"] = anotherValidAuditPolicy
+					test(admissionv1.Update, cm, newCm, true, statusCodeAllowed, "ConfigMap is not referenced by a Shoot", "")
 				})
 
 				It("did not change policy field", func() {

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/add.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/add.go
@@ -76,7 +76,8 @@ func NewHandler(apiReader, c client.Reader, decoder admission.Decoder) admission
 			}
 			return sets.New(getIssuersFromShoot(shoot)...).Equal(sets.New(getIssuersFromShoot(oldShoot)...))
 		},
-		AdmitConfig: h.admitConfig,
+		ShootFieldSelector: gardencore.ShootAuthenticationConfigMapName,
+		AdmitConfig:        h.admitConfig,
 	}
 }
 

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
@@ -23,6 +23,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/authenticationconfig"
+	"github.com/gardener/gardener/pkg/api/indexer"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -207,7 +209,10 @@ anonymous:
 	BeforeEach(func() {
 		testEncoder = &jsonserializer.Serializer{}
 
-		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(kubernetes.GardenScheme).
+			WithIndex(&gardencorev1beta1.Shoot{}, gardencore.ShootAuthenticationConfigMapName, indexer.ShootAuthenticationConfigMapNameIndexerFunc).
+			Build()
 
 		decoder = admission.NewDecoder(kubernetes.GardenScheme)
 
@@ -619,7 +624,9 @@ anonymous:
 					shootInDifferentNamespaceAndReferencing.Namespace = shootNamespace + "other"
 					Expect(fakeClient.Create(ctx, shootInDifferentNamespaceAndReferencing)).To(Succeed())
 
-					test(admissionv1.Update, cm, cm, true, statusCodeAllowed, "ConfigMap is not referenced by a Shoot", "")
+					newCm := cm.DeepCopy()
+					newCm.Data["config.yaml"] = anotherValidAuthenticationConfiguration
+					test(admissionv1.Update, cm, newCm, true, statusCodeAllowed, "ConfigMap is not referenced by a Shoot", "")
 				})
 
 				It("did not change config.yaml field", func() {

--- a/pkg/admissioncontroller/webhook/admission/authorizationconfig/add.go
+++ b/pkg/admissioncontroller/webhook/admission/authorizationconfig/add.go
@@ -67,7 +67,8 @@ func NewHandler(apiReader, c client.Reader, decoder admission.Decoder) admission
 		SkipValidationOnShootUpdate: func(shoot, oldShoot *gardencore.Shoot) bool {
 			return sets.New(getKubeconfigAuthorizerNamesFromShoot(shoot)...).Equal(sets.New(getKubeconfigAuthorizerNamesFromShoot(oldShoot)...))
 		},
-		AdmitConfig: admitConfig,
+		ShootFieldSelector: gardencore.ShootAuthorizationConfigMapName,
+		AdmitConfig:        admitConfig,
 	}
 }
 

--- a/pkg/admissioncontroller/webhook/admission/authorizationconfig/add_test.go
+++ b/pkg/admissioncontroller/webhook/admission/authorizationconfig/add_test.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/authorizationconfig"
+	"github.com/gardener/gardener/pkg/api/indexer"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
@@ -113,7 +115,10 @@ authorizers:
 	BeforeEach(func() {
 		testEncoder = &jsonserializer.Serializer{}
 
-		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(kubernetes.GardenScheme).
+			WithIndex(&gardencorev1beta1.Shoot{}, gardencore.ShootAuthorizationConfigMapName, indexer.ShootAuthorizationConfigMapNameIndexerFunc).
+			Build()
 
 		decoder = admission.NewDecoder(kubernetes.GardenScheme)
 
@@ -343,7 +348,9 @@ authorizers:
 					shootInDifferentNamespaceAndReferencing.Namespace = shootNamespace + "other"
 					Expect(fakeClient.Create(ctx, shootInDifferentNamespaceAndReferencing)).To(Succeed())
 
-					test(admissionv1.Update, configMap, configMap, true, statusCodeAllowed, "ConfigMap is not referenced by a Shoot", "")
+					newCm := configMap.DeepCopy()
+					newCm.Data["config.yaml"] = anotherValidAuthorizationConfiguration
+					test(admissionv1.Update, configMap, newCm, true, statusCodeAllowed, "ConfigMap is not referenced by a Shoot", "")
 				})
 
 				It("did not change config.yaml field", func() {

--- a/pkg/api/indexer/gardener_core.go
+++ b/pkg/api/indexer/gardener_core.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
@@ -136,6 +137,57 @@ func NamespacedCloudProfileParentRefNameIndexerFunc(obj client.Object) []string 
 func AddProjectNamespace(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &gardencorev1beta1.Project{}, core.ProjectNamespace, ProjectNamespaceIndexerFunc); err != nil {
 		return fmt.Errorf("failed to add indexer for %s to Project Informer: %w", core.ProjectNamespace, err)
+	}
+	return nil
+}
+
+// ShootAuditPolicyConfigMapNameIndexerFunc extracts the audit policy ConfigMap name from a Shoot.
+func ShootAuditPolicyConfigMapNameIndexerFunc(obj client.Object) []string {
+	shoot, ok := obj.(*gardencorev1beta1.Shoot)
+	if !ok {
+		return []string{""}
+	}
+	return []string{v1beta1helper.GetShootAuditPolicyConfigMapName(shoot.Spec.Kubernetes.KubeAPIServer)}
+}
+
+// ShootAuthenticationConfigMapNameIndexerFunc extracts the authentication configuration ConfigMap name from a Shoot.
+func ShootAuthenticationConfigMapNameIndexerFunc(obj client.Object) []string {
+	shoot, ok := obj.(*gardencorev1beta1.Shoot)
+	if !ok {
+		return []string{""}
+	}
+	return []string{v1beta1helper.GetShootAuthenticationConfigurationConfigMapName(shoot.Spec.Kubernetes.KubeAPIServer)}
+}
+
+// ShootAuthorizationConfigMapNameIndexerFunc extracts the authorization configuration ConfigMap name from a Shoot.
+func ShootAuthorizationConfigMapNameIndexerFunc(obj client.Object) []string {
+	shoot, ok := obj.(*gardencorev1beta1.Shoot)
+	if !ok {
+		return []string{""}
+	}
+	return []string{v1beta1helper.GetShootAuthorizationConfigurationConfigMapName(shoot.Spec.Kubernetes.KubeAPIServer)}
+}
+
+// AddShootAuditPolicyConfigMapName adds an index for core.ShootAuditPolicyConfigMapName to the given indexer.
+func AddShootAuditPolicyConfigMapName(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx, &gardencorev1beta1.Shoot{}, core.ShootAuditPolicyConfigMapName, ShootAuditPolicyConfigMapNameIndexerFunc); err != nil {
+		return fmt.Errorf("failed to add indexer for %s to Shoot Informer: %w", core.ShootAuditPolicyConfigMapName, err)
+	}
+	return nil
+}
+
+// AddShootAuthenticationConfigMapName adds an index for core.ShootAuthenticationConfigMapName to the given indexer.
+func AddShootAuthenticationConfigMapName(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx, &gardencorev1beta1.Shoot{}, core.ShootAuthenticationConfigMapName, ShootAuthenticationConfigMapNameIndexerFunc); err != nil {
+		return fmt.Errorf("failed to add indexer for %s to Shoot Informer: %w", core.ShootAuthenticationConfigMapName, err)
+	}
+	return nil
+}
+
+// AddShootAuthorizationConfigMapName adds an index for core.ShootAuthorizationConfigMapName to the given indexer.
+func AddShootAuthorizationConfigMapName(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx, &gardencorev1beta1.Shoot{}, core.ShootAuthorizationConfigMapName, ShootAuthorizationConfigMapNameIndexerFunc); err != nil {
+		return fmt.Errorf("failed to add indexer for %s to Shoot Informer: %w", core.ShootAuthorizationConfigMapName, err)
 	}
 	return nil
 }

--- a/pkg/api/indexer/gardener_core_test.go
+++ b/pkg/api/indexer/gardener_core_test.go
@@ -39,6 +39,55 @@ var _ = Describe("Core", func() {
 		Entry("Project w/ namespace", &gardencorev1beta1.Project{Spec: gardencorev1beta1.ProjectSpec{Namespace: new("namespace")}}, ConsistOf("namespace")),
 	)
 
+	DescribeTable("#AddShootAuditPolicyConfigMapName",
+		func(obj client.Object, matcher gomegatypes.GomegaMatcher) {
+			Expect(AddShootAuditPolicyConfigMapName(context.TODO(), indexer)).To(Succeed())
+
+			Expect(indexer.obj).To(Equal(&gardencorev1beta1.Shoot{}))
+			Expect(indexer.field).To(Equal("spec.kubernetes.kubeAPIServer.auditConfig.auditPolicy.configMapRef.name"))
+			Expect(indexer.extractValue).NotTo(BeNil())
+			Expect(indexer.extractValue(obj)).To(matcher)
+		},
+
+		Entry("no Shoot", &corev1.Secret{}, ConsistOf("")),
+		Entry("Shoot w/o kubeAPIServer", &gardencorev1beta1.Shoot{}, ConsistOf("")),
+		Entry("Shoot w/ kubeAPIServer but w/o auditConfig", &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Kubernetes: gardencorev1beta1.Kubernetes{KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{}}}}, ConsistOf("")),
+		Entry("Shoot w/ auditConfig but w/o configMapRef", &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Kubernetes: gardencorev1beta1.Kubernetes{KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{AuditConfig: &gardencorev1beta1.AuditConfig{AuditPolicy: &gardencorev1beta1.AuditPolicy{}}}}}}, ConsistOf("")),
+		Entry("Shoot w/ configMapRef", &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Kubernetes: gardencorev1beta1.Kubernetes{KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{AuditConfig: &gardencorev1beta1.AuditConfig{AuditPolicy: &gardencorev1beta1.AuditPolicy{ConfigMapRef: &corev1.ObjectReference{Name: "audit-policy"}}}}}}}, ConsistOf("audit-policy")),
+	)
+
+	DescribeTable("#AddShootAuthenticationConfigMapName",
+		func(obj client.Object, matcher gomegatypes.GomegaMatcher) {
+			Expect(AddShootAuthenticationConfigMapName(context.TODO(), indexer)).To(Succeed())
+
+			Expect(indexer.obj).To(Equal(&gardencorev1beta1.Shoot{}))
+			Expect(indexer.field).To(Equal("spec.kubernetes.kubeAPIServer.structuredAuthentication.configMapName"))
+			Expect(indexer.extractValue).NotTo(BeNil())
+			Expect(indexer.extractValue(obj)).To(matcher)
+		},
+
+		Entry("no Shoot", &corev1.Secret{}, ConsistOf("")),
+		Entry("Shoot w/o kubeAPIServer", &gardencorev1beta1.Shoot{}, ConsistOf("")),
+		Entry("Shoot w/ kubeAPIServer but w/o structuredAuthentication", &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Kubernetes: gardencorev1beta1.Kubernetes{KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{}}}}, ConsistOf("")),
+		Entry("Shoot w/ structuredAuthentication", &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Kubernetes: gardencorev1beta1.Kubernetes{KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{StructuredAuthentication: &gardencorev1beta1.StructuredAuthentication{ConfigMapName: "auth-config"}}}}}, ConsistOf("auth-config")),
+	)
+
+	DescribeTable("#AddShootAuthorizationConfigMapName",
+		func(obj client.Object, matcher gomegatypes.GomegaMatcher) {
+			Expect(AddShootAuthorizationConfigMapName(context.TODO(), indexer)).To(Succeed())
+
+			Expect(indexer.obj).To(Equal(&gardencorev1beta1.Shoot{}))
+			Expect(indexer.field).To(Equal("spec.kubernetes.kubeAPIServer.structuredAuthorization.configMapName"))
+			Expect(indexer.extractValue).NotTo(BeNil())
+			Expect(indexer.extractValue(obj)).To(matcher)
+		},
+
+		Entry("no Shoot", &corev1.Secret{}, ConsistOf("")),
+		Entry("Shoot w/o kubeAPIServer", &gardencorev1beta1.Shoot{}, ConsistOf("")),
+		Entry("Shoot w/ kubeAPIServer but w/o structuredAuthorization", &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Kubernetes: gardencorev1beta1.Kubernetes{KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{}}}}, ConsistOf("")),
+		Entry("Shoot w/ structuredAuthorization", &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Kubernetes: gardencorev1beta1.Kubernetes{KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{StructuredAuthorization: &gardencorev1beta1.StructuredAuthorization{ConfigMapName: "authz-config"}}}}}, ConsistOf("authz-config")),
+	)
+
 	DescribeTable("#AddShootSeedName",
 		func(obj client.Object, matcher gomegatypes.GomegaMatcher) {
 			Expect(AddShootSeedName(context.TODO(), indexer)).To(Succeed())

--- a/pkg/apis/core/field_constants.go
+++ b/pkg/apis/core/field_constants.go
@@ -60,6 +60,15 @@ const (
 	// ShootCloudProfileRefKind is the field selector path for finding
 	// the referenced CloudProfile kind of a core.gardener.cloud/v1beta1.Shoot.
 	ShootCloudProfileRefKind = "spec.cloudProfile.Kind"
+	// ShootAuditPolicyConfigMapName is the field selector path for finding Shoots
+	// referencing a given audit policy ConfigMap.
+	ShootAuditPolicyConfigMapName = "spec.kubernetes.kubeAPIServer.auditConfig.auditPolicy.configMapRef.name"
+	// ShootAuthenticationConfigMapName is the field selector path for finding Shoots
+	// referencing a given authentication configuration ConfigMap.
+	ShootAuthenticationConfigMapName = "spec.kubernetes.kubeAPIServer.structuredAuthentication.configMapName"
+	// ShootAuthorizationConfigMapName is the field selector path for finding Shoots
+	// referencing a given authorization configuration ConfigMap.
+	ShootAuthorizationConfigMapName = "spec.kubernetes.kubeAPIServer.structuredAuthorization.configMapName"
 	// ShootSeedName is the field selector path for finding
 	// the Seed cluster of a core.gardener.cloud/v1beta1.Shoot.
 	ShootSeedName = "spec.seedName"

--- a/pkg/webhook/configvalidator/handler.go
+++ b/pkg/webhook/configvalidator/handler.go
@@ -27,7 +27,7 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	operator "github.com/gardener/gardener/pkg/apis/operator"
+	"github.com/gardener/gardener/pkg/apis/operator"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 )
 
@@ -221,7 +221,15 @@ func (h *Handler) admitConfigMapForShoots(ctx context.Context, request admission
 	}
 
 	if err := h.Decoder.Decode(request, newConfigMap); err != nil {
-		return admission.Errored(http.StatusInternalServerError, err)
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error decoding ConfigMap: %w", err))
+	}
+	
+	if err := h.Decoder.DecodeRaw(request.OldObject, oldConfigMap); err != nil {
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error decoding old ConfigMap: %w", err))
+	}
+
+	if apiequality.Semantic.DeepEqual(newConfigMap.Data, oldConfigMap.Data) {
+		return admissionwebhook.Allowed(fmt.Sprintf("%s did not change", h.ConfigMapPurpose))
 	}
 
 	// lookup if ConfigMap is referenced by any shoot in the same namespace
@@ -249,14 +257,6 @@ func (h *Handler) admitConfigMapForShoots(ctx context.Context, request admission
 	configRaw, err := h.rawConfigurationFromConfigMap(newConfigMap.Data)
 	if err != nil {
 		return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("error getting %s from ConfigMap %s: %w", h.ConfigMapPurpose, client.ObjectKeyFromObject(newConfigMap), err))
-	}
-
-	if err = h.Decoder.DecodeRaw(request.OldObject, oldConfigMap); err != nil {
-		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error decoding old ConfigMap: %w", err))
-	}
-
-	if oldConfigRaw, ok := oldConfigMap.Data[h.ConfigMapDataKey]; ok && oldConfigRaw == configRaw {
-		return admissionwebhook.Allowed(fmt.Sprintf("%s did not change", h.ConfigMapPurpose))
 	}
 
 	if errCode, err := h.AdmitConfig(ctx, configRaw, shoots); err != nil {

--- a/pkg/webhook/configvalidator/handler.go
+++ b/pkg/webhook/configvalidator/handler.go
@@ -61,6 +61,7 @@ type Handler struct {
 
 	ConfigMapPurpose            string
 	ConfigMapDataKey            string
+	ShootFieldSelector          string
 	GetConfigMapNameFromShoot   func(shoot *gardencore.Shoot) string
 	SkipValidationOnShootUpdate func(shoot, oldShoot *gardencore.Shoot) bool
 	AdmitConfig                 func(ctx context.Context, configRaw string, shootsReferencingConfigMap []*gardencore.Shoot) (int32, error)
@@ -223,7 +224,7 @@ func (h *Handler) admitConfigMapForShoots(ctx context.Context, request admission
 	if err := h.Decoder.Decode(request, newConfigMap); err != nil {
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error decoding ConfigMap: %w", err))
 	}
-	
+
 	if err := h.Decoder.DecodeRaw(request.OldObject, oldConfigMap); err != nil {
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error decoding old ConfigMap: %w", err))
 	}
@@ -234,7 +235,11 @@ func (h *Handler) admitConfigMapForShoots(ctx context.Context, request admission
 
 	// lookup if ConfigMap is referenced by any shoot in the same namespace
 	shootList := &gardencorev1beta1.ShootList{}
-	if err := h.Client.List(ctx, shootList, client.InNamespace(request.Namespace)); err != nil {
+	listOpts := []client.ListOption{client.InNamespace(request.Namespace)}
+	if h.ShootFieldSelector != "" {
+		listOpts = append(listOpts, client.MatchingFields{h.ShootFieldSelector: request.Name})
+	}
+	if err := h.Client.List(ctx, shootList, listOpts...); err != nil {
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed listing shoots in namespace %s: %w", request.Namespace, err))
 	}
 
@@ -244,10 +249,7 @@ func (h *Handler) admitConfigMapForShoots(ctx context.Context, request admission
 		if err := gardenCoreScheme.Convert(&obj, shoot, nil); err != nil {
 			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed converting Shoot %s into internal version: %w", client.ObjectKeyFromObject(&obj), err))
 		}
-
-		if h.GetConfigMapNameFromShoot(shoot) == request.Name {
-			shoots = append(shoots, shoot)
-		}
+		shoots = append(shoots, shoot)
 	}
 
 	if len(shoots) == 0 {

--- a/pkg/webhook/configvalidator/handler_test.go
+++ b/pkg/webhook/configvalidator/handler_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Handler", func() {
 		encoder    runtime.Encoder
 		decoder    admission.Decoder
 
+		dataKey   string
 		configMap *corev1.ConfigMap
 		shoot     *gardencorev1beta1.Shoot
 		garden    *operatorv1alpha1.Garden
@@ -52,6 +53,7 @@ var _ = Describe("Handler", func() {
 		encoder = &jsonserializer.Serializer{}
 		decoder = admission.NewDecoder(scheme)
 
+		dataKey = "config.yaml"
 		configMap = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "config-name",
@@ -107,7 +109,7 @@ var _ = Describe("Handler", func() {
 			Decoder:   decoder,
 
 			ConfigMapPurpose: "test config",
-			ConfigMapDataKey: "config.yaml",
+			ConfigMapDataKey: dataKey,
 			GetConfigMapNameFromShoot: func(_ *core.Shoot) string {
 				return configMap.Name
 			},
@@ -262,9 +264,16 @@ var _ = Describe("Handler", func() {
 			request.Operation = admissionv1.Update
 			request.Name = configMap.Name
 
+			configMap.Data = map[string]string{dataKey: "foo"}
 			rawConfigMap, err := runtime.Encode(encoder, configMap)
 			Expect(err).NotTo(HaveOccurred())
 			request.Object.Raw = rawConfigMap
+
+			oldConfigMap := configMap.DeepCopy()
+			oldConfigMap.Data = map[string]string{dataKey: "bar"}
+			rawOldConfigMap, err := runtime.Encode(encoder, oldConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+			request.OldObject.Raw = rawOldConfigMap
 		})
 
 		It("should allow because the operation is not update", func() {
@@ -294,6 +303,11 @@ var _ = Describe("Handler", func() {
 
 		It("should return an error because the ConfigMap does not contain the data key", func() {
 			Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
+			emptyConfigMap := configMap.DeepCopy()
+			emptyConfigMap.Data = map[string]string{}
+			rawEmptyConfigMap, err := runtime.Encode(encoder, emptyConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+			request.Object.Raw = rawEmptyConfigMap
 
 			response := handler.Handle(ctx, request)
 			Expect(response.Allowed).To(BeFalse())

--- a/pkg/webhook/configvalidator/handler_test.go
+++ b/pkg/webhook/configvalidator/handler_test.go
@@ -20,6 +20,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/gardener/gardener/pkg/api/indexer"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
@@ -49,7 +50,10 @@ var _ = Describe("Handler", func() {
 		utilruntime.Must(gardencorev1beta1.AddToScheme(scheme))
 		utilruntime.Must(corev1.AddToScheme(scheme))
 
-		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(scheme).
+			WithIndex(&gardencorev1beta1.Shoot{}, core.ShootAuditPolicyConfigMapName, indexer.ShootAuditPolicyConfigMapNameIndexerFunc).
+			Build()
 		encoder = &jsonserializer.Serializer{}
 		decoder = admission.NewDecoder(scheme)
 
@@ -72,6 +76,13 @@ var _ = Describe("Handler", func() {
 			Spec: gardencorev1beta1.ShootSpec{
 				Kubernetes: gardencorev1beta1.Kubernetes{
 					Version: "1.35.0",
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						AuditConfig: &gardencorev1beta1.AuditConfig{
+							AuditPolicy: &gardencorev1beta1.AuditPolicy{
+								ConfigMapRef: &corev1.ObjectReference{Name: configMap.Name},
+							},
+						},
+					},
 				},
 			},
 		}
@@ -113,6 +124,7 @@ var _ = Describe("Handler", func() {
 			GetConfigMapNameFromShoot: func(_ *core.Shoot) string {
 				return configMap.Name
 			},
+			ShootFieldSelector: core.ShootAuditPolicyConfigMapName,
 			GetNamespace: func() string {
 				return configMap.Namespace
 			},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area performance
/kind bug

**What this PR does / why we need it**:
The Gardener Admission Controller has been recording high memory spikes (up to `120GiB`) in larger landscapes. It was found that the [`configvalidator`](https://github.com/gardener/gardener/blob/c0f53aec6e01a766f433db99b7c926be1b75b69c/pkg/webhook/configvalidator/handler.go) claims plenty of address space to convert the external API version of a shoot (`v1beta1`) to the internal type, which is especially critical for projects containing hundreds or thousands of shoot clusters.

This PR reduces the required memory footprint by:
- Exiting early in case the ConfigMap content is unchanged, e.g. only a finalizer is added.
- Introducing audit, auth and authz field indexes for efficient listing of involved shoots.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The memory footprint of the `gardener-admission-controller` was improved for audit, authentication, and authorization config validators.
```
