### PR TITLE
Don't fail Shoot maintenance if an ETCD encryption key rotation is in progress

### DIFF
--- a/docs/usage/shoot/shoot_maintenance.md
+++ b/docs/usage/shoot/shoot_maintenance.md
@@ -108,6 +108,7 @@ spec:
 
 During the daily maintenance, the `gardener-controller-manager` starts the rotation for specific credentials if the Shoot opted-in for automatic rotation for the given credential and the set period has passed since the last rotation completion.
 Automatic ETCD encryption key rotation requires a running ETCD and `kube-apiserver`, so it is skipped while the Shoot is hibernated. If an overdue automatic rotation cannot run during the next maintenance window because of the hibernation schedule, Gardener reports the `AutomaticCredentialsRotationPossible` constraint in the Shoot status. Adjust the maintenance window or hibernation schedule so that maintenance runs while the Shoot is awake.
+If an ETCD encryption key rotation is still in progress when the maintenance runs, the automatic rotation is skipped for this maintenance window and reevaluated in the next one. This is not reported as a maintenance failure.
 Automatic rotation can be disabled for specific credential by setting the `rotationPeriod` field to `0`.
 
 ## Cluster Reconciliation

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -706,12 +706,10 @@ func computeCredentialsToRotationResults(log logr.Logger, shoot *gardencorev1bet
 				isSuccessful: true,
 			}
 		} else {
-			reason := "ETCD encryption key rotation is already in progress"
-			maintenanceResults[v1beta1constants.OperationRotateETCDEncryptionKey] = updateResult{
-				description:  "Could not start ETCD encryption key rotation",
-				reason:       reason,
-				isSuccessful: false,
-			}
+			// A new rotation cannot be started while another one is still in progress. This is not a maintenance
+			// failure though: the etcd encryption key is already being rotated, so the rotation is simply skipped and
+			// reevaluated in the next maintenance window.
+			log.Info("Skipping automatic rotation of ETCD encryption key because a rotation is already in progress", "phase", etcdEncryptionKeyRotationPhase)
 		}
 	}
 

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -95,7 +95,10 @@ func requeueAfterDuration(shoot *gardencorev1beta1.Shoot) (time.Duration, time.T
 // Such maintenance operations can fail if a version must be updated, but the GCM cannot find a suitable version to update to.
 // Note: the updates might still be rejected by APIServer validation.
 type updateResult struct {
-	description  string
+	// description states what the maintenance operation did, or why it failed if isSuccessful is false.
+	description string
+	// reason states why the maintenance operation was performed in the first place. It must not be used for stating
+	// why the operation failed, see description.
 	reason       string
 	isSuccessful bool
 }
@@ -465,7 +468,7 @@ func buildMaintenanceMessages(kubernetesControlPlaneUpdate *updateResult, worker
 		}
 
 		countFailedOperations++
-		description = fmt.Sprintf("%s, %s", description, fmt.Sprintf("Credentials %q: Automatic rotation failed. Reason for update: %s", credentials, result.reason))
+		description = fmt.Sprintf("%s, %s", description, fmt.Sprintf("Credentials %q: Automatic rotation failed. Reason for rotation: %s", credentials, result.reason))
 		failureReason = fmt.Sprintf("%s, Credentials %q: Automatic rotation failure due to: %s", failureReason, credentials, result.description)
 	}
 

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -1637,25 +1637,28 @@ var _ = Describe("Shoot Maintenance", func() {
 			}))
 		})
 
