### PR TITLE
[GEP-28] Don't validate/mutate OS version for unmanaged infra self-hosted shoot

### DIFF
--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -339,7 +339,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, opts shootV
 	)
 
 	allErrs = append(allErrs, ValidateCloudProfileReference(spec.CloudProfile, spec.CloudProfileName, spec.Kubernetes.Version, fldPath)...)
-	allErrs = append(allErrs, validateProvider(meta.Namespace, spec.Provider, spec.Kubernetes, spec.Networking, workerless, fldPath.Child("provider"), inTemplate)...)
+	allErrs = append(allErrs, validateProvider(meta.Namespace, spec.Provider, spec.Kubernetes, spec.Networking, workerless, spec.CredentialsBindingName != nil || spec.SecretBindingName != nil, fldPath.Child("provider"), inTemplate)...)
 	allErrs = append(allErrs, validateAddons(spec.Addons, spec.Purpose, workerless, spec.Kubernetes.Version, opts, fldPath.Child("addons"))...)
 	allErrs = append(allErrs, validateDNS(spec.DNS, spec.Kubernetes.Version, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, validateExtensions(spec.Extensions, fldPath.Child("extensions"))...)
@@ -483,7 +483,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 		// worker Kubernetes versions must not be downgraded; minor version skips are allowed, except for AutoInPlaceUpdate and ManualInPlaceUpdate.
 		allErrs = append(allErrs, ValidateKubernetesVersionUpdate(newKubernetesVersion, oldKubernetesVersion, !helper.IsUpdateStrategyInPlace(newWorker.UpdateStrategy), idxPath.Child("kubernetes", "version"))...)
 
-		if helper.IsUpdateStrategyInPlace(newWorker.UpdateStrategy) {
+		if helper.IsUpdateStrategyInPlace(newWorker.UpdateStrategy) && (newSpec.CredentialsBindingName != nil || newSpec.SecretBindingName != nil) {
 			allErrs = append(allErrs, validateMachineImageVersionInPlaceUpdate(newWorker.Machine.Image, oldWorker.Machine.Image, idxPath.Child("machine", "image", "version"))...)
 		}
 	}
@@ -2188,7 +2188,7 @@ func validateMaintenance(maintenance *core.Maintenance, fldPath *field.Path, wor
 	return allErrs
 }
 
-func validateProvider(shootNamespace string, provider core.Provider, kubernetes core.Kubernetes, networking *core.Networking, workerless bool, fldPath *field.Path, inTemplate bool) field.ErrorList {
+func validateProvider(shootNamespace string, provider core.Provider, kubernetes core.Kubernetes, networking *core.Networking, workerless, hasManagedInfrastructure bool, fldPath *field.Path, inTemplate bool) field.ErrorList {
 	var (
 		allErrs = field.ErrorList{}
 		maxPod  int32
@@ -2216,7 +2216,7 @@ func validateProvider(shootNamespace string, provider core.Provider, kubernetes 
 		}
 
 		for i, worker := range provider.Workers {
-			allErrs = append(allErrs, ValidateWorker(worker, kubernetes, shootNamespace, provider.Type, fldPath.Child("workers").Index(i), inTemplate)...)
+			allErrs = append(allErrs, ValidateWorker(worker, kubernetes, shootNamespace, provider.Type, fldPath.Child("workers").Index(i), inTemplate, hasManagedInfrastructure)...)
 
 			if worker.Kubernetes != nil && worker.Kubernetes.Kubelet != nil && worker.Kubernetes.Kubelet.MaxPods != nil && *worker.Kubernetes.Kubelet.MaxPods > maxPod {
 				maxPod = *worker.Kubernetes.Kubelet.MaxPods
@@ -2250,7 +2250,7 @@ const (
 var volumeSizeRegex = regexp.MustCompile(`^(\d)+Gi$`)
 
 // ValidateWorker validates the worker object.
-func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, shootNamespace, shootProviderType string, fldPath *field.Path, inTemplate bool) field.ErrorList {
+func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, shootNamespace, shootProviderType string, fldPath *field.Path, inTemplate, hasManagedInfrastructure bool) field.ErrorList {
 	kubernetesVersion := kubernetes.Version
 	allErrs := field.ErrorList{}
 
@@ -2274,7 +2274,7 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, shootNamespa
 			if len(worker.Machine.Image.Name) == 0 {
 				allErrs = append(allErrs, field.Required(fldPath.Child("machine", "image", "name"), "must specify a machine image name"))
 			}
-			if len(worker.Machine.Image.Version) == 0 {
+			if hasManagedInfrastructure && len(worker.Machine.Image.Version) == 0 {
 				allErrs = append(allErrs, field.Required(fldPath.Child("machine", "image", "version"), "must specify a machine image version"))
 			}
 		}

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -8633,7 +8633,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MaxSurge:       &maxSurge,
 					MaxUnavailable: &maxUnavailable,
 				}
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 
 				Expect(errList).To(matcher)
 			},
@@ -8725,7 +8725,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MaxUnavailable: maxUnavailable,
 					UpdateStrategy: &updateStrategy,
 				}
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type": Equal(expectType),
@@ -8768,7 +8768,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MaxUnavailable: &maxUnavailable,
 					Labels:         labels,
 				}
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type": Equal(expectType),
@@ -8804,7 +8804,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MaxUnavailable: &maxUnavailable,
 					Annotations:    annotations,
 				}
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type": Equal(expectType),
@@ -8839,7 +8839,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MaxUnavailable: &maxUnavailable,
 					Taints:         taints,
 				}
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type": Equal(expectType),
@@ -8883,7 +8883,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				MaxUnavailable: &maxUnavailable,
 				DataVolumes:    dataVolumes,
 			}
