### PR TITLE
Fix gardenlet nil pointer panic in kube-apiserver SNI exposure for self-hosted shoots

### DIFF
--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -175,9 +175,6 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 			}
 
 			values := &kubeapiserverexposure.SNIValues{
-				Hosts: []string{
-					v1beta1helper.GetAPIServerDomain(*b.Shoot.InternalClusterDomain),
-				},
 				APIServerProxy: &kubeapiserverexposure.APIServerProxy{
 					APIServerClusterIP: b.APIServerClusterIP,
 				},
@@ -188,6 +185,11 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 				IstioTLSTermination:   b.ShootUsesIstioTLSTermination(),
 				WildcardConfiguration: wildcardConfiguration,
 				TLSMinVersion:         b.shootKubeAPIServerTLSMinVersion(),
+			}
+
+			// InternalClusterDomain is nil for self-hosted shoots, which only have an external domain.
+			if b.Shoot.InternalClusterDomain != nil {
+				values.Hosts = append(values.Hosts, v1beta1helper.GetAPIServerDomain(*b.Shoot.InternalClusterDomain))
 			}
 
 			if b.Shoot.ExternalClusterDomain != nil {
@@ -217,14 +219,18 @@ func mapToReservedKubeApiServerRange(ip net.IP) string {
 
 // ReconcileIstioInternalLoadBalancingConfigMap reconciles the configmap for istio internal load balancing.
 func (b *Botanist) ReconcileIstioInternalLoadBalancingConfigMap(ctx context.Context) error {
+	// InternalClusterDomain is nil for self-hosted shoots, which only have an external domain.
+	var hosts []string
+	if b.Shoot.InternalClusterDomain != nil {
+		hosts = append(hosts, v1beta1helper.GetAPIServerDomain(*b.Shoot.InternalClusterDomain))
+	}
+
 	return kubeapiserverexposure.ReconcileIstioInternalLoadBalancingConfigMap(
 		ctx,
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		b.IstioNamespace(),
-		[]string{
-			v1beta1helper.GetAPIServerDomain(*b.Shoot.InternalClusterDomain),
-		},
+		hosts,
 		b.ShootUsesIstioTLSTermination(),
 	)
 }

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
@@ -106,6 +106,18 @@ var _ = Describe("KubeAPIServerExposure", func() {
 			})).To(Succeed())
 		})
 
+		It("should not panic when InternalClusterDomain is nil", func() {
+			botanist.Shoot.InternalClusterDomain = nil
+			botanist.Shoot.ExternalClusterDomain = new("external.foo.bar")
+
+			Expect(botanist.DefaultKubeAPIServerService().Deploy(context.TODO())).To(Succeed())
+
+			Expect(botanist.Shoot.Components.ControlPlane.KubeAPIServerSNI).NotTo(BeNil())
+
+			// We call Deploy to trigger the valuesFunc and ensure it doesn't panic.
+			Expect(botanist.Shoot.Components.ControlPlane.KubeAPIServerSNI.Deploy(context.TODO())).To(Succeed())
+		})
+
 		It("should not panic when ExternalClusterDomain is nil", func() {
 			botanist.Shoot.ExternalClusterDomain = nil
 
@@ -126,6 +138,14 @@ var _ = Describe("KubeAPIServerExposure", func() {
 
 			// We call Deploy to trigger the valuesFunc and ensure it doesn't panic.
 			Expect(botanist.Shoot.Components.ControlPlane.KubeAPIServerSNI.Deploy(context.TODO())).To(Succeed())
+		})
+	})
+
+	Describe("#ReconcileIstioInternalLoadBalancingConfigMap", func() {
+		It("should not panic when InternalClusterDomain is nil", func() {
+			botanist.Shoot.InternalClusterDomain = nil
+
+			Expect(botanist.ReconcileIstioInternalLoadBalancingConfigMap(context.TODO())).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area control-plane
/area robustness
/kind bug

**What this PR does / why we need it**:
`Botanist.setAPIServerServiceClusterIPs` and `Botanist.ReconcileIstioInternalLoadBalancingConfigMap` in `pkg/gardenlet/operation/botanist/kubeapiserverexposure.go` unconditionally dereferenced `*b.Shoot.InternalClusterDomain`. That field is documented as, and actually is, `nil` for self-hosted shoots (shoots that only have an external domain), unlike every other call site of this field in the codebase, which already guards it with a nil check (e.g. `kubeapiserver.go`, `advertisedaddresses.go`).

`reconciler_delete.go` and `reconciler_migrate.go` schedule the "Deploying Kubernetes API server service" and "Reconcile Istio internal load balancing ConfigMap" flow tasks for self-hosted shoots without the `b.Shoot.IsSelfHosted()` skip that `reconciler_reconcile.go` already applies to the same tasks on the create/reconcile path. As a result, deleting or migrating any self-hosted shoot hits the nil dereference and panics gardenlet, which drops its lease and flips the Seed's `GardenletReady` condition.

**Special notes for your reviewer**:
This fixes the nil-pointer-dereference class of panic reported, in the same functions and file named in the reported stack trace (`setAPIServerServiceClusterIPs` / `DeployKubeAPIServerSNI` / `kubeapiserverexposure.go`). The reachable trigger identified here is self-hosted shoot deletion/migration, which lacks the same-task skip that the create/reconcile flow already has; the original report's exact environment (a plain shoot creation on v1.138.1) could not be reproduced locally, but this is the only unconditional dereference of a documented-nilable field left in this file, and it is on a path this repository's own flow graphs prove is reachable today.

Note: the `Graph Update: go_modules` job is currently failing on `master` for reasons unrelated to Go source changes (dependency graph submission); Build and CodeQL are green on `master` at the commit this branch is based on.

Validation performed:
- Added a Ginkgo test reproducing the exact panic: with the fix reverted (source only, tests kept), `go test ./pkg/gardenlet/operation/botanist/...` panics with the identical nil-pointer-dereference stack trace at `kubeapiserverexposure.go:179` and `kubeapiserverexposure.go:226`. With the fix applied, all 551 specs in the package pass.
- `go build ./...` succeeds.
- `gofmt -l` and `go vet ./pkg/gardenlet/operation/botanist/...` are clean on the changed files.
- `golangci-lint run ./pkg/gardenlet/operation/botanist/...` (default linters; the repo's custom config could not be fully mirrored locally because its `logcheck.so` plugin requires an exact Go toolchain match with the installed `golangci-lint` binary, which was unavailable in this environment) reports 11 pre-existing `staticcheck` findings, none in the two files this change touches.
- Not validated against a live seed/gardenlet reproducing an actual self-hosted shoot deletion end-to-end; only unit-tested as described above.

**Release note**:
```other operator
Fixed a gardenlet panic (nil pointer dereference) in the kube-apiserver SNI/Istio exposure path that could occur when deleting or migrating a self-hosted Shoot.
```

Fixes #14526

```release-note
Fix gardenlet nil pointer panic in kube-apiserver SNI exposure for self-hosted shoots
```