### PR TITLE
[GEP-28] Sync ETCD auth tokens

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -78,7 +78,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 	}
 
 	if ctx.SyncControlPlaneAuthTokens {
-		for _, componentName := range []string{v1beta1constants.DeploymentNameKubeControllerManager, v1beta1constants.DeploymentNameKubeScheduler} {
+		for _, componentName := range []string{v1beta1constants.DeploymentNameKubeControllerManager, v1beta1constants.DeploymentNameKubeScheduler, v1beta1constants.ETCDMain, v1beta1constants.ETCDEvents} {
 			additionalTokenSyncConfigs = append(additionalTokenSyncConfigs, nodeagentconfigv1alpha1.TokenSecretSyncConfig{
 				SecretName: gardenerutils.SecretNamePrefixShootAccess + componentName,
 				Path:       staticpod.FilePathForProjectedVolumeItem(componentName, "kubeconfig", resourcesv1alpha1.DataKeyToken),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
@@ -112,6 +112,14 @@ WantedBy=multi-user.target`),
 						Path:       "/var/lib/static-pods/kube-scheduler/kubeconfig/token",
 					},
 					{
+						SecretName: "shoot-access-etcd-main",
+						Path:       "/var/lib/static-pods/etcd-main/kubeconfig/token",
+					},
+					{
+						SecretName: "shoot-access-etcd-events",
+						Path:       "/var/lib/static-pods/etcd-events/kubeconfig/token",
+					},
+					{
 						SecretName: "shoot-access-cluster-admin",
 						Path:       "/etc/kubernetes/admin-token",
 					},

--- a/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer.go
+++ b/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer.go
@@ -299,6 +299,8 @@ func (a *authorizer) authorizeSecret(ctx context.Context, log logr.Logger, machi
 		openTelemetryCollectorTokenSecretName,
 		gardenerutils.SecretNamePrefixShootAccess + v1beta1constants.DeploymentNameKubeControllerManager,
 		gardenerutils.SecretNamePrefixShootAccess + v1beta1constants.DeploymentNameKubeScheduler,
+		gardenerutils.SecretNamePrefixShootAccess + v1beta1constants.ETCDMain,
+		gardenerutils.SecretNamePrefixShootAccess + v1beta1constants.ETCDEvents,
 		gardenerutils.SecretNamePrefixShootAccess + adminaccess.ShootAccessSecretNameSuffix,
 	}
 

--- a/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer_test.go
+++ b/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer_test.go
@@ -677,7 +677,7 @@ var _ = Describe("Authorizer", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(decision).To(Equal(auth.DecisionDeny))
-				Expect(reason).To(Equal(fmt.Sprintf("gardener-node-agent can only access secrets [gardener-valitail gardener-opentelemetry-collector shoot-access-kube-controller-manager shoot-access-kube-scheduler shoot-access-cluster-admin %s] in \"kube-system\" namespace", machineSecretName)))
+				Expect(reason).To(Equal(fmt.Sprintf("gardener-node-agent can only access secrets [gardener-valitail gardener-opentelemetry-collector shoot-access-kube-controller-manager shoot-access-kube-scheduler shoot-access-etcd-main shoot-access-etcd-events shoot-access-cluster-admin %s] in \"kube-system\" namespace", machineSecretName)))
 			},
 				Entry("get", "get"),
 				Entry("list", "list"),
@@ -702,7 +702,7 @@ var _ = Describe("Authorizer", func() {
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(decision).To(Equal(auth.DecisionDeny))
-					Expect(reason).To(Equal(fmt.Sprintf("gardener-node-agent can only access secrets [gardener-valitail gardener-opentelemetry-collector shoot-access-kube-controller-manager shoot-access-kube-scheduler shoot-access-cluster-admin %s] in \"kube-system\" namespace", machineSecretName)))
+					Expect(reason).To(Equal(fmt.Sprintf("gardener-node-agent can only access secrets [gardener-valitail gardener-opentelemetry-collector shoot-access-kube-controller-manager shoot-access-kube-scheduler shoot-access-etcd-main shoot-access-etcd-events shoot-access-cluster-admin %s] in \"kube-system\" namespace", machineSecretName)))
 				}
 			},
 				Entry("get", "get"),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
etcds pods back-restore container use auth token, they should also be synced.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