-			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 			Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("volume"),
@@ -8909,7 +8909,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				MaxUnavailable: &maxUnavailable,
 				Volume:         &vol,
 			}
-			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 			Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),
 				"Field":    Equal("volume.size"),
@@ -8935,7 +8935,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				MaxUnavailable: &maxUnavailable,
 				Volume:         &vol,
 			}
-			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 			Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(errType),
 				"Field": Equal("volume.name"),
@@ -8967,7 +8967,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Volume:         &vol,
 				DataVolumes:    dataVolumes,
 			}
-			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 			Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),
 				"Field":    Equal("dataVolumes[1].size"),
@@ -8997,7 +8997,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Volume:         &vol,
 				DataVolumes:    dataVolumes,
 			}
-			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 			Expect(errList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
@@ -9036,7 +9036,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				DataVolumes:           dataVolumes,
 				KubeletDataVolumeName: &name,
 			}
-			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 			Expect(errList).To(ConsistOf())
 		})
 
@@ -9064,7 +9064,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				DataVolumes:           dataVolumes,
 				KubeletDataVolumeName: &name3,
 			}
-			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 			Expect(errList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
@@ -9095,7 +9095,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Volume:         &vol,
 				DataVolumes:    dataVolumes,
 			}
-			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 			Expect(errList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeDuplicate),
@@ -9134,7 +9134,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					},
 				},
 			}
-			errList := ValidateWorker(worker, core.Kubernetes{Version: "1.33.3"}, shootNamespace, providerType, nil, false)
+			errList := ValidateWorker(worker, core.Kubernetes{Version: "1.33.3"}, shootNamespace, providerType, nil, false, true)
 			Expect(errList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
@@ -9239,7 +9239,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			It("should allow worker without taints", func() {
-				errList := ValidateWorker(worker, kubernetes, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, kubernetes, shootNamespace, providerType, fldPath, false, true)
 
 				Expect(errList).To(BeEmpty())
 			})
@@ -9253,7 +9253,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Effect: "NoExecute",
 				}}
 
-				errList := ValidateWorker(worker, kubernetes, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, kubernetes, shootNamespace, providerType, fldPath, false, true)
 
 				Expect(errList).To(BeEmpty())
 			})
@@ -9270,7 +9270,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Effect: "NoExecute",
 				}}
 
-				errList := ValidateWorker(worker, kubernetes, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, kubernetes, shootNamespace, providerType, fldPath, false, true)
 
 				Expect(errList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -9413,7 +9413,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			It("should fail if the update strategy is not supported", func() {
 				worker.UpdateStrategy = new(testUpdateStrategy)
 
-				Expect(ValidateWorker(worker, core.Kubernetes{}, shootNamespace, providerType, fldPath, false)).To(ConsistOf(
+				Expect(ValidateWorker(worker, core.Kubernetes{}, shootNamespace, providerType, fldPath, false, true)).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeNotSupported),
 						"Field":  Equal("workers[0].updateStrategy"),
@@ -9425,7 +9425,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			It("should succeed if the update strategy is supported", func() {
 				worker.UpdateStrategy = new(core.AutoInPlaceUpdate)
 
-				Expect(ValidateWorker(worker, core.Kubernetes{}, shootNamespace, providerType, fldPath, false)).To(BeEmpty())
+				Expect(ValidateWorker(worker, core.Kubernetes{}, shootNamespace, providerType, fldPath, false, true)).To(BeEmpty())
 			})
 		})
 
@@ -9502,7 +9502,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			It("should succeed if MachineControllerManagerSettings is nil", func() {
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(BeEmpty())
 			})
 
@@ -9511,7 +9511,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					DisableHealthTimeout: new(false),
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(BeEmpty())
 			})
 
