### PR TITLE
fix: deploy OTel node scrape config only with enabled shoot node logging

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
@@ -23,7 +23,7 @@ import (
 )
 
 // CentralScrapeConfigs returns the central ScrapeConfig resources for the shoot prometheus.
-func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless bool) []*monitoringv1alpha1.ScrapeConfig {
+func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless, shootNodeLoggingEnabled bool) []*monitoringv1alpha1.ScrapeConfig {
 	out := []*monitoringv1alpha1.ScrapeConfig{
 		// We fetch kubelet metrics from seed's kube-system Prometheus and filter the metrics in shoot's namespace.
 		{
@@ -364,7 +364,7 @@ func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless bo
 			},
 		)
 
-		if features.DefaultFeatureGate.Enabled(features.OpenTelemetryCollector) {
+		if shootNodeLoggingEnabled && features.DefaultFeatureGate.Enabled(features.OpenTelemetryCollector) {
 			nodeMetricsURL := fmt.Sprintf("/api/v1/nodes/${1}:%d/proxy/metrics", otelcomponent.MetricsPort)
 			out = append(out,
 				&monitoringv1alpha1.ScrapeConfig{

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
@@ -355,16 +355,21 @@ var _ = Describe("ScrapeConfigs", func() {
 
 		When("cluster is workerless", func() {
 			It("should return the expected objects even when the OTel feature is enabled", func() {
-				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, true)).To(HaveExactElements(workerlessScrapeConfigs))
+				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, true, false)).To(HaveExactElements(workerlessScrapeConfigs))
 
 				DeferCleanup(testutils.WithFeatureGate(features.DefaultFeatureGate, features.OpenTelemetryCollector, true))
-				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, true)).To(HaveExactElements(workerlessScrapeConfigs))
+				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, true, true)).To(HaveExactElements(workerlessScrapeConfigs))
 			})
 		})
 
 		When("cluster is not workerless", func() {
 			It("should return expected scrape configs with OTel feature disabled", func() {
-				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false)).To(HaveExactElements(nonWorkerlessScrapeConfigs))
+				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false, false)).To(HaveExactElements(nonWorkerlessScrapeConfigs))
+			})
+
+			It("should not return the OTel scrape config when shoot node logging is disabled", func() {
+				DeferCleanup(testutils.WithFeatureGate(features.DefaultFeatureGate, features.OpenTelemetryCollector, true))
+				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false, false)).To(HaveExactElements(nonWorkerlessScrapeConfigs))
 			})
 
 			It("should return expected scrape configs with OTel feature enabled", func() {
@@ -442,7 +447,7 @@ var _ = Describe("ScrapeConfigs", func() {
 						},
 					},
 				)
-				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false)).To(HaveExactElements(items))
+				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false, true)).To(HaveExactElements(items))
 			})
 		})
 	})

--- a/pkg/gardenlet/operation/botanist/monitoring.go
+++ b/pkg/gardenlet/operation/botanist/monitoring.go
@@ -190,7 +190,7 @@ func (b *Botanist) DeployPrometheus(ctx context.Context) error {
 	if !found {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
 	}
-	b.Shoot.Components.ControlPlane.Prometheus.SetCentralScrapeConfigs(shootprometheus.CentralScrapeConfigs(b.Shoot.ControlPlaneNamespace, caSecret.Name, b.Shoot.IsWorkerless))
+	b.Shoot.Components.ControlPlane.Prometheus.SetCentralScrapeConfigs(shootprometheus.CentralScrapeConfigs(b.Shoot.ControlPlaneNamespace, caSecret.Name, b.Shoot.IsWorkerless, b.isShootNodeLoggingEnabled()))
 
 	return b.Shoot.Components.ControlPlane.Prometheus.Deploy(ctx)
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

The `opentelemetry-collector-nodes` Prometheus scrape configuration was previously generated whenever the `OpenTelemetryCollector` feature gate was enabled, even when shoot node logging was disabled. This caused Prometheus to scrape port `18888` on nodes where no collector was running.

This change makes the scrape configuration depend on both the OTel feature gate and the actual shoot node logging configuration. A regression test covers the feature-enabled/node-logging-disabled case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Only configure Prometheus to scrape OpenTelemetry node metrics when shoot node logging is enabled.
```
