### PR TITLE
Fix `resourceId` for `etcd-backup-restore`

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -83,6 +83,8 @@ images:
     sourceRepository: github.com/gardener/etcd-backup-restore
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl
     tag: "v0.44.1"
+    resourceId:
+      name: etcdbrctl
   - name: dependency-watchdog
     sourceRepository: github.com/gardener/dependency-watchdog
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dependency-watchdog


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
Fix the `resourceId` for the `etcd-backup-restore` component, introduced with https://github.com/gardener/gardener/pull/14993.

If not specified, the default resource ID is the component name itself, here `etcd-backup-restore`.
However, the resource in https://github.com/gardener/etcd-backup-restore is published as `etcdbrctl` (see [component descriptor](https://github.com/gardener/etcd-backup-restore/releases/download/v0.44.2/component-descriptor.yaml)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Also see https://github.com/gardener/etcd-druid/pull/1349.

/cc @LucaBernstein 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The OCM component descriptor was fixed for component `etcd-backup-restore`.
```