@@ -9520,7 +9520,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					DisableHealthTimeout: new(true),
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.disableHealthTimeout"),
@@ -9535,7 +9535,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					DisableHealthTimeout: new(false),
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(BeEmpty())
 			})
 
@@ -9546,7 +9546,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					DisableHealthTimeout: new(true),
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(BeEmpty())
 			})
 
@@ -9555,7 +9555,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MachineDrainTimeout: &metav1.Duration{Duration: time.Minute * -2},
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.machineDrainTimeout"),
@@ -9568,7 +9568,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MachineHealthTimeout: &metav1.Duration{Duration: time.Minute * -2},
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.machineHealthTimeout"),
@@ -9581,7 +9581,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MachineCreationTimeout: &metav1.Duration{Duration: time.Minute * -2},
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.machineCreationTimeout"),
@@ -9594,7 +9594,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MachineInPlaceUpdateTimeout: &metav1.Duration{Duration: time.Minute * 2},
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.inPlaceUpdateTimeout"),
@@ -9609,7 +9609,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MachineInPlaceUpdateTimeout: &metav1.Duration{Duration: time.Minute * 2},
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(BeEmpty())
 			})
 
@@ -9620,7 +9620,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MachineInPlaceUpdateTimeout: &metav1.Duration{Duration: time.Minute * -2},
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.inPlaceUpdateTimeout"),
@@ -9633,7 +9633,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MaxEvictRetries: new(int32(-2)),
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(ConsistOf(field.Invalid(field.NewPath("workers[0].machineControllerManagerSettings.maxEvictRetries"), int64(-2), "must be greater than or equal to 0").WithOrigin("minimum")))
 			})
 
@@ -9642,7 +9642,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MachinePreserveTimeout: &metav1.Duration{Duration: time.Minute * -2},
 				}
 
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.machinePreserveTimeout"),
@@ -9656,7 +9656,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				worker.MachineControllerManagerSettings = &core.MachineControllerManagerSettings{
 					AutoPreserveFailedMachineMax: new(worker.Maximum),
 				}
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(BeEmpty())
 			})
 
@@ -9666,7 +9666,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				worker.MachineControllerManagerSettings = &core.MachineControllerManagerSettings{
 					AutoPreserveFailedMachineMax: new(worker.Maximum - 1),
 				}
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(BeEmpty())
 			})
 
@@ -9676,7 +9676,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				worker.MachineControllerManagerSettings = &core.MachineControllerManagerSettings{
 					AutoPreserveFailedMachineMax: new(worker.Maximum + 1),
 				}
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.autoPreserveFailedMachineMax"),
@@ -9690,7 +9690,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				worker.MachineControllerManagerSettings = &core.MachineControllerManagerSettings{
 					AutoPreserveFailedMachineMax: new(worker.Maximum + 1),
 				}
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.autoPreserveFailedMachineMax"),
@@ -9704,7 +9704,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				worker.MachineControllerManagerSettings = &core.MachineControllerManagerSettings{
 					AutoPreserveFailedMachineMax: new(int32(0)),
 				}
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(BeEmpty())
 			})
 
@@ -9714,7 +9714,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				worker.MachineControllerManagerSettings = &core.MachineControllerManagerSettings{
 					AutoPreserveFailedMachineMax: new(int32(-1)),
 				}
-				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false)
+				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, fldPath, false, true)
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.autoPreserveFailedMachineMax"),
@@ -9737,7 +9737,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			Priority:       new(int32(-2)),
 		}
 
-		errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false)
+		errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, shootNamespace, providerType, nil, false, true)
 		Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 			"Type":   Equal(field.ErrorTypeInvalid),
 			"Field":  Equal("priority"),

--- a/pkg/apis/core/v1beta1/defaults_shoot.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot.go
@@ -182,7 +182,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 			}
 		}
 
