### PR TITLE
[GEP-28] `gardenadm restore`: Approve all non-approved GNA CSRs in the init flow, do not stop at the first match

### DIFF
--- a/pkg/gardenadm/botanist/nodeagent.go
+++ b/pkg/gardenadm/botanist/nodeagent.go
@@ -103,6 +103,7 @@ func (b *GardenadmBotanist) ActivateGardenerNodeAgent(ctx context.Context) error
 		return fmt.Errorf("failed checking whether gardener-node-agent's kubeconfig %s exists: %w", nodeagentconfigv1alpha1.KubeconfigFilePath, err)
 	}
 	if alreadyBootstrapped {
+		// gardener-node-agent already obtained its client certificate and wrote its kubeconfig, nothing to do
 		return nil
 	}
 
@@ -131,12 +132,21 @@ func (b *GardenadmBotanist) ActivateGardenerNodeAgent(ctx context.Context) error
 
 // ApproveNodeAgentCertificateSigningRequest approves the node agent certificate signing request.
 func (b *GardenadmBotanist) ApproveNodeAgentCertificateSigningRequest(ctx context.Context) error {
+	alreadyBootstrapped, err := b.FS.Exists(nodeagentconfigv1alpha1.KubeconfigFilePath)
+	if err != nil {
+		return fmt.Errorf("failed checking whether gardener-node-agent's kubeconfig %s exists: %w", nodeagentconfigv1alpha1.KubeconfigFilePath, err)
+	}
+	if alreadyBootstrapped {
+		// gardener-node-agent already obtained its client certificate and wrote its kubeconfig, nothing to do
+		return nil
+	}
+
 	bootstrapToken, err := b.FS.ReadFile(nodeagentconfigv1alpha1.BootstrapTokenFilePath)
 	if err != nil {
 		if !errors.Is(err, afero.ErrFileNotFound) {
 			return fmt.Errorf("failed to read bootstrap token file: %w", err)
 		}
-		// bootstrap token already deleted, nothing to do
+		// bootstrap token file already deleted by gardener-node-agent once bootstrapped, nothing to do
 		return nil
 	}
 
@@ -148,6 +158,7 @@ func (b *GardenadmBotanist) ApproveNodeAgentCertificateSigningRequest(ctx contex
 		return fmt.Errorf("failed listing certificate signing requests: %w", err)
 	}
 
+	foundForApproval := false
 	for _, csr := range csrList.Items {
 		if csr.Spec.Username == username && csr.Spec.SignerName == certificatesv1.KubeAPIServerClientSignerName {
 			x509cr, err := utils.DecodeCertificateRequest(csr.Spec.Request)
@@ -172,13 +183,17 @@ func (b *GardenadmBotanist) ApproveNodeAgentCertificateSigningRequest(ctx contex
 				if err := b.SeedClientSet.Client().SubResource("approval").Update(ctx, &csr); err != nil {
 					return fmt.Errorf("failed approving certificate signing request: %w", err)
 				}
-			}
 
-			return nil
+				foundForApproval = true
+			}
 		}
 	}
 
-	return fmt.Errorf("no certificate signing request found for gardener-node-agent from username %q", username)
+	if !foundForApproval {
+		return fmt.Errorf("no certificate signing request found to approve for gardener-node-agent from username %q", username)
+	}
+
+	return nil
 }
 
 // FinalizeGardenerNodeAgentBootstrapping deletes the temporary cluster-admin ClusterRoleBinding for

--- a/pkg/gardenadm/botanist/nodeagent.go
+++ b/pkg/gardenadm/botanist/nodeagent.go
@@ -158,7 +158,7 @@ func (b *GardenadmBotanist) ApproveNodeAgentCertificateSigningRequest(ctx contex
 		return fmt.Errorf("failed listing certificate signing requests: %w", err)
 	}
 
