### PR TITLE
[GEP-28] Introduce GinK (Gardener-in-KinD) dev setup for self-hosted Shoots with managed infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ DEV_SETUP_WITH_LPP_RESIZE_SUPPORT        ?= false
 DEV_SETUP_WITH_WORKLOAD_IDENTITY_SUPPORT ?= false
 IPFAMILY                                 ?= ipv4
 
-kind-% gind-% operator-% gardener-% garden-% seed-% seed2-% ci-e2e-kind: export IPFAMILY := $(IPFAMILY)
+kind-% gind-% gink-% operator-% gardener-% garden-% seed-% seed2-% ci-e2e-kind: export IPFAMILY := $(IPFAMILY)
 kind-%: export WITH_LPP_RESIZE_SUPPORT := $(DEV_SETUP_WITH_LPP_RESIZE_SUPPORT)
 
 export KUBECONFIG_RUNTIME_CLUSTER         := $(DEV_SETUP)/kubeconfigs/runtime/kubeconfig
@@ -301,6 +301,10 @@ kind2-down: kind-single-node2-down
 # gind-{up,down}
 gind-up gind-down: $(YQ)
 	$(DEV_SETUP)/gind.sh $(subst gind-,,$@)
+
+# gink-{up,down}
+gink-up gink-down: $(YQ)
+	$(DEV_SETUP)/gink.sh $(subst gink-,,$@)
 
 # speed-up skaffold deployments by building all images concurrently
 export SKAFFOLD_BUILD_CONCURRENCY = 0

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -420,13 +420,15 @@ func (g *garden) Start(ctx context.Context) error {
 						// Gardenlet does not have the required RBAC permissions for listing/watching the following
 						// resources on cluster level. Hence, we need to watch them individually with the help of a
 						// SingleObject cache.
-						&corev1.ConfigMap{}:                  kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ConfigMap{}),
-						&corev1.Namespace{}:                  kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Namespace{}),
-						&corev1.Secret{}:                     kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Secret{}),
-						&corev1.ServiceAccount{}:             kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ServiceAccount{}),
-						&gardencorev1.ControllerDeployment{}: kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1.ControllerDeployment{}),
-						&gardencorev1beta1.InternalSecret{}:  kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1beta1.InternalSecret{}),
-						&gardencorev1beta1.Project{}:         kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1beta1.Project{}),
+						&corev1.ConfigMap{}:                    kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ConfigMap{}),
+						&corev1.Namespace{}:                    kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Namespace{}),
+						&corev1.Secret{}:                       kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Secret{}),
+						&corev1.ServiceAccount{}:               kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ServiceAccount{}),
+						&gardencorev1.ControllerDeployment{}:   kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1.ControllerDeployment{}),
+						&gardencorev1beta1.InternalSecret{}:    kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1beta1.InternalSecret{}),
+						&gardencorev1beta1.Project{}:           kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1beta1.Project{}),
+						&gardencorev1beta1.SecretBinding{}:     kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1beta1.SecretBinding{}),
+						&securityv1alpha1.CredentialsBinding{}: kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &securityv1alpha1.CredentialsBinding{}),
 					},
 					kubernetes.GardenScheme,
 				)(config, opts)

--- a/dev-setup/gardenadm.sh
+++ b/dev-setup/gardenadm.sh
@@ -11,7 +11,7 @@ VALID_COMMANDS=("up" "down")
 
 SCENARIO="${SCENARIO:-unmanaged-infra}"
 NETWORK_PROVIDER="${NETWORK_PROVIDER:-calico}"