-		It("should fail etcd encryption key rotation when etcd key rotation is in progress", func() {
-			shoot.Spec.Maintenance.AutoRotation.Credentials.SSHKeypair.RotationPeriod.Duration = 0
-			shoot.Spec.Maintenance.AutoRotation.Credentials.Observability.RotationPeriod.Duration = 0
-			shoot.Status.Credentials = &gardencorev1beta1.ShootCredentials{
-				Rotation: &gardencorev1beta1.ShootCredentialsRotation{
-					ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
-						Phase: gardencorev1beta1.RotationPrepared,
+		DescribeTable("should not attempt etcd encryption key rotation when a rotation is already in progress",
+			func(phase gardencorev1beta1.CredentialsRotationPhase) {
+				shoot.Spec.Maintenance.AutoRotation.Credentials.SSHKeypair.RotationPeriod.Duration = 0
+				shoot.Spec.Maintenance.AutoRotation.Credentials.Observability.RotationPeriod.Duration = 0
+				shoot.Status.Credentials = &gardencorev1beta1.ShootCredentials{
+					Rotation: &gardencorev1beta1.ShootCredentialsRotation{
+						ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+							Phase: phase,
+						},
 					},
-				},
-			}
-			results := computeCredentialsToRotationResults(log, shoot, metav1.Time{Time: now})
+				}
+				results := computeCredentialsToRotationResults(log, shoot, metav1.Time{Time: now})
 
-			Expect(results).To(HaveLen(1))
-			Expect(results["rotate-etcd-encryption-key"]).To(Equal(updateResult{
-				description:  "Could not start ETCD encryption key rotation",
-				reason:       "ETCD encryption key rotation is already in progress",
-				isSuccessful: false,
-			}))
-		})
+				Expect(results).To(BeEmpty())
+			},
+
+			Entry("preparing", gardencorev1beta1.RotationPreparing),
+			Entry("preparing without workers rollout", gardencorev1beta1.RotationPreparingWithoutWorkersRollout),
+			Entry("waiting for workers rollout", gardencorev1beta1.RotationWaitingForWorkersRollout),
+			Entry("prepared", gardencorev1beta1.RotationPrepared),
+			Entry("completing", gardencorev1beta1.RotationCompleting),
+		)
 
 		It("should not attempt etcd encryption key rotation when shoot is hibernated", func() {
 			shoot.Spec.Maintenance.AutoRotation.Credentials.SSHKeypair.RotationPeriod.Duration = 0

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -2388,7 +2388,7 @@ var _ = Describe("Shoot Maintenance", func() {
 			Entry("failed credentials rotation",
 				entry{
 					credentials:     map[string]updateResult{"ssh-keypair": {isSuccessful: false, description: "rotation prerequisites not met", reason: "Rotation period elapsed"}},
-					expectedDesc:    `(0/1) maintenance operations successful. Credentials "ssh-keypair": Automatic rotation failed. Reason for update: Rotation period elapsed`,
+					expectedDesc:    `(0/1) maintenance operations successful. Credentials "ssh-keypair": Automatic rotation failed. Reason for rotation: Rotation period elapsed`,
 					expectedFailure: `Credentials "ssh-keypair": Automatic rotation failure due to: rotation prerequisites not met`,
 				},
 			),

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -1867,6 +1867,47 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 			}, "rotate-etcd-encryption-key-start", "Credentials \"rotate-etcd-encryption-key\": ETCD Encryption key rotation started", "rotate-etcd-encryption-key-start"),
 		)
 
+		It("should skip the etcd encryption key rotation without failing the maintenance when a rotation is already in progress", func() {
+			patch := client.MergeFrom(shoot.DeepCopy())
+			shoot.Status.Credentials = &gardencorev1beta1.ShootCredentials{
+				Rotation: &gardencorev1beta1.ShootCredentialsRotation{
+					ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+						Phase: gardencorev1beta1.RotationPrepared,
+					},
+				},
+			}
+			Expect(testClient.Status().Patch(ctx, shoot, patch)).To(Succeed())
+
+			patch = client.MergeFrom(shoot.DeepCopy())
+			shoot.Spec.Maintenance.AutoRotation = &gardencorev1beta1.MaintenanceAutoRotation{
+				Credentials: &gardencorev1beta1.MaintenanceCredentialsAutoRotation{
+					SSHKeypair: &gardencorev1beta1.MaintenanceRotationConfig{
+						RotationPeriod: new(metav1.Duration{Duration: time.Hour}),
+					},
+					ETCDEncryptionKey: &gardencorev1beta1.MaintenanceRotationConfig{
+						RotationPeriod: new(metav1.Duration{Duration: time.Hour}),
+					},
+				},
+			}
+			Expect(testClient.Patch(ctx, shoot, patch)).To(Succeed())
+			fakeClock.SetTime(fakeClock.Now().Add(2 * time.Hour))
+
+			Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+				g.Expect(shoot.Status.LastMaintenance).NotTo(BeNil())
+				g.Expect(shoot.Status.LastMaintenance.Description).To(ContainSubstring("Credentials \"rotate-ssh-keypair\": SSH keypair rotation started"))
+				g.Expect(shoot.Status.LastMaintenance.Description).NotTo(ContainSubstring("rotate-etcd-encryption-key"))
+				g.Expect(shoot.Status.LastMaintenance.State).To(Equal(gardencorev1beta1.LastOperationStateSucceeded))
+				g.Expect(shoot.Status.LastMaintenance.FailureReason).To(BeNil())
+				g.Expect(shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation]).To(And(
+					ContainSubstring("rotate-ssh-keypair"),
+					Not(ContainSubstring("rotate-etcd-encryption-key")),
+				))
+			}).Should(Succeed())
+		})
+
 		It("should auto rotate multiple credentials", func() {
 			patch := client.MergeFrom(shoot.DeepCopy())
 			shoot.Spec.Maintenance.AutoRotation = &gardencorev1beta1.MaintenanceAutoRotation{


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/area usability
/kind bug

**What this PR does / why we need it**:

When an automatic ETCD encryption key rotation could not be started because a rotation was already in progress, the maintenance controller recorded a failed maintenance operation. This set `.status.lastMaintenance.state` to `Failed` although nothing had failed, and it repeated in every maintenance window until the running rotation finished.

The rotation is skipped now and reevaluated in the next maintenance window, just like it is already done for hibernated Shoots (#15209). The second commit fixes the maintenance messages for failed credentials rotations, which stated neither the reason for the rotation nor the cause of the failure.

**Which issue(s) this PR fixes**:
Fixes #15628

**Special notes for your reviewer**:

The skip is silent and does not show up in `.status.lastMaintenance` at all, mirroring the hibernation case. The running rotation is visible in `.status.credentials.rotation.etcdEncryptionKey.phase` anyway.

The failure branch touched by the second commit is unreachable after the first one, see its commit message.

**Release note**:
```bugfix user
Shoot maintenance is no longer reported as `Failed` when an automatic ETCD encryption key rotation cannot be started because a rotation is already in progress. The rotation is skipped and reevaluated in the next maintenance window instead.
```
