### PR TITLE
[GEP-28] Allow traffic from world to GRM for self-hosted shoot with unmanged infra

### DIFF
--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -326,6 +326,8 @@ type Values struct {
 	NodeAgentAuthorizerAuthorizeWithSelectors *bool
 	// MachineNamespace is the namespace in the source cluster in which the Machine objects are stored.
 	MachineNamespace *string
+	// IsSelfHostedShoot specifies whether GRM is deployed for a self-hosted shoot cluster.
+	IsSelfHostedShoot bool
 	// PodKubeAPIServerLoadBalancingWebhook specifies the settings of pod-kube-apiserver-load-balancing webhook.
 	PodKubeAPIServerLoadBalancingWebhook PodKubeAPIServerLoadBalancingWebhook
 	// VPAInPlaceUpdatesEnabled specifies if a vpa-in-place-updates webhook should be enabled.
@@ -776,6 +778,13 @@ func (r *resourceManager) ensureService(ctx context.Context) error {
 				Port:     new(intstr.FromInt32(r.serverPort())),
 				Protocol: new(corev1.ProtocolTCP),
 			}))
+		}
+
+		if r.values.IsSelfHostedShoot {
+			// For self-hosted shoots the kube-apiserver runs as a host-network static pod and cannot be matched
+			// by a podSelector-based NetworkPolicy. Allowing webhook traffic from all sources ensures the
+			// apiserver can reach GRM even when GRM is not scheduled on the control-plane node.
+			metav1.SetMetaDataAnnotation(&service.ObjectMeta, resourcesv1alpha1.NetworkingFromWorldToPorts, fmt.Sprintf(`[{"protocol":"TCP","port":%d}]`, r.serverPort()))
 		}
 
 		// TODO: Consider enabling TAR even for seed/garden runtime/self-hosted shoots.

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -2499,6 +2499,25 @@ subjects:
 			})
 		})
 
+		Context("target cluster != source cluster, self-hosted shoot", func() {
+			BeforeEach(func() {
+				cfg.IsSelfHostedShoot = true
+				resourceManager = New(fakeClient, deployNamespace, sm, cfg)
+				resourceManager.SetSecrets(secrets)
+			})
+
+			It("should annotate the service to allow webhook traffic from all sources", func() {
+				Expect(resourceManager.Deploy(ctx)).To(Succeed())
+
+				actualService := &corev1.Service{}
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, actualService)).To(Succeed())
+				Expect(actualService.Annotations).To(HaveKeyWithValue(
+					"networking.resources.gardener.cloud/from-world-to-ports",
+					fmt.Sprintf(`[{"protocol":"TCP","port":%d}]`, serverPort),
+				))
+			})
+		})
+
 		Context("target cluster != source cluster, workerless shoot", func() {
 			JustBeforeEach(func() {
 				clusterRole.Rules = allowManagedResources

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -70,6 +70,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 	}
 
 	if b.Shoot.IsSelfHosted() {
+		values.IsSelfHostedShoot = true
 		values.KubernetesServiceHost = nil
 		// Disable the vpa-in-place-updates webhook as there are no VPA components that manage VPA resources and
 		// there is no reason for the GRM webhook to be deployed.

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -155,6 +155,7 @@ var _ = Describe("ResourceManager", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(resourceManager.GetValues().MachineNamespace).To(HaveValue(Equal("kube-system")))
+					Expect(resourceManager.GetValues().IsSelfHostedShoot).To(BeTrue())
 					Expect(resourceManager.GetValues().VPAInPlaceUpdatesEnabled).To(BeFalse())
 					Expect(resourceManager.GetValues().SystemComponentTolerations).To(ContainElement(HaveField("Key", "node-role.kubernetes.io/control-plane")))
 				})
@@ -187,6 +188,7 @@ var _ = Describe("ResourceManager", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(resourceManager.GetValues().MachineNamespace).To(BeNil())
+					Expect(resourceManager.GetValues().IsSelfHostedShoot).To(BeTrue())
 					Expect(resourceManager.GetValues().VPAInPlaceUpdatesEnabled).To(BeFalse())
 				})
 			})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind bug

**What this PR does / why we need it**:
This PR allow traffic from world to GRM for self hosted shoot with unamanged infra, this is needed so KAPI that is running in host network can reach to GRM pods in worker nodes.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