-VALID_SCENARIOS=("unmanaged-infra" "managed-infra" "connect" "connect-kind")
+VALID_SCENARIOS=("unmanaged-infra" "managed-infra" "connect" "connect-kind" "connect-managed")
 
 function skaffold_profiles() {
   local profiles=(
@@ -49,6 +49,9 @@ garden_runtime_cluster_kubeconfig="$KUBECONFIG_RUNTIME_CLUSTER"
 if [[ "$SCENARIO" == "connect" ]]; then
   garden_runtime_cluster_kubeconfig="$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER"
   ./hack/usage/generate-kubeconfig.sh self-hosted-shoot --docker gind-machine-0 > "$garden_runtime_cluster_kubeconfig"
+elif [[ "$SCENARIO" == "connect-managed" ]]; then
+  garden_runtime_cluster_kubeconfig="$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER"
+  ./hack/usage/generate-kubeconfig.sh self-hosted-shoot | grep -v "namespace: kube-system" > "$garden_runtime_cluster_kubeconfig"
 fi
 
 case "$COMMAND" in
@@ -92,7 +95,7 @@ case "$COMMAND" in
     ;;
 
   down)
-    if [[ "$SCENARIO" != "connect" ]]; then
+    if [[ "$SCENARIO" != "connect" && "$SCENARIO" != "connect-managed" ]]; then
       skaffold delete \
         -n "gardenadm-$SCENARIO"
     else

--- a/dev-setup/gardenadm/resources/overlays/managed-infra/kustomization.yaml
+++ b/dev-setup/gardenadm/resources/overlays/managed-infra/kustomization.yaml
@@ -11,6 +11,7 @@ components:
 - ../../../../gardenconfig/components/credentials/secret-project-garden
 
 patches:
+- path: patch-cloudprofile.yaml
 - path: patch-shoot.yaml
 - target:
     kind: Shoot

--- a/dev-setup/gardenadm/resources/overlays/managed-infra/patch-cloudprofile.yaml
+++ b/dev-setup/gardenadm/resources/overlays/managed-infra/patch-cloudprofile.yaml
@@ -1,0 +1,9 @@
+apiVersion: core.gardener.cloud/v1beta1
+kind: CloudProfile
+metadata:
+  name: local
+spec:
+  regions:
+    - name: local
+      zones:
+        - name: local

--- a/dev-setup/gardenlet/overlays/multi-node-gardenadm/.gitignore
+++ b/dev-setup/gardenlet/overlays/multi-node-gardenadm/.gitignore
@@ -1,0 +1,1 @@
+patch-*.yaml

--- a/dev-setup/gardenlet/overlays/multi-node-gardenadm/generate-patch-managedseed.sh
+++ b/dev-setup/gardenlet/overlays/multi-node-gardenadm/generate-patch-managedseed.sh
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -o pipefail
+
+source "$(dirname "$0")/../../../../hack/lockfile.sh"
+acquire_lockfile "/tmp/generate-patch-managedseed.sh.lock"
+
+dir="$(dirname $0)"
+type="${1:-unmanaged-infra}"
+
+if [[ "$type" == "unmanaged-infra" ]]; then
+  patch_file="$dir/patch-managedseed.yaml"
+  cat <<EOF > "$patch_file"
+apiVersion: seedmanagement.gardener.cloud/v1alpha1
+kind: ManagedSeed
+metadata:
+  name: root
+  namespace: garden
+spec:
+  gardenlet:
+    config:
+      seedConfig:
+        spec:
+          networks:
+            nodes: 172.18.0.0/24
+            pods: 10.0.0.0/15
+            services: 10.2.0.0/16
+            shootDefaults:
+              pods: 10.3.0.0/16
+              services: 10.4.0.0/16
+EOF
+fi
+
+if [[ "$type" == "managed-infra" ]]; then
+  patch_file="$dir/patch-managedseed.yaml"
+  cat <<EOF > "$patch_file"
+apiVersion: seedmanagement.gardener.cloud/v1alpha1
+kind: ManagedSeed
+metadata:
+  name: root
+  namespace: garden
+spec:
+  gardenlet:
+    config:
+      seedConfig:
+        spec:
+          networks:
+            nodes: 10.0.0.0/16
+            pods: 10.3.0.0/16
+            services: 10.4.0.0/16
+            shootDefaults:
+              pods: 10.5.0.0/16
+              services: 10.6.0.0/16
+EOF
+fi

--- a/dev-setup/gardenlet/overlays/multi-node-gardenadm/kustomization.yaml
+++ b/dev-setup/gardenlet/overlays/multi-node-gardenadm/kustomization.yaml
@@ -6,3 +6,6 @@ resources:
 
 components:
 - ../../components/kubeconfigs/seed-root
+
+patches:
+- path: patch-managedseed.yaml

--- a/dev-setup/gind.sh
+++ b/dev-setup/gind.sh
@@ -91,6 +91,7 @@ case "$COMMAND" in
 
     # Register the self-hosted shoot as a seed via a ManagedSeed
     if (( level >= 5 )); then
+      "$(dirname "$0")/gardenlet/overlays/multi-node-gardenadm/generate-patch-managedseed.sh" unmanaged-infra
       make seed-up KUBECONFIG="$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER"
     fi
     ;;

--- a/dev-setup/gink.sh
+++ b/dev-setup/gink.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o pipefail
+
+COMMAND="${1:-up}"
+VALID_COMMANDS=("up" "down")
+
+SCENARIO="${SCENARIO:-default}"
+declare -A SCENARIO_LEVEL=(
+  [default]=1  # Run `gardenadm bootstrap` and export the kubeconfig for the self-hosted shoot
+  [connect]=2  # Like 'default', but also deploys Gardener into the self-hosted shoot and runs `gardenadm connect` to deploy gardenlet which registers the Shoot
+  [full]=3     # Like 'connect', but also registers the self-hosted shoot as a seed via a ManagedSeed
+)
+
+if [[ -z "${SCENARIO_LEVEL[$SCENARIO]+x}" ]]; then
+  echo "Error: Invalid scenario '${SCENARIO}'. Valid options are: ${!SCENARIO_LEVEL[*]}." >&2
+  exit 1
+fi
+
+level="${SCENARIO_LEVEL[$SCENARIO]}"
+
+GARDENADM_RESOURCES_DIR="$(dirname "$0")/gardenadm/resources"
+GARDENADM_GENERATED_DIR="$GARDENADM_RESOURCES_DIR/generated"
+
+case "$COMMAND" in
+  up)
+    make kind-up
+
+    make gardenadm-up SCENARIO=managed-infra
+    make gardenadm
+
+    GARDENADM_BOOTSTRAP_FLAGS="${GARDENADM_BOOTSTRAP_FLAGS:-}"
+
+    KUBECONFIG="$KUBECONFIG_RUNTIME_CLUSTER" \
+    IMAGEVECTOR_OVERWRITE="$GARDENADM_GENERATED_DIR/.imagevector-overwrite.yaml" \
+    IMAGEVECTOR_OVERWRITE_COMPONENTS="$GARDENADM_RESOURCES_DIR/imagevector-overwrite-components.yaml" \
+    IMAGEVECTOR_OVERWRITE_CHARTS="$GARDENADM_GENERATED_DIR/.imagevector-overwrite-charts.yaml" \
+      "$(dirname "$0")/../bin/gardenadm" bootstrap \
+        -d "$GARDENADM_GENERATED_DIR/managed-infra" \
+        --kubeconfig-output "$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER" \
+        ${GARDENADM_BOOTSTRAP_FLAGS}
+
+    cp "$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER" "$(dirname "$0")/gardenconfig/components/credentials/secret-project-garden/kubeconfig/kubeconfig"
+    cp "$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER" "$(dirname "$0")/gardenconfig/components/credentials/secret-project-local/kubeconfig/kubeconfig"
+
+    kubectl --kubeconfig "$KUBECONFIG_RUNTIME_CLUSTER" scale deployment gardener-resource-manager -n shoot--garden--root --replicas=0
+
+    # Deploy Gardener into the self-hosted shoot and run `gardenadm connect` to deploy gardenlet which registers the Shoot
+    if (( level >= 2 )); then
+      make gardenadm-up SCENARIO=connect-managed # deploys gardener-operator, the 'Garden' resource, and waits for reconciliation
+      connect_command="$(KUBECONFIG=$KUBECONFIG_VIRTUAL_GARDEN_CLUSTER "$(dirname "$0")/../bin/gardenadm" token create --print-connect-command --shoot-namespace garden --shoot-name root)"
+      # The connect command must run inside the control plane machine pod (mirroring how gind.sh runs it in machine-0
+      # via docker exec). The machine pod has gardenadm installed in /gardenadm/gardenadm.
+      technical_id="shoot--garden--root"
+      machine_namespace="infra-${technical_id}"
+      machine_pod="$(kubectl --kubeconfig "$KUBECONFIG_RUNTIME_CLUSTER" -n "$machine_namespace" get pods -l app=machine --sort-by=.metadata.name -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep "${technical_id}-control-plane-" | head -1)"
+      kubectl --kubeconfig "$KUBECONFIG_RUNTIME_CLUSTER" exec -n "$machine_namespace" "$machine_pod" -c node -- bash -c "IMAGEVECTOR_OVERWRITE=/var/lib/gardenadm/imagevector-overwrite.yaml IMAGEVECTOR_OVERWRITE_CHARTS=/var/lib/gardenadm/imagevector-overwrite-charts.yaml /opt/bin/${connect_command}"
+    fi
+
+    # Register the self-hosted shoot as a seed via a ManagedSeed
+    if (( level >= 3 )); then
+      "$(dirname "$0")/gardenlet/overlays/multi-node-gardenadm/generate-patch-managedseed.sh" managed-infra
+      make seed-up KUBECONFIG="$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER"
+    fi
+    ;;
+
+  down)
+    if kubectl --kubeconfig "$KUBECONFIG_VIRTUAL_GARDEN_CLUSTER" -n garden get managedseed root &>/dev/null; then
+      make seed-down KUBECONFIG="$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER"
+    fi
+
+    make gardenadm-down SCENARIO=managed-infra
+
+    make kind-down
+    ;;
+
+  *)
+    echo "Error: Invalid command '${COMMAND}'. Valid options are: ${VALID_COMMANDS[*]}." >&2
+    exit 1
+   ;;
+esac

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -177,39 +177,37 @@ gind-machine-0   Ready    control-plane   7m15s   v1.35.0
 gind-machine-1   Ready    worker          8m48s   v1.35.0
 ```
 
+### Tearing Down
+
+When you are done, you can delete the setup by running
+
+```shell
+make gind-down
+```
+
 ## "Managed Infrastructure" Scenario
-
-### Setting Up the KinD Cluster
-
-```shell
-make kind-up
-```
-
-All following steps assume that you are using the kubeconfig for this KinD cluster:
-
-```shell
-export KUBECONFIG=$PWD/dev-setup/kubeconfigs/runtime/kubeconfig
-```
 
 Use the following command to prepare the `gardenadm` managed infrastructure scenario:
 
 ```shell
