### PR TITLE
Increase metrics-server liveness probe failure threshold and timeout

### DIFF
--- a/pkg/component/observability/monitoring/metricsserver/metricsserver.go
+++ b/pkg/component/observability/monitoring/metricsserver/metricsserver.go
@@ -325,7 +325,8 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 								},
 								InitialDelaySeconds: 30,
 								PeriodSeconds:       30,
-								FailureThreshold:    1,
+								TimeoutSeconds:      5,
+								FailureThreshold:    3,
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{

--- a/pkg/component/observability/monitoring/metricsserver/metricsserver_test.go
+++ b/pkg/component/observability/monitoring/metricsserver/metricsserver_test.go
@@ -228,13 +228,14 @@ spec:
         image: ` + image + `
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 1
+          failureThreshold: 3
           httpGet:
             path: /livez
             port: 8443
             scheme: HTTPS
           initialDelaySeconds: 30
           periodSeconds: 30
+          timeoutSeconds: 5
         name: metrics-server
         readinessProbe:
           failureThreshold: 1


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area monitoring
/area robustness
/area ops-productivity
/kind bug

**What this PR does / why we need it**:

The shoot `metrics-server` liveness probe is configured with `FailureThreshold: 1` and no
explicit `TimeoutSeconds`, so it defaults to Kubernetes' 1-second timeout. Since `metrics-server`
is known to occasionally respond to `/livez` slower than 1 second under load, a single slow
response is enough for kubelet to kill and restart the container, with no retries.

Because the Deployment uses `maxUnavailable: 0` and is HA-scaled to 2 replicas, a single
probe-induced restart flips `Available` to `False (MinimumReplicasUnavailable)`, which propagates
into the shoot's `SystemComponentsHealthy` condition and produces recurring, self-clearing
"System Components = Error" reports on clusters that are otherwise healthy.

This PR aligns the liveness probe with common practice for this component: `FailureThreshold: 3`
and an explicit `TimeoutSeconds: 5`. A genuinely hung `metrics-server` is still detected and
restarted, just after 3 x 30s instead of a single 1s hiccup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Scope is limited to the liveness probe, which is what causes the reported restarts. The readiness
probe (`FailureThreshold: 1`, `PeriodSeconds: 10`) is left unchanged; it only causes brief removal
from Service endpoints rather than a restart, and the issue itself treats it as a separate,
lower-priority concern.

Validation performed:
- `go build ./pkg/component/observability/monitoring/metricsserver/...` succeeds.
- `go test ./pkg/component/observability/monitoring/metricsserver/...` passes with the updated
  golden manifest fixture.
- Confirmed the fixture actually exercises this change: reverting only the test-fixture edit
  (keeping the source change) makes the test fail, showing the old `failureThreshold: 1` / no
  `timeoutSeconds` golden diffing against the new probe values; restoring the fixture edit makes
  it pass again.
- `gofmt -l` reports no formatting issues on the changed package.
- `golangci-lint run` was run against the repo's real `.golangci.yaml.in` config (with only the
  custom `logcheck` analyzer plugin stripped, since that plugin failed to build locally due to a
  macOS/BSD-vs-GNU `date` incompatibility in the build tooling, unrelated to this change) and
  reports 0 issues on the changed package.
- This is a config-value change validated via a manifest-rendering unit test, not a live-cluster
  reproduction of the restart behavior described in the issue.

**Release note**:
```other operator
Increased the failure threshold and added an explicit timeout to the shoot `metrics-server` liveness probe to avoid spurious container restarts caused by occasional slow `/livez` responses.
```

Fixes #15636

```release-note
Increase metrics-server liveness probe failure threshold and timeout
```