-	foundForApproval := false
+	found := false
 	for _, csr := range csrList.Items {
 		if csr.Spec.Username == username && csr.Spec.SignerName == certificatesv1.KubeAPIServerClientSignerName {
 			x509cr, err := utils.DecodeCertificateRequest(csr.Spec.Request)
@@ -169,6 +169,8 @@ func (b *GardenadmBotanist) ApproveNodeAgentCertificateSigningRequest(ctx contex
 			if !strings.HasPrefix(x509cr.Subject.CommonName, v1beta1constants.NodeAgentUserNamePrefix) {
 				continue
 			}
+
+			found = true
 
 			if !slices.ContainsFunc(csr.Status.Conditions, func(condition certificatesv1.CertificateSigningRequestCondition) bool {
 				return condition.Type == certificatesv1.CertificateApproved && condition.Status == corev1.ConditionTrue
@@ -183,14 +185,12 @@ func (b *GardenadmBotanist) ApproveNodeAgentCertificateSigningRequest(ctx contex
 				if err := b.SeedClientSet.Client().SubResource("approval").Update(ctx, &csr); err != nil {
 					return fmt.Errorf("failed approving certificate signing request: %w", err)
 				}
-
-				foundForApproval = true
 			}
 		}
 	}
 
-	if !foundForApproval {
-		return fmt.Errorf("no certificate signing request found to approve for gardener-node-agent from username %q", username)
+	if !found {
+		return fmt.Errorf("no certificate signing request found for gardener-node-agent from username %q", username)
 	}
 
 	return nil

--- a/pkg/gardenadm/botanist/nodeagent.go
+++ b/pkg/gardenadm/botanist/nodeagent.go
@@ -130,7 +130,10 @@ func (b *GardenadmBotanist) ActivateGardenerNodeAgent(ctx context.Context) error
 	return b.DBus.Start(ctx, nil, nil, nodeagentconfigv1alpha1.UnitName)
 }
 
-// ApproveNodeAgentCertificateSigningRequest approves the node agent certificate signing request.
+// ApproveNodeAgentCertificateSigningRequest approves all not-yet-approved gardener-node-agent client certificate
+// signing requests. It does not stop at the first match: in the `gardenadm restore` flow, an etcd restore brings back a
+// stale already-approved CSR under the same (reissued) bootstrap-token username. Stopping there would skip the new
+// Pending CSR that gardener-node-agent just created, leaving it without a client certificate so the node never joins.
 func (b *GardenadmBotanist) ApproveNodeAgentCertificateSigningRequest(ctx context.Context) error {
 	alreadyBootstrapped, err := b.FS.Exists(nodeagentconfigv1alpha1.KubeconfigFilePath)
 	if err != nil {

--- a/pkg/gardenadm/botanist/nodeagent_test.go
+++ b/pkg/gardenadm/botanist/nodeagent_test.go
@@ -188,14 +188,20 @@ var _ = Describe("NodeAgent", func() {
 	})
 
 	Describe("#ApproveNodeAgentCertificateSigningRequest", func() {
-		It("should return an error when bootstrap token file does not exist", func() {
+		It("should return nil when the gardener-node-agent kubeconfig already exists", func() {
+			Expect(b.FS.WriteFile("/var/lib/gardener-node-agent/credentials/kubeconfig", []byte("kubeconfig"), 0o600)).To(Succeed())
+
+			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(Succeed())
+		})
+
+		It("should return nil when bootstrap token file does not exist", func() {
 			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(Succeed())
 		})
 
 		It("should return an error when no CSR was found for the node", func() {
 			Expect(b.FS.WriteFile("/var/lib/gardener-node-agent/credentials/bootstrap-token", []byte(fooToken), 0o600)).To(Succeed())
 
-			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(MatchError(Equal(fmt.Sprintf("no certificate signing request found for gardener-node-agent from username %q", fooUsername))))
+			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(MatchError(Equal(fmt.Sprintf("no certificate signing request found to approve for gardener-node-agent from username %q", fooUsername))))
 		})
 
 		It("should approve the CSR when not already approved", func() {
@@ -230,6 +236,61 @@ var _ = Describe("NodeAgent", func() {
 			}))
 		})
 
+		It("should approve all pending CSRs and not stop at the first already approved one", func() {
+			Expect(b.FS.WriteFile("/var/lib/gardener-node-agent/credentials/bootstrap-token", []byte(fooToken), 0o600)).To(Succeed())
+
+			privateKey, err := secretsutils.FakeGenerateKey(rand.Reader, 4096)
+			Expect(err).NotTo(HaveOccurred())
+			certificateSubject := &pkix.Name{
+				CommonName: "gardener.cloud:node-agent:machine:" + hostName,
+			}
+			csrData, err := certutil.MakeCSR(privateKey, certificateSubject, []string{}, []net.IP{})
+			Expect(err).NotTo(HaveOccurred())
+
+			approvedCSR := &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "csr-approved"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   fooUsername,
+					Request:    csrData,
+					SignerName: certificatesv1.KubeAPIServerClientSignerName,
+				},
+			}
+			Expect(fakeSeedClient.Create(ctx, approvedCSR)).To(Succeed())
+			approvedCSR.Status.Conditions = []certificatesv1.CertificateSigningRequestCondition{{
+				Type:   certificatesv1.CertificateApproved,
+				Status: corev1.ConditionTrue,
+				Reason: "AlreadyApproved",
+			}}
+			Expect(fakeSeedClient.SubResource("approval").Update(ctx, approvedCSR)).To(Succeed())
+
+			pendingCSR := &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "csr-pending"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   fooUsername,
+					Request:    csrData,
+					SignerName: certificatesv1.KubeAPIServerClientSignerName,
+				},
+			}
+			Expect(fakeSeedClient.Create(ctx, pendingCSR)).To(Succeed())
+
+			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(Succeed())
+
+			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(pendingCSR), pendingCSR)).To(Succeed())
+			Expect(pendingCSR.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
+				Type:    certificatesv1.CertificateApproved,
+				Status:  corev1.ConditionTrue,
+				Reason:  "RequestApproved",
+				Message: "Approving gardener-node-agent client certificate signing request via gardenadm",
+			}))
+
+			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(approvedCSR), approvedCSR)).To(Succeed())
+			Expect(approvedCSR.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
+				Type:   certificatesv1.CertificateApproved,
+				Status: corev1.ConditionTrue,
+				Reason: "AlreadyApproved",
+			}))
+		})
+
 		It("should not approve the CSR and return an error if the CSR is not for gardener-node-agent", func() {
 			Expect(b.FS.WriteFile("/var/lib/gardener-node-agent/credentials/bootstrap-token", []byte(fooToken), 0o600)).To(Succeed())
 
@@ -251,7 +312,7 @@ var _ = Describe("NodeAgent", func() {
 			}
 			Expect(fakeSeedClient.Create(ctx, csr)).To(Succeed())
 
-			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(MatchError(Equal(fmt.Sprintf("no certificate signing request found for gardener-node-agent from username %q", fooUsername))))
+			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(MatchError(Equal(fmt.Sprintf("no certificate signing request found to approve for gardener-node-agent from username %q", fooUsername))))
 
 			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(Succeed())
 			Expect(csr.Status.Conditions).To(BeEmpty())

--- a/pkg/gardenadm/botanist/nodeagent_test.go
+++ b/pkg/gardenadm/botanist/nodeagent_test.go
@@ -204,128 +204,120 @@ var _ = Describe("NodeAgent", func() {
 			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(MatchError(Equal(fmt.Sprintf("no certificate signing request found for gardener-node-agent from username %q", fooUsername))))
 		})
 
-		It("should approve the CSR when not already approved", func() {
-			Expect(b.FS.WriteFile("/var/lib/gardener-node-agent/credentials/bootstrap-token", []byte(fooToken), 0o600)).To(Succeed())
+		When("a bootstrap token and a gardener-node-agent CSR request exist", func() {
+			var csrData []byte
 
-			privateKey, err := secretsutils.FakeGenerateKey(rand.Reader, 4096)
-			Expect(err).NotTo(HaveOccurred())
-			certificateSubject := &pkix.Name{
-				CommonName: "gardener.cloud:node-agent:machine:" + hostName,
-			}
-			csrData, err := certutil.MakeCSR(privateKey, certificateSubject, []string{}, []net.IP{})
-			Expect(err).NotTo(HaveOccurred())
+			BeforeEach(func() {
+				Expect(b.FS.WriteFile("/var/lib/gardener-node-agent/credentials/bootstrap-token", []byte(fooToken), 0o600)).To(Succeed())
 
-			csr := &certificatesv1.CertificateSigningRequest{
-				ObjectMeta: metav1.ObjectMeta{Name: "csr"},
-				Spec: certificatesv1.CertificateSigningRequestSpec{
-					Username:   fooUsername,
-					Request:    csrData,
-					SignerName: certificatesv1.KubeAPIServerClientSignerName,
-				},
-			}
-			Expect(fakeSeedClient.Create(ctx, csr)).To(Succeed())
+				privateKey, err := secretsutils.FakeGenerateKey(rand.Reader, 4096)
+				Expect(err).NotTo(HaveOccurred())
+				certificateSubject := &pkix.Name{
+					CommonName: "gardener.cloud:node-agent:machine:" + hostName,
+				}
+				csrData, err = certutil.MakeCSR(privateKey, certificateSubject, []string{}, []net.IP{})
+				Expect(err).NotTo(HaveOccurred())
+			})
 
-			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(Succeed())
+			It("should approve the CSR when not already approved", func() {
+				csr := &certificatesv1.CertificateSigningRequest{
+					ObjectMeta: metav1.ObjectMeta{Name: "csr"},
+					Spec: certificatesv1.CertificateSigningRequestSpec{
+						Username:   fooUsername,
+						Request:    csrData,
+						SignerName: certificatesv1.KubeAPIServerClientSignerName,
+					},
+				}
+				Expect(fakeSeedClient.Create(ctx, csr)).To(Succeed())
 
-			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(Succeed())
-			Expect(csr.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
-				Type:    certificatesv1.CertificateApproved,
-				Status:  corev1.ConditionTrue,
-				Reason:  "RequestApproved",
-				Message: "Approving gardener-node-agent client certificate signing request via gardenadm",
-			}))
-		})
+				Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(Succeed())
 
-		It("should approve all pending CSRs and not stop at the first already approved one", func() {
-			Expect(b.FS.WriteFile("/var/lib/gardener-node-agent/credentials/bootstrap-token", []byte(fooToken), 0o600)).To(Succeed())
+				Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(Succeed())
+				Expect(csr.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
+					Type:    certificatesv1.CertificateApproved,
+					Status:  corev1.ConditionTrue,
+					Reason:  "RequestApproved",
+					Message: "Approving gardener-node-agent client certificate signing request via gardenadm",
+				}))
+			})
 
-			privateKey, err := secretsutils.FakeGenerateKey(rand.Reader, 4096)
-			Expect(err).NotTo(HaveOccurred())
-			certificateSubject := &pkix.Name{
-				CommonName: "gardener.cloud:node-agent:machine:" + hostName,
-			}
-			csrData, err := certutil.MakeCSR(privateKey, certificateSubject, []string{}, []net.IP{})
-			Expect(err).NotTo(HaveOccurred())
+			It("should approve all pending CSRs and not stop at the first already approved one", func() {
+				approvedCSR := &certificatesv1.CertificateSigningRequest{
+					ObjectMeta: metav1.ObjectMeta{Name: "csr-approved"},
+					Spec: certificatesv1.CertificateSigningRequestSpec{
+						Username:   fooUsername,
+						Request:    csrData,
+						SignerName: certificatesv1.KubeAPIServerClientSignerName,
+					},
+				}
+				Expect(fakeSeedClient.Create(ctx, approvedCSR)).To(Succeed())
+				approvedCSR.Status.Conditions = []certificatesv1.CertificateSigningRequestCondition{{
+					Type:   certificatesv1.CertificateApproved,
+					Status: corev1.ConditionTrue,
+					Reason: "AlreadyApproved",
+				}}
+				Expect(fakeSeedClient.SubResource("approval").Update(ctx, approvedCSR)).To(Succeed())
 
-			approvedCSR := &certificatesv1.CertificateSigningRequest{
-				ObjectMeta: metav1.ObjectMeta{Name: "csr-approved"},
-				Spec: certificatesv1.CertificateSigningRequestSpec{
-					Username:   fooUsername,
-					Request:    csrData,
-					SignerName: certificatesv1.KubeAPIServerClientSignerName,
-				},
-			}
-			Expect(fakeSeedClient.Create(ctx, approvedCSR)).To(Succeed())
-			approvedCSR.Status.Conditions = []certificatesv1.CertificateSigningRequestCondition{{
-				Type:   certificatesv1.CertificateApproved,
-				Status: corev1.ConditionTrue,
-				Reason: "AlreadyApproved",
-			}}
-			Expect(fakeSeedClient.SubResource("approval").Update(ctx, approvedCSR)).To(Succeed())
+				var pendingCSRs []*certificatesv1.CertificateSigningRequest
+				for _, name := range []string{"csr-pending-1", "csr-pending-2"} {
+					pendingCSR := &certificatesv1.CertificateSigningRequest{
+						ObjectMeta: metav1.ObjectMeta{Name: name},
+						Spec: certificatesv1.CertificateSigningRequestSpec{
+							Username:   fooUsername,
+							Request:    csrData,
+							SignerName: certificatesv1.KubeAPIServerClientSignerName,
+						},
+					}
+					Expect(fakeSeedClient.Create(ctx, pendingCSR)).To(Succeed())
+					pendingCSRs = append(pendingCSRs, pendingCSR)
+				}
 
-			pendingCSR := &certificatesv1.CertificateSigningRequest{
-				ObjectMeta: metav1.ObjectMeta{Name: "csr-pending"},
-				Spec: certificatesv1.CertificateSigningRequestSpec{
-					Username:   fooUsername,
-					Request:    csrData,
-					SignerName: certificatesv1.KubeAPIServerClientSignerName,
-				},
-			}
-			Expect(fakeSeedClient.Create(ctx, pendingCSR)).To(Succeed())
+				Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(Succeed())
 
-			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(Succeed())
+				for _, pendingCSR := range pendingCSRs {
+					Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(pendingCSR), pendingCSR)).To(Succeed())
+					Expect(pendingCSR.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
+						Type:    certificatesv1.CertificateApproved,
+						Status:  corev1.ConditionTrue,
+						Reason:  "RequestApproved",
+						Message: "Approving gardener-node-agent client certificate signing request via gardenadm",
+					}))
+				}
 
-			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(pendingCSR), pendingCSR)).To(Succeed())
-			Expect(pendingCSR.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
-				Type:    certificatesv1.CertificateApproved,
-				Status:  corev1.ConditionTrue,
-				Reason:  "RequestApproved",
-				Message: "Approving gardener-node-agent client certificate signing request via gardenadm",
-			}))
+				Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(approvedCSR), approvedCSR)).To(Succeed())
+				Expect(approvedCSR.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
+					Type:   certificatesv1.CertificateApproved,
+					Status: corev1.ConditionTrue,
+					Reason: "AlreadyApproved",
+				}))
+			})
 