-make gardenadm-up SCENARIO=managed-infra
+make gink-up # Gardener-in-kind
 ```
 
-This will first build the needed images and then render the needed manifests for `gardenadm bootstrap` to the [`./dev-setup/gardenadm/resources/generated/managed-infra`](../../dev-setup/gardenadm/resources/generated/managed-infra) directory.
-
-### Bootstrapping the Self-Hosted Shoot Cluster
-
-Use `go run` to execute `gardenadm` commands on your machine:
+This will first setup a kind cluster and then use the cluster to perform `gardenadm bootstrap` to create a self-hosted shoot cluster.
+At first, this will build the needed images and then render the needed manifests for `gardenadm bootstrap` to the [`./dev-setup/gardenadm/resources/generated/managed-infra`](../../dev-setup/gardenadm/resources/generated/managed-infra) directory.
+The whole process usually takes a couple of minutes, but eventually you should see output like this:
 
 ```shell
-$ export IMAGEVECTOR_OVERWRITE=$PWD/dev-setup/gardenadm/resources/generated/.imagevector-overwrite.yaml
-$ go run ./cmd/gardenadm bootstrap -d ./dev-setup/gardenadm/resources/generated/managed-infra
-...
 [shoot--garden--root-control-plane-58ffc-2l6s7] Your Shoot cluster control-plane has initialized successfully!