-		if obj.Spec.Maintenance.AutoUpdate.MachineImageVersion == nil {
+		if obj.Spec.Maintenance.AutoUpdate.MachineImageVersion == nil && (obj.Spec.CredentialsBindingName != nil || obj.Spec.SecretBindingName != nil) {
 			obj.Spec.Maintenance.AutoUpdate.MachineImageVersion = new(true)
 		}
 

--- a/pkg/apis/core/v1beta1/defaults_shoot_test.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot_test.go
@@ -638,6 +638,8 @@ var _ = Describe("Shoot defaulting", func() {
 		})
 
 		It("should default both KubernetesVersion and MachineImageVersion field for shoot with workers", func() {
+			obj.Spec.CredentialsBindingName = new("credentials")
+
 			SetObjectDefaults_Shoot(obj)
 
 			Expect(obj.Spec.Maintenance).NotTo(BeNil())

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -121,7 +121,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 		return err
 	}
 
-	if !v1beta1helper.IsWorkerless(shoot) {
+	if !v1beta1helper.IsWorkerless(shoot) && v1beta1helper.HasManagedInfrastructure(shoot) {
 		workerToMachineImageUpdate, err = maintainMachineImages(log, maintainedShoot, cloudProfile)
 		if err != nil {
 			// continue execution to allow the kubernetes version update

--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -535,6 +535,13 @@ func (c *mutationContext) ensureMachineImage(oldWorkers []core.Worker, worker co
 	// from the old shoot object to not accidentally update it to the default machine image.
 	// This should only happen in the maintenance time window of shoots and is performed by the
 	// shoot maintenance controller.
+
+	// For unmanaged infrastructure shoots, the OS is not managed by the shoot, do not default
+	// Machine.Image.Version from the CloudProfile.
+	if helper.IsShootSelfHosted(c.shoot.Spec.Provider.Workers) && !helper.HasManagedInfrastructure(c.shoot) {
+		return worker.Machine.Image, nil
+	}
+
 	machineType := v1beta1helper.FindMachineTypeByName(c.cloudProfileSpec.MachineTypes, worker.Machine.Type)
 
 	oldWorker := helper.FindWorkerByName(oldWorkers, worker.Name)

--- a/plugin/pkg/shoot/mutator/admission_test.go
+++ b/plugin/pkg/shoot/mutator/admission_test.go
@@ -1624,6 +1624,42 @@ var _ = Describe("mutator", func() {
 						Expect(shoot.Spec.Provider.Workers[0].Machine.Image.Version).To(Equal("24.1"))
 					})
 				})
+
+				It("should not default machine image version for self-hosted shoot without managed infrastructure", func() {
+					shoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
+						Name: imageName1,
+					}
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(shoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&core.ShootMachineImage{
+						Name: imageName1,
+					}))
+				})
+
+				It("should default machine image version for self-hosted shoot that has managed infrastructure", func() {
+					expectedImageVersion := latestNonExpiredVersionThatSupportsCapabilities
+					if !isCapabilityCloudProfile {
+						expectedImageVersion = latestNonExpiredVersion
+					}
+					shoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
+						Name: imageName1,
+					}
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					shoot.Spec.CredentialsBindingName = new("binding")
+
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(shoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&core.ShootMachineImage{
+						Name:    imageName1,
+						Version: expectedImageVersion,
+					}))
+				})
 			})
 
 			Context("update Shoot", func() {
@@ -1966,6 +2002,48 @@ var _ = Describe("mutator", func() {
 
 					Expect(err).To(Not(HaveOccurred()))
 					Expect(newShoot.Spec.Provider.Workers[0].Machine.Image.Version).To(Equal("24.0"))
+				})
+
+				It("should not default machine image version for self-hosted shoot without managed infrastructure", func() {
+					newShoot := shoot.DeepCopy()
+					newShoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
+						Name: imageName1,
+					}
+					newShoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+
+					attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), newShoot.Namespace, newShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(newShoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&core.ShootMachineImage{
+						Name: imageName1,
+					}))
+				})
+
+				It("should default machine image version for self-hosted shoot that has managed infrastructure", func() {
+					expectedImageVersion := latestNonExpiredVersionThatSupportsCapabilities
+					if !isCapabilityCloudProfile {
+						expectedImageVersion = latestNonExpiredVersion
+					}
+					newShoot := shoot.DeepCopy()
+					newWorker := newShoot.Spec.Provider.Workers[0].DeepCopy()
+					newWorker.Name = "cp-worker"
+					newWorker.Machine.Image = &core.ShootMachineImage{
+						Name: imageName1,
+					}
+					newWorker.ControlPlane = &core.WorkerControlPlane{}
+					newShoot.Spec.Provider.Workers = append(newShoot.Spec.Provider.Workers, *newWorker)
+					newShoot.Spec.CredentialsBindingName = new("binding")
+
+					attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), newShoot.Namespace, newShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
+
+					Expect(err).NotTo(HaveOccurred())
+					cpWorkerIdx := len(newShoot.Spec.Provider.Workers) - 1
+					Expect(newShoot.Spec.Provider.Workers[cpWorkerIdx].Machine.Image).To(Equal(&core.ShootMachineImage{
+						Name:    imageName1,
+						Version: expectedImageVersion,
+					}))
 				})
 			})
 		},

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -1060,6 +1060,11 @@ func (c *validationContext) validateMachineCapabilities(path *field.Path, worker
 }
 
 func (c *validationContext) validateMachineImage(idxPath *field.Path, worker core.Worker, oldWorker core.Worker, isNewWorkerPool bool, a admission.Attributes) *field.Error {
+	// For unmanaged infrastructure shoots, the OS is not managed by the shoot, do not default
+	// Machine image version is not required and must not be validated against the CloudProfile.
+	if helper.IsShootSelfHosted(c.shoot.Spec.Provider.Workers) && !helper.HasManagedInfrastructure(c.shoot) {
+		return nil
+	}
 	isUpdateStrategyInPlace := helper.IsUpdateStrategyInPlace(worker.UpdateStrategy)
 	isMachineImagePresentInCloudprofile, architectureSupported, activeMachineImageVersion, inPlaceUpdateSupported, validMachineImageVersions := validateMachineImagesConstraints(a, c.cloudProfileSpec.MachineImages, isNewWorkerPool, isUpdateStrategyInPlace, worker.Machine, oldWorker.Machine, c.cloudProfileSpec.MachineCapabilities)
 	if !isMachineImagePresentInCloudprofile {

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -1060,8 +1060,7 @@ func (c *validationContext) validateMachineCapabilities(path *field.Path, worker
 }
 
 func (c *validationContext) validateMachineImage(idxPath *field.Path, worker core.Worker, oldWorker core.Worker, isNewWorkerPool bool, a admission.Attributes) *field.Error {
-	// For unmanaged infrastructure shoots, the OS is not managed by the shoot, do not default
-	// Machine image version is not required and must not be validated against the CloudProfile.
+	// For unmanaged infrastructure shoots, the OS is not managed by the shoot so validation of the machine image is not required.
 	if helper.IsShootSelfHosted(c.shoot.Spec.Provider.Workers) && !helper.HasManagedInfrastructure(c.shoot) {
 		return nil
 	}

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -4196,6 +4196,36 @@ var _ = Describe("validator", func() {
 					Expect(err).To(BeForbiddenError())
 					Expect(err.Error()).To(ContainSubstring("machine image 'cr-image-name@1.2.3' does not support container runtime 'unsupported-cr-1', supported values: [supported-cr-1 supported-cr-2"))
 				})
+
+				It("should not validate machine image for self-hosted shoot without managed infrastructure", func() {
+					shoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
+						Name:    imageName1,
+						Version: expiredVersion,
+					}
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					shoot.Spec.SecretBindingName = nil
+					shoot.Spec.CredentialsBindingName = nil
+
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					err := admissionHandler.Validate(ctx, attrs, nil)
+
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should validate machine image for self-hosted shoot that has managed infrastructure", func() {
+					shoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
+						Name:    imageName1,
+						Version: expiredVersion,
+					}
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					err := admissionHandler.Validate(ctx, attrs, nil)
+
+					Expect(err).To(BeForbiddenError())
+					Expect(err.Error()).To(ContainSubstring("machine image version"))
+					Expect(err.Error()).To(ContainSubstring("is expired"))
+				})
 			})
 
 			Context("update Shoot", func() {
@@ -4888,6 +4918,38 @@ var _ = Describe("validator", func() {
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(newShoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&core.ShootMachineImage{Name: "constraint-image-name", Version: "1.2.4"}))
+				})
+
+				It("should not validate machine image for self-hosted shoot without managed infrastructure", func() {
+					newShoot := shoot.DeepCopy()
+					newShoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
+						Name:    imageName1,
+						Version: expiredVersion,
+					}
+					newShoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					newShoot.Spec.SecretBindingName = nil
+					newShoot.Spec.CredentialsBindingName = nil
+
+					attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Validate(ctx, attrs, nil)
+
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should validate machine image for self-hosted shoot that has managed infrastructure", func() {
+					newShoot := shoot.DeepCopy()
+					newShoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
+						Name:    imageName1,
+						Version: expiredVersion,
+					}
+					newShoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+
+					attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+					err := admissionHandler.Validate(ctx, attrs, nil)
+
+					Expect(err).To(BeForbiddenError())
+					Expect(err.Error()).To(ContainSubstring("machine image version"))
+					Expect(err.Error()).To(ContainSubstring("is expired"))
 				})
 			})
 

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
@@ -25,6 +25,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/controllermanager/v1alpha1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/shoot/maintenance"
 	controllermanagerfeatures "github.com/gardener/gardener/pkg/controllermanager/features"
