### PR TITLE
Use `goimports -format-only` in `make format`, `make check` and codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ endif
 .PHONY: format
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 	@MODE=$(MODE) ./hack/format.sh ./charts ./cmd ./extensions ./pkg ./plugin ./test ./hack
-	@cd $(LOGCHECK_DIR); $(abspath $(GOIMPORTS)) -l -w .
+	@cd $(LOGCHECK_DIR); $(abspath $(GOIMPORTS)) -format-only -l -w .
 
 .PHONY: sast
 sast: $(GOSEC)

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -27,7 +27,7 @@ folders=()
 for f in "$@"; do
   folders+=( "$(echo $f | sed 's/\.\.\.//')" )
 done
-unformatted_files="$(goimports -l ${folders[*]})"
+unformatted_files="$(goimports -format-only -l ${folders[*]})"
 if [[ "$unformatted_files" ]]; then
   echo "Unformatted files detected:"
   echo "$unformatted_files"

--- a/hack/format.sh
+++ b/hack/format.sh
@@ -8,7 +8,7 @@ set -e
 
 echo "> Format"
 
-goimports -l -w $@
+goimports -format-only -l -w $@
 
 # Format import order only after files have been formatted by imports.
 echo "> Format Import Order"

--- a/hack/generate-imagename-constants.sh
+++ b/hack/generate-imagename-constants.sh
@@ -41,4 +41,4 @@ $out
 
 out_file="${images_yaml%.yaml}.go"
 echo "$out" > "$out_file"
-goimports -l -w "$out_file"
+goimports -format-only -l -w "$out_file"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
`goimports` fixes imports by scanning the module cache, which makes `make format` take 8+ minutes with a CPU spike.
This switches the `goimports` invocations to `-format-only`, which only formats and groups imports (skipping the scan), bringing `make format` down to ~15s. The change is applied to `make format`, `make check` and the image-name constants codegen.

**Which issue(s) this PR fixes**:
Fixes #15644

**Special notes for your reviewer**:
`-format-only` no longer auto-adds missing or removes unused imports locally, but these are still caught in CI: such code fails to compile, so `golangci-lint` reports it as a typecheck error. The `goimports-reviser` phase was not the bottleneck.

Root cause: #2655 switched `format`/`check` from `gofmt` to `goimports` in 2020; goimports' import-resolution scans the module cache, a cost that grew with the cache (~48 GB) into an 8+ min runtime. `-format-only` skips that scan.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
`make format` no longer scans the module cache to fix imports, reducing its runtime from several minutes to a few seconds.
```