-...
 ```
+
+`make gink-up` supports a `SCENARIO` variable that controls how far the setup proceeds (e.g., `make gink-up SCENARIO=default`):
+
+| `SCENARIO` | Description                                                                                                                                                     |
+|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `default`  | Creates the kind cluster, runs `gardenadm bootstrap` and exports the kubeconfig for the self-hosted shoot. This is the default when no `SCENARIO` is specified. |
+| `connect`  | Like `default`, but also deploys Gardener into the self-hosted shoot and runs `gardenadm connect` to deploy gardenlet which registers the `Shoot`.              |
+| `full`     | Like `connect`, but also registers the self-hosted shoot as a seed via a `ManagedSeed`, enabling it to host shoot clusters.                                     |
 
 ### Connecting to the Self-Hosted Shoot Cluster
 
@@ -224,18 +222,19 @@ NAME                                                    STATUS   ROLES    AGE   
 machine-shoot--garden--root-control-plane-58ffc-2l6s7   Ready    <none>   4m11s   v1.35.0
 ```
 
-### Tearing Down the KinD Cluster
+### Tearing Down
 
 When you are done, you can delete the setup by running
 
 ```shell
-make kind-down
+make gink-down
 ```
 
 ## Connecting the Self-Hosted Shoot Cluster to Gardener
 
 > [!TIP]
 > For the unmanaged infrastructure scenario, this step is automated when using `make gind-up SCENARIO=connect`.