@@ -50,8 +51,9 @@ var (
 	testClient client.Client
 	mgrClient  client.Reader
 
-	testNamespace *corev1.Namespace
-	fakeClock     *testclock.FakeClock
+	testNamespace   *corev1.Namespace
+	gardenNamespace *corev1.Namespace
+	fakeClock       *testclock.FakeClock
 )
 
 var _ = BeforeSuite(func() {
@@ -96,12 +98,29 @@ var _ = BeforeSuite(func() {
 		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
 	})
 
+	By("Create garden Namespace")
+	gardenNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: v1beta1constants.GardenNamespace,
+		},
+	}
+	Expect(testClient.Create(ctx, gardenNamespace)).To(Succeed())
+	log.Info("Created garden Namespace for test")
+
+	DeferCleanup(func() {
+		By("Delete garden Namespace")
+		Expect(testClient.Delete(ctx, gardenNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
 	By("Setup manager")
 	mgr, err := manager.New(restConfig, manager.Options{
 		Scheme:  kubernetes.GardenScheme,
 		Metrics: metricsserver.Options{BindAddress: "0"},
 		Cache: cache.Options{
-			DefaultNamespaces: map[string]cache.Config{testNamespace.Name: {}},
+			DefaultNamespaces: map[string]cache.Config{
+				testNamespace.Name:               {},
+				v1beta1constants.GardenNamespace: {},
+			},
 		},
 		Controller: controllerconfig.Controller{
 			SkipNameValidation: new(true),

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -1013,6 +1013,41 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 				}).Should(Succeed())
 			})
 		})
+
+		It("should not update machine image for self-hosted shoot without managed infrastructure", func() {
+			selfHostedShoot := shoot.DeepCopy()
+			selfHostedShoot.Name = ""
+			selfHostedShoot.ResourceVersion = ""
+			selfHostedShoot.Namespace = v1beta1constants.GardenNamespace
+			selfHostedShoot.Spec.CredentialsBindingName = nil
+			selfHostedShoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{
+				{
+					Name:         "worker",
+					Minimum:      1,
+					Maximum:      1,
+					ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+					Machine:      shoot.Spec.Provider.Workers[0].Machine,
+				},
+			}
+			selfHostedShoot.Spec.Provider.Workers[0].Machine.Image = testMachineImage.DeepCopy()
+			selfHostedShoot.Spec.Maintenance.AutoUpdate.MachineImageVersion = new(true)
+
+			By("Create shoot without managed infrastructure")
+			Expect(testClient.Create(ctx, selfHostedShoot)).To(Succeed())
+			DeferCleanup(func() {
+				By("Delete shoot without managed infrastructure")
+				Expect(client.IgnoreNotFound(testClient.Delete(ctx, selfHostedShoot))).To(Succeed())
+			})
+
+			By("Trigger maintenance")
+			Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, selfHostedShoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+
+			waitForShootToBeMaintained(selfHostedShoot)
+
+			By("Ensure machine image version was not updated")
+			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(selfHostedShoot), selfHostedShoot)).To(Succeed())
+			Expect(*selfHostedShoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(gardencorev1beta1.ShootMachineImage{Name: testMachineImage.Name, Version: testMachineImage.Version}))
+		})
 	})
 
 	Describe("Kubernetes version maintenance tests", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR adapts shoot validation/mutation for self-hosted shoot with unmanged infra. Since OS is not managed by shoot, validation/mutation should not be performed.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
