### PR TITLE
[GEP-28] Default `pid` in kubelet config in OSC defaulting

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -100,6 +100,7 @@ kubeAPIQPS: 50
 kubeReserved:
   cpu: 80m
   memory: 1Gi
+  pid: 20k
 logging:
   flushFrequency: 0
   options:

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
@@ -166,6 +166,7 @@ var (
 	kubeReservedDefaults = map[string]string{
 		string(corev1.ResourceCPU):    "80m",
 		string(corev1.ResourceMemory): "1Gi",
+		string("pid"):                 "20k",
 	}
 )
 
@@ -240,7 +241,7 @@ func setConfigDefaults(c *components.ConfigurableKubeletConfigParameters) {
 	}
 
 	if c.KubeReserved == nil {
-		c.KubeReserved = make(map[string]string, 2)
+		c.KubeReserved = make(map[string]string, 3)
 	}
 	for k, v := range kubeReservedDefaults {
 		if c.KubeReserved[k] == "" {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
@@ -141,6 +141,7 @@ var _ = Describe("Config", func() {
 			KubeReserved: map[string]string{
 				"cpu":    "80m",
 				"memory": "1Gi",
+				"pid":    "20k",
 			},
 			MaxOpenFiles:   1000000,
 			MaxPods:        110,
@@ -233,7 +234,7 @@ var _ = Describe("Config", func() {
 			ImageMaximumGCAge:                metav1.Duration{Duration: 0 * time.Second},
 			KubeAPIBurst:                     50,
 			KubeAPIQPS:                       new(int32(50)),
-			KubeReserved:                     utils.MergeStringMaps(params.KubeReserved, map[string]string{"memory": "1Gi"}),
+			KubeReserved:                     utils.MergeStringMaps(params.KubeReserved, map[string]string{"memory": "1Gi", "pid": "20k"}),
 			MaxOpenFiles:                     1000000,
 			MaxPods:                          *params.MaxPods,
 			MemorySwap:                       *params.MemorySwap,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
Currently, PIDs are being defaulted by the shoot plugin here - https://github.com/gardener/gardener/blob/baac5b05b827ed08a2ff7327c99a565f22dc7144/plugin/pkg/shoot/resourcereservation/admission.go#L189
But there is defaulting present at OSC level also here - https://github.com/gardener/gardener/blob/baac5b05b827ed08a2ff7327c99a565f22dc7144/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config.go#L172

For self-hosted shoot when the node is first bootstrapped, it uses the second defaulting logic and doesn't default the PID, but when the shoot is created, PID gets defaulted to `20k`. 
This will cause unnecessary updates, and based on updated strategy of pool cause the InPlace or Rolling update.

To prevent this, the PR defaults the PID to 20k in OSC defaulting also.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