+> For the managed infrastructure scenario, this step is automated when using `make gink-up SCENARIO=connect`.
 
 After you have successfully bootstrapped a self-hosted shoot cluster (either via the [unmanaged infrastructure](#unmanaged-infrastructure-scenario) or the [managed infrastructure](#managed-infrastructure-scenario) scenario), you can connect it to an existing Gardener system.
 For this, you need to deploy Gardener to your self-hosted shoot cluster.
@@ -310,6 +309,7 @@ garden      root   local          local      local    1.35.0        Awake       
 
 > [!TIP]
 > For the unmanaged infrastructure scenario, this step is automated when using `make gind-up SCENARIO=full`.
+> For the managed infrastructure scenario, this step is automated when using `make gink-up SCENARIO=full`.
 
 After the self-hosted shoot has been connected to Gardener (see above), you can register it as a seed by creating a `ManagedSeed` resource.
 This enables the self-hosted shoot to host other shoot clusters.

--- a/hack/ci-e2e-kind-gardenadm-unmanaged-infra-external-gardener.sh
+++ b/hack/ci-e2e-kind-gardenadm-unmanaged-infra-external-gardener.sh
@@ -30,5 +30,6 @@ make gardenadm-up SCENARIO=connect-kind
 make test-e2e-local-gardenadm-unmanaged-infra-initjoin
 make test-e2e-local-gardenadm-unmanaged-infra-connect
 
+"$(dirname "$0")/../dev-setup/gardenlet/overlays/multi-node-gardenadm/generate-patch-managedseed.sh" unmanaged-infra
 make seed-up KUBECONFIG="$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER"
 make test-e2e-local-gardenadm-unmanaged-infra-seed

--- a/hack/ci-e2e-kind-gardenadm-unmanaged-infra.sh
+++ b/hack/ci-e2e-kind-gardenadm-unmanaged-infra.sh
@@ -29,5 +29,6 @@ make test-e2e-local-gardenadm-unmanaged-infra-initjoin
 make gardenadm-up SCENARIO=connect
 make test-e2e-local-gardenadm-unmanaged-infra-connect
 
+"$(dirname "$0")/../dev-setup/gardenlet/overlays/multi-node-gardenadm/generate-patch-managedseed.sh" unmanaged-infra
 make seed-up KUBECONFIG="$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER"
 make test-e2e-local-gardenadm-unmanaged-infra-seed

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -220,6 +220,9 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 				authwebhook.WithAlwaysAllowedVerbs("get", "list", "watch"),
 			)
 
+		case credentialsBindingResource:
+			return requestAuthorizer.CheckRead(graph.VertexTypeCredentialsBinding, attrs)
+
 		case eventCoreResource, eventResource:
 			return a.authorizeEvent(log, attrs)
 
@@ -250,6 +253,9 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 					seedmanagement.ManagedSeedShootName: shootName,
 				}),
 			)