-			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(approvedCSR), approvedCSR)).To(Succeed())
-			Expect(approvedCSR.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
-				Type:   certificatesv1.CertificateApproved,
-				Status: corev1.ConditionTrue,
-				Reason: "AlreadyApproved",
-			}))
-		})
+			It("should return nil when the only matching CSR is already approved", func() {
+				approvedCSR := &certificatesv1.CertificateSigningRequest{
+					ObjectMeta: metav1.ObjectMeta{Name: "csr-approved"},
+					Spec: certificatesv1.CertificateSigningRequestSpec{
+						Username:   fooUsername,
+						Request:    csrData,
+						SignerName: certificatesv1.KubeAPIServerClientSignerName,
+					},
+				}
+				Expect(fakeSeedClient.Create(ctx, approvedCSR)).To(Succeed())
+				approvedCSR.Status.Conditions = []certificatesv1.CertificateSigningRequestCondition{{
+					Type:   certificatesv1.CertificateApproved,
+					Status: corev1.ConditionTrue,
+					Reason: "AlreadyApproved",
+				}}
+				Expect(fakeSeedClient.SubResource("approval").Update(ctx, approvedCSR)).To(Succeed())
 
-		It("should return nil when the only matching CSR is already approved", func() {
-			Expect(b.FS.WriteFile("/var/lib/gardener-node-agent/credentials/bootstrap-token", []byte(fooToken), 0o600)).To(Succeed())
+				Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(Succeed())
 
-			privateKey, err := secretsutils.FakeGenerateKey(rand.Reader, 4096)
-			Expect(err).NotTo(HaveOccurred())
-			certificateSubject := &pkix.Name{
-				CommonName: "gardener.cloud:node-agent:machine:" + hostName,
-			}
-			csrData, err := certutil.MakeCSR(privateKey, certificateSubject, []string{}, []net.IP{})
-			Expect(err).NotTo(HaveOccurred())
-
-			approvedCSR := &certificatesv1.CertificateSigningRequest{
-				ObjectMeta: metav1.ObjectMeta{Name: "csr-approved"},
-				Spec: certificatesv1.CertificateSigningRequestSpec{
-					Username:   fooUsername,
-					Request:    csrData,
-					SignerName: certificatesv1.KubeAPIServerClientSignerName,
-				},
-			}
-			Expect(fakeSeedClient.Create(ctx, approvedCSR)).To(Succeed())
-			approvedCSR.Status.Conditions = []certificatesv1.CertificateSigningRequestCondition{{
-				Type:   certificatesv1.CertificateApproved,
-				Status: corev1.ConditionTrue,
-				Reason: "AlreadyApproved",
-			}}
-			Expect(fakeSeedClient.SubResource("approval").Update(ctx, approvedCSR)).To(Succeed())
-
-			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(Succeed())
-
-			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(approvedCSR), approvedCSR)).To(Succeed())
-			Expect(approvedCSR.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
-				Type:   certificatesv1.CertificateApproved,
-				Status: corev1.ConditionTrue,
-				Reason: "AlreadyApproved",
-			}))
+				Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(approvedCSR), approvedCSR)).To(Succeed())
+				Expect(approvedCSR.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
+					Type:   certificatesv1.CertificateApproved,
+					Status: corev1.ConditionTrue,
+					Reason: "AlreadyApproved",
+				}))
+			})
 		})
 
 		It("should not approve the CSR and return an error if the CSR is not for gardener-node-agent", func() {

--- a/pkg/gardenadm/botanist/nodeagent_test.go
+++ b/pkg/gardenadm/botanist/nodeagent_test.go
@@ -201,7 +201,7 @@ var _ = Describe("NodeAgent", func() {
 		It("should return an error when no CSR was found for the node", func() {
 			Expect(b.FS.WriteFile("/var/lib/gardener-node-agent/credentials/bootstrap-token", []byte(fooToken), 0o600)).To(Succeed())
 
-			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(MatchError(Equal(fmt.Sprintf("no certificate signing request found to approve for gardener-node-agent from username %q", fooUsername))))
+			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(MatchError(Equal(fmt.Sprintf("no certificate signing request found for gardener-node-agent from username %q", fooUsername))))
 		})
 
 		It("should approve the CSR when not already approved", func() {
@@ -291,6 +291,43 @@ var _ = Describe("NodeAgent", func() {
 			}))
 		})
 
+		It("should return nil when the only matching CSR is already approved", func() {
+			Expect(b.FS.WriteFile("/var/lib/gardener-node-agent/credentials/bootstrap-token", []byte(fooToken), 0o600)).To(Succeed())
+
+			privateKey, err := secretsutils.FakeGenerateKey(rand.Reader, 4096)
+			Expect(err).NotTo(HaveOccurred())
+			certificateSubject := &pkix.Name{
+				CommonName: "gardener.cloud:node-agent:machine:" + hostName,
+			}
+			csrData, err := certutil.MakeCSR(privateKey, certificateSubject, []string{}, []net.IP{})
+			Expect(err).NotTo(HaveOccurred())
+
+			approvedCSR := &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "csr-approved"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   fooUsername,
+					Request:    csrData,
+					SignerName: certificatesv1.KubeAPIServerClientSignerName,
+				},
+			}
+			Expect(fakeSeedClient.Create(ctx, approvedCSR)).To(Succeed())
+			approvedCSR.Status.Conditions = []certificatesv1.CertificateSigningRequestCondition{{
+				Type:   certificatesv1.CertificateApproved,
+				Status: corev1.ConditionTrue,
+				Reason: "AlreadyApproved",
+			}}
+			Expect(fakeSeedClient.SubResource("approval").Update(ctx, approvedCSR)).To(Succeed())
+
+			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(Succeed())
+
+			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(approvedCSR), approvedCSR)).To(Succeed())
+			Expect(approvedCSR.Status.Conditions).To(HaveExactElements(certificatesv1.CertificateSigningRequestCondition{
+				Type:   certificatesv1.CertificateApproved,
+				Status: corev1.ConditionTrue,
+				Reason: "AlreadyApproved",
+			}))
+		})
+
 		It("should not approve the CSR and return an error if the CSR is not for gardener-node-agent", func() {
 			Expect(b.FS.WriteFile("/var/lib/gardener-node-agent/credentials/bootstrap-token", []byte(fooToken), 0o600)).To(Succeed())
 
@@ -312,7 +349,7 @@ var _ = Describe("NodeAgent", func() {
 			}
 			Expect(fakeSeedClient.Create(ctx, csr)).To(Succeed())
 
-			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(MatchError(Equal(fmt.Sprintf("no certificate signing request found to approve for gardener-node-agent from username %q", fooUsername))))
+			Expect(b.ApproveNodeAgentCertificateSigningRequest(ctx)).To(MatchError(Equal(fmt.Sprintf("no certificate signing request found for gardener-node-agent from username %q", fooUsername))))
 
 			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(Succeed())
 			Expect(csr.Status.Conditions).To(BeEmpty())

--- a/pkg/gardenadm/cmd/discover/existing/existing_test.go
+++ b/pkg/gardenadm/cmd/discover/existing/existing_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Existing", func() {
 
 			Eventually(func() string { return string(stdOut.Contents()) }).Should(SatisfyAll(
 				ContainSubstring("Computing required resources for Shoot..."),
-				ContainSubstring("Fetching required resources for from garden cluster..."),
+				ContainSubstring("Fetching required resources from garden cluster..."),
 				ContainSubstring("Exported Namespace/"+resources.Namespace.Name),
 				ContainSubstring("Exported Project/"+resources.Project.Name),
 				ContainSubstring("Exported Secret/"+resources.Secret.Name),

--- a/pkg/gardenadm/cmd/discover/internal/shared/shared.go
+++ b/pkg/gardenadm/cmd/discover/internal/shared/shared.go
@@ -128,7 +128,7 @@ func RunForShoot(
 		})
 	}
 
-	fmt.Fprintf(opts.Out, "Fetching required resources for from garden cluster...\n\n")
+	fmt.Fprintf(opts.Out, "Fetching required resources from garden cluster...\n\n")
 
 	return flow.Parallel(taskFns...)(ctx)
 }

--- a/pkg/gardenadm/cmd/discover/new/new_test.go
+++ b/pkg/gardenadm/cmd/discover/new/new_test.go
@@ -97,7 +97,7 @@ var _ = Describe("New", func() {
 
 			Eventually(func() string { return string(stdOut.Contents()) }).Should(SatisfyAll(
 				ContainSubstring("Computing required resources for Shoot..."),
-				ContainSubstring("Fetching required resources for from garden cluster..."),
+				ContainSubstring("Fetching required resources from garden cluster..."),
 				ContainSubstring("Exported Namespace/"+resources.Namespace.Name),
 				ContainSubstring("Exported Project/"+resources.Project.Name),
 				ContainSubstring("Exported Secret/"+resources.Secret.Name),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area disaster-recovery control-plane ipcei
/kind enhancement

**What this PR does / why we need it**:
During `gardenadm restore` multiple `gardener-node-agent` CertificateSigningRequests can be present. The init flow previously approved only the first matching CSR and returned, leaving later pending CSRs.

Additionally, it makes the approval step idempotent on retries: it now early-exits when `gardener-node-agent` has already written its kubeconfig (i.e. its CSR was already approved), rather than erroring that there is no CSR left to approve.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/15607

**Special notes for your reviewer**:
The early-exit keys off the presence of the `gardener-node-agent` kubeconfig (`/var/lib/gardener-node-agent/credentials/kubeconfig`), mirroring the existing check in `ActivateGardenerNodeAgent`. The kubeconfig is written at CSR-approval time and never deleted, so it is a durable "already bootstrapped" signal — unlike the bootstrap-token file, which is deleted only later by gardener-node-agent and thus leaves a retry window uncovered.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardenadm init`/`gardenadm restore` now approve all pending `gardener-node-agent` certificate signing requests instead of only the first one, and the approval step is idempotent on retries.
```
