### PR TITLE
[GEP-28] Fix control plane health check for self-hosted shoot

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -707,7 +707,7 @@ func (h *Health) checkWorkers(
 // ComputeRequiredMonitoringSeedDeployments returns names of monitoring deployments based on the given shoot.
 func ComputeRequiredMonitoringSeedDeployments(shoot *gardencorev1beta1.Shoot) sets.Set[string] {
 	requiredDeployments := commonMonitoringDeployments.Clone()
-	if v1beta1helper.IsWorkerless(shoot) {
+	if v1beta1helper.IsWorkerless(shoot) || v1beta1helper.IsShootSelfHosted(shoot.Spec.Provider.Workers) {
 		requiredDeployments.Delete(v1beta1constants.DeploymentNameKubeStateMetrics)
 	}
 

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	healthchecker "github.com/gardener/gardener/pkg/utils/kubernetes/health/checker"
 )
@@ -431,7 +432,16 @@ func (h *Health) checkControlPlane(
 		return exitCondition, nil
 	}
 
-	requiredControlPlaneDeployments, err := ComputeRequiredControlPlaneDeployments(h.shoot.GetInfo())
+	shootIsGarden := false
+	if h.shoot.IsSelfHosted() {
+		var err error
+		shootIsGarden, err = gardenletutils.ClusterIsGarden(ctx, h.seedClient.Client())
+		if err != nil {
+			return nil, fmt.Errorf("failed checking whether shoot is garden: %w", err)
+		}
+	}
+
+	requiredControlPlaneDeployments, err := ComputeRequiredControlPlaneDeployments(h.shoot.GetInfo(), shootIsGarden)
 	if err != nil {
 		return nil, err
 	}
@@ -1118,7 +1128,7 @@ func cosmeticMachineMessage(numberOfMachines int) string {
 }
 
 // ComputeRequiredControlPlaneDeployments returns names of required deployments based on the given shoot.
-func ComputeRequiredControlPlaneDeployments(shoot *gardencorev1beta1.Shoot) (sets.Set[string], error) {
+func ComputeRequiredControlPlaneDeployments(shoot *gardencorev1beta1.Shoot, shootIsGarden bool) (sets.Set[string], error) {
 	requiredControlPlaneDeployments := commonControlPlaneDeployments.Clone()
 
 	if !v1beta1helper.IsWorkerless(shoot) {
@@ -1129,7 +1139,7 @@ func ComputeRequiredControlPlaneDeployments(shoot *gardencorev1beta1.Shoot) (set
 			requiredControlPlaneDeployments.Insert(v1beta1constants.DeploymentNameClusterAutoscaler)
 		}
 
-		if v1beta1helper.ShootWantsVerticalPodAutoscaler(shoot) {
+		if !shootIsGarden && v1beta1helper.ShootWantsVerticalPodAutoscaler(shoot) {
 			for _, vpaDeployment := range v1beta1constants.GetShootVPADeploymentNames() {
 				requiredControlPlaneDeployments.Insert(vpaDeployment)
 			}

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -1133,10 +1133,12 @@ func ComputeRequiredControlPlaneDeployments(shoot *gardencorev1beta1.Shoot, shoo
 
 	if !v1beta1helper.IsWorkerless(shoot) {
 		requiredControlPlaneDeployments.Insert(v1beta1constants.DeploymentNameKubeScheduler)
-		requiredControlPlaneDeployments.Insert(v1beta1constants.DeploymentNameMachineControllerManager)
 
-		if v1beta1helper.ShootWantsClusterAutoscaler(shoot) {
-			requiredControlPlaneDeployments.Insert(v1beta1constants.DeploymentNameClusterAutoscaler)
+		if v1beta1helper.HasManagedInfrastructure(shoot) {
+			requiredControlPlaneDeployments.Insert(v1beta1constants.DeploymentNameMachineControllerManager)
+			if v1beta1helper.ShootWantsClusterAutoscaler(shoot) {
+				requiredControlPlaneDeployments.Insert(v1beta1constants.DeploymentNameClusterAutoscaler)
+			}
 		}
 
 		if !shootIsGarden && v1beta1helper.ShootWantsVerticalPodAutoscaler(shoot) {

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -450,7 +450,7 @@ func (h *Health) checkControlPlane(
 		return exitCondition, err
 	}
 
-	if !h.shoot.IsWorkerless && v1beta1helper.SeedSettingDependencyWatchdogProberEnabled(h.seed.GetInfo().Spec.Settings) {
+	if !h.shoot.IsWorkerless && !h.shoot.IsSelfHosted() && v1beta1helper.SeedSettingDependencyWatchdogProberEnabled(h.seed.GetInfo().Spec.Settings) {
 		if scaledDownDeploymentNames, err := CheckIfDependencyWatchdogProberScaledDownControllers(ctx, h.seedClient.Client(), h.shoot.ControlPlaneNamespace); err != nil {
 			return new(v1beta1helper.FailedCondition(h.clock, h.shoot.GetInfo().Status.LastOperation, h.conditionThresholds, condition, "ControllersScaledDownCheckError", err.Error())), nil
 		} else if len(scaledDownDeploymentNames) > 0 {

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -450,6 +450,7 @@ func (h *Health) checkControlPlane(
 		return exitCondition, err
 	}
 
+	// TODO(acumino): Remove check for self-hosted shoot when dependency-watchdog-prober is enabled for self-hosted shoots.
 	if !h.shoot.IsWorkerless && !h.shoot.IsSelfHosted() && v1beta1helper.SeedSettingDependencyWatchdogProberEnabled(h.seed.GetInfo().Spec.Settings) {
 		if scaledDownDeploymentNames, err := CheckIfDependencyWatchdogProberScaledDownControllers(ctx, h.seedClient.Client(), h.shoot.ControlPlaneNamespace); err != nil {
 			return new(v1beta1helper.FailedCondition(h.clock, h.shoot.GetInfo().Status.LastOperation, h.conditionThresholds, condition, "ControllersScaledDownCheckError", err.Error())), nil
@@ -707,6 +708,7 @@ func (h *Health) checkWorkers(
 // ComputeRequiredMonitoringSeedDeployments returns names of monitoring deployments based on the given shoot.
 func ComputeRequiredMonitoringSeedDeployments(shoot *gardencorev1beta1.Shoot) sets.Set[string] {
 	requiredDeployments := commonMonitoringDeployments.Clone()
+	// TODO(acumino): Remove check for self-hosted shoot when kube-state-metrics is enabled for self-hosted shoots.
 	if v1beta1helper.IsWorkerless(shoot) || v1beta1helper.IsShootSelfHosted(shoot.Spec.Provider.Workers) {
 		requiredDeployments.Delete(v1beta1constants.DeploymentNameKubeStateMetrics)
 	}

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -99,7 +99,27 @@ var _ = Describe("health check", func() {
 				"kube-apiserver",
 				"kube-controller-manager",
 			}
-			commonDeploymentNames = append(workerlessDeploymentNames, "kube-scheduler", "machine-controller-manager")
+			baseWorkerDeploymentNames = []any{
+				"gardener-resource-manager",
+				"kube-apiserver",
+				"kube-controller-manager",
+				"kube-scheduler",
+			}
+			managedInfraDeploymentNames = []any{
+				"gardener-resource-manager",
+				"kube-apiserver",
+				"kube-controller-manager",
+				"kube-scheduler",
+				"machine-controller-manager",
+			}
+			managedInfraShoot = &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					SecretBindingName: new("test-binding"),
+					Provider: gardencorev1beta1.Provider{
+						Workers: []gardencorev1beta1.Worker{{Name: "worker"}},
+					},
+				},
+			}
 		)
 
 		tests := func(shoot *gardencorev1beta1.Shoot, names []any, isWorkerless bool) {
@@ -108,27 +128,6 @@ var _ = Describe("health check", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(deploymentNames.UnsortedList()).To(ConsistOf(names...))
-			})
-
-			It("should return expected deployments for shoot with Cluster Autoscaler", func() {
-				if isWorkerless {
-					return
-				}
-
-				expectedDeploymentNames := append(names, "cluster-autoscaler")
-				shootWithCA := shoot.DeepCopy()
-				shootWithCA.Spec.Provider.Workers = []gardencorev1beta1.Worker{
-					{
-						Name:    "worker",
-						Minimum: 0,
-						Maximum: 1,
-					},
-				}
-
-				deploymentNames, err := ComputeRequiredControlPlaneDeployments(shootWithCA, false)
-
-				Expect(err).ToNot(HaveOccurred())
-				Expect(deploymentNames.UnsortedList()).To(ConsistOf(expectedDeploymentNames...))
 			})
 
 			It("should return expected deployments for shoot with VPA", func() {
@@ -167,11 +166,27 @@ var _ = Describe("health check", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(deploymentNames.UnsortedList()).To(ConsistOf(names...))
 			})
-
 		}
 
-		Context("shoot", func() {
-			tests(shoot, commonDeploymentNames, false)
+		Context("shoot without managed infrastructure", func() {
+			tests(shoot, baseWorkerDeploymentNames, false)
+		})
+
+		Context("shoot with managed infrastructure", func() {
+			tests(managedInfraShoot, managedInfraDeploymentNames, false)
+
+			It("should include cluster-autoscaler when workers have maximum > 0", func() {
+				shootWithCA := managedInfraShoot.DeepCopy()
+				shootWithCA.Spec.Provider.Workers = []gardencorev1beta1.Worker{
+					{Name: "worker", Minimum: 0, Maximum: 1},
+				}
+
+				deploymentNames, err := ComputeRequiredControlPlaneDeployments(shootWithCA, false)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deploymentNames.UnsortedList()).To(ConsistOf(
+					append(managedInfraDeploymentNames, "cluster-autoscaler")...))
+			})
 		})
 
 		Context("workerless shoot", func() {

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -208,7 +208,7 @@ var _ = Describe("health check", func() {
 				Spec: gardencorev1beta1.ShootSpec{
 					Provider: gardencorev1beta1.Provider{
 						Workers: []gardencorev1beta1.Worker{
-							{Name: "worker", ControlPlane: &gardencorev1beta1.WorkerControlPlane{}},
+							{Name: "control-plane", ControlPlane: &gardencorev1beta1.WorkerControlPlane{}},
 						},
 					},
 				},

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -104,7 +104,7 @@ var _ = Describe("health check", func() {
 
 		tests := func(shoot *gardencorev1beta1.Shoot, names []any, isWorkerless bool) {
 			It("should return expected deployments for shoot", func() {
-				deploymentNames, err := ComputeRequiredControlPlaneDeployments(shoot)
+				deploymentNames, err := ComputeRequiredControlPlaneDeployments(shoot, false)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(deploymentNames.UnsortedList()).To(ConsistOf(names...))
@@ -125,7 +125,7 @@ var _ = Describe("health check", func() {
 					},
 				}
 
-				deploymentNames, err := ComputeRequiredControlPlaneDeployments(shootWithCA)
+				deploymentNames, err := ComputeRequiredControlPlaneDeployments(shootWithCA, false)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(deploymentNames.UnsortedList()).To(ConsistOf(expectedDeploymentNames...))
@@ -144,10 +144,28 @@ var _ = Describe("health check", func() {
 					},
 				}
 
-				deploymentNames, err := ComputeRequiredControlPlaneDeployments(shootWithVPA)
+				deploymentNames, err := ComputeRequiredControlPlaneDeployments(shootWithVPA, false)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(deploymentNames.UnsortedList()).To(ConsistOf(expectedDeploymentNames...))
+			})
+
+			It("should not include VPA deployments when shoot is garden", func() {
+				if isWorkerless {
+					return
+				}
+
+				shootWithVPA := shoot.DeepCopy()
+				shootWithVPA.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					VerticalPodAutoscaler: &gardencorev1beta1.VerticalPodAutoscaler{
+						Enabled: true,
+					},
+				}
+
+				deploymentNames, err := ComputeRequiredControlPlaneDeployments(shootWithVPA, true)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deploymentNames.UnsortedList()).To(ConsistOf(names...))
 			})
 
 		}

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -202,6 +202,19 @@ var _ = Describe("health check", func() {
 		It("should return expected deployments for workerless shoot", func() {
 			Expect(ComputeRequiredMonitoringSeedDeployments(workerlessShoot).UnsortedList()).To(BeEmpty())
 		})
+
+		It("should return expected deployments for self-hosted shoot", func() {
+			selfHostedShoot := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Provider: gardencorev1beta1.Provider{
+						Workers: []gardencorev1beta1.Worker{
+							{Name: "worker", ControlPlane: &gardencorev1beta1.WorkerControlPlane{}},
+						},
+					},
+				},
+			}
+			Expect(ComputeRequiredMonitoringSeedDeployments(selfHostedShoot).UnsortedList()).To(BeEmpty())
+		})
 	})
 
 	DescribeTable("#PardonCondition",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Fix control plane health check for self-hosted shoot
- There will be no CA and MCM for unmannaged infra shoot
- If shoot is garden there will be no VPA

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