+
+		case secretBindingResource:
+			return requestAuthorizer.CheckRead(graph.VertexTypeSecretBinding, attrs)
 
 		case secretResource:
 			return a.authorizeSecret(ctx, requestAuthorizer, userType, attrs)

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -2139,6 +2139,138 @@ var _ = Describe("Shoot", func() {
 				})
 			})
 
+			When("requested for CredentialsBindings", func() {
+				var (
+					name, namespace string
+					attrs           *auth.AttributesRecord
+				)
+
+				BeforeEach(func() {
+					name, namespace = "foo", "bar"
+					attrs = &auth.AttributesRecord{
+						User:            gardenletUser,
+						Name:            name,
+						Namespace:       namespace,
+						APIGroup:        securityv1alpha1.SchemeGroupVersion.Group,
+						Resource:        "credentialsbindings",
+						ResourceRequest: true,
+						Verb:            "get",
+					}
+				})
+
+				DescribeTable("should return correct result if path exists",
+					func(verb string) {
+						attrs.Verb = verb
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeCredentialsBinding, namespace, name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(true)
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+					},
+
+					Entry("get", "get"),
+					Entry("list", "list"),
+					Entry("watch", "watch"),
+				)
+
+				DescribeTable("should have no opinion because no allowed verb",
+					func(verb string) {
+						attrs.Verb = verb
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list watch]"))
+					},
+
+					Entry("create", "create"),
+					Entry("patch", "patch"),
+					Entry("update", "update"),
+					Entry("delete", "delete"),
+					Entry("deletecollection", "deletecollection"),
+				)
+
+				It("should have no opinion because path to shoot does not exist", func() {
+					graph.EXPECT().HasPathFrom(graphutils.VertexTypeCredentialsBinding, namespace, name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("no relationship found"))
+				})
+			})
+
+			When("requested for SecretBindings", func() {
+				var (
+					name, namespace string
+					attrs           *auth.AttributesRecord
+				)
+
+				BeforeEach(func() {
+					name, namespace = "foo", "bar"
+					attrs = &auth.AttributesRecord{
+						User:            gardenletUser,
+						Name:            name,
+						Namespace:       namespace,
+						APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+						Resource:        "secretbindings",
+						ResourceRequest: true,
+						Verb:            "get",
+					}
+				})
+
+				DescribeTable("should return correct result if path exists",
+					func(verb string) {
+						attrs.Verb = verb
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeSecretBinding, namespace, name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(true)
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+					},
+
+					Entry("get", "get"),
+					Entry("list", "list"),
+					Entry("watch", "watch"),
+				)
+
+				DescribeTable("should have no opinion because no allowed verb",
+					func(verb string) {
+						attrs.Verb = verb
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list watch]"))
+					},
+
+					Entry("create", "create"),
+					Entry("patch", "patch"),
+					Entry("update", "update"),
+					Entry("delete", "delete"),
+					Entry("deletecollection", "deletecollection"),
+				)
+
+				It("should have no opinion because path to shoot does not exist", func() {
+					graph.EXPECT().HasPathFrom(graphutils.VertexTypeSecretBinding, namespace, name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("no relationship found"))
+				})
+			})
+
 			When("requested for Secrets", func() {
 				var (
 					name, namespace string

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -317,6 +317,11 @@ func prepareGardenerResources(ctx context.Context, b *botanist.GardenadmBotanist
 		},
 		Resources: sharedcomponent.StringifyGroupResources(sharedcomponent.GetResourcesForEncryptionFromConfig(shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig)),
 	}
+	// The bootstrap restore (KinD → self-hosted shoot) has already completed successfully. Mark it as such so that
+	// gardenlet computes a normal Reconcile rather than triggering another Restore with the now-stale ShootState.
+	if shoot.Status.LastOperation != nil && shoot.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeRestore {
+		shoot.Status.LastOperation.State = gardencorev1beta1.LastOperationStateSucceeded
+	}
 	if err := b.GardenClient.Status().Patch(ctx, shoot, patch); err != nil {
 		return fmt.Errorf("failed patching Shoot %s status in garden cluster: %w", client.ObjectKeyFromObject(b.Shoot.GetInfo()), err)
 	}

--- a/pkg/gardenlet/operation/botanist/flow.go
+++ b/pkg/gardenlet/operation/botanist/flow.go
@@ -737,7 +737,7 @@ func (b *Botanist) ReconcileWorkerTaskGroup(skipReadiness bool) flow.TaskGroup {
 		_ = g.Add(flow.Task{
 			Name:         "Deploying cluster-autoscaler",
 			Fn:           b.DeployClusterAutoscaler,
-			SkipIf:       b.Shoot.HibernationEnabled,
+			SkipIf:       b.isGardenadmBootstrap() || b.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/utils/graph/graph.go
+++ b/pkg/utils/graph/graph.go
@@ -78,6 +78,7 @@ func (g *graph) Setup(ctx context.Context, c cache.Cache) error {
 		{&seedmanagementv1alpha1.Gardenlet{}, g.setupGardenletWatch},
 		{&seedmanagementv1alpha1.ManagedSeed{}, g.setupManagedSeedWatch},
 		{&gardencorev1beta1.Project{}, g.setupProjectWatch},
+		{&gardencorev1beta1.SecretBinding{}, g.setupSecretBindingWatch},
 		{&corev1.ServiceAccount{}, g.setupServiceAccountWatch},
 		{&gardencorev1beta1.Shoot{}, g.setupShootWatch},
 		{&securityv1alpha1.CredentialsBinding{}, g.setupCredentialsBindingWatch},
@@ -85,7 +86,6 @@ func (g *graph) Setup(ctx context.Context, c cache.Cache) error {
 
 	if !g.forSelfHostedShoots {
 		setups = append(setups,
-			resourceSetup{&gardencorev1beta1.SecretBinding{}, g.setupSecretBindingWatch},
 			resourceSetup{&gardencorev1beta1.Seed{}, g.setupSeedWatch},
 		)
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Introduces GinK (Gardener-in-KinD) as the local development setup for the `gardenadm` managed infrastructure scenario. The KinD cluster is used for the `gardenadm bootstrap` process. It also contains all nodes of the cluster as pods. `cluster-autoscaler` and `machine-controller-manager` manage the nodes via `provider-local`.

The setup is analogous to GinD and uses a very similar approach.

As not everything was working out of the box, several commits address bugs/limitations to make it possible run the setup.

`make gink-up` supports a `SCENARIO` variable that controls how far the setup proceeds:

| `SCENARIO`  | Description |
|-------------|-------------|
| `default`  | Creates the kind cluster, runs `gardenadm bootstrap` and exports the kubeconfig for the self-hosted shoot. This is the default when no `SCENARIO` is specified. |
| `connect`  | Like `default`, but also deploys Gardener into the self-hosted shoot and runs `gardenadm connect` to deploy gardenlet which registers the `Shoot`. |
| `full`     | Like `connect`, but also registers the self-hosted shoot as a seed via a `ManagedSeed`, enabling it to host shoot clusters. |

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:

Please note that the reconciliation of the `Shoot` resource at the end of `gardenadm connect` does not succeed. This is due to the fact that the registration of the `Shoot` resource causes defaulting to occur and hence requires changes to the operating system configuration. However, the rollout of the operating system configuration via node rollout does not work, yet. This will be addressed at a later point in time.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The local `gardenadm` development setup for the managed infrastructure scenario now uses GinK (Gardener-in-KinD). Refer to the [updated documentation](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally_with_gardenadm.md) for details.
```

/cc @rfranzke @timebertt 