### PR TITLE
[GEP-28] `gardenadm discover`: Export Secrets/ConfigMaps referenced by ControllerDeployments

### DIFF
--- a/pkg/gardenadm/cmd/discover/existing/existing_test.go
+++ b/pkg/gardenadm/cmd/discover/existing/existing_test.go
@@ -89,6 +89,9 @@ var _ = Describe("Existing", func() {
 		Expect(fakeClient.Create(ctx, resources.ControllerRegistrationNetwork)).To(Succeed())
 		Expect(fakeClient.Create(ctx, resources.ControllerDeploymentDNS)).To(Succeed())
 		Expect(fakeClient.Create(ctx, resources.ControllerRegistrationDNS)).To(Succeed())
+		Expect(fakeClient.Create(ctx, resources.ReferencedSecret)).To(Succeed())
+		Expect(fakeClient.Create(ctx, resources.ReferencedConfigMap)).To(Succeed())
+		Expect(fakeClient.Create(ctx, resources.ReferencedOCISecret)).To(Succeed())
 
 		backupBucketSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -190,6 +193,9 @@ var _ = Describe("Existing", func() {
 				ContainSubstring("Exported ControllerRegistration/"+resources.ControllerRegistrationNetwork.Name),
 				ContainSubstring("Exported ControllerDeployment/"+resources.ControllerDeploymentDNS.Name),
 				ContainSubstring("Exported ControllerRegistration/"+resources.ControllerRegistrationDNS.Name),
+				ContainSubstring("Exported Secret/"+resources.ReferencedSecret.Name),
+				ContainSubstring("Exported ConfigMap/"+resources.ReferencedConfigMap.Name),
+				ContainSubstring("Exported Secret/"+resources.ReferencedOCISecret.Name),
 				ContainSubstring("Exported Secret/"+backupBucketSecret.Name),
 				ContainSubstring("Exported Secret/"+backupBucketGeneratedSecret.Name),
 				ContainSubstring("Exported BackupBucket/"+backupBucket.Name),
@@ -211,6 +217,9 @@ var _ = Describe("Existing", func() {
 				fmt.Sprintf("controllerregistration-%s.yaml", resources.ControllerRegistrationNetwork.Name),
 				fmt.Sprintf("controllerdeployment-%s.yaml", resources.ControllerDeploymentDNS.Name),
 				fmt.Sprintf("controllerregistration-%s.yaml", resources.ControllerRegistrationDNS.Name),
+				fmt.Sprintf("secret-%s.yaml", resources.ReferencedSecret.Name),
+				fmt.Sprintf("configmap-%s.yaml", resources.ReferencedConfigMap.Name),
+				fmt.Sprintf("secret-%s.yaml", resources.ReferencedOCISecret.Name),
 				fmt.Sprintf("secret-%s.yaml", backupBucketSecret.Name),
 				fmt.Sprintf("secret-%s.yaml", backupBucketGeneratedSecret.Name),
 				fmt.Sprintf("backupbucket-%s.yaml", backupBucket.Name),

--- a/pkg/gardenadm/cmd/discover/existing/existing_test.go
+++ b/pkg/gardenadm/cmd/discover/existing/existing_test.go
@@ -91,7 +91,8 @@ var _ = Describe("Existing", func() {
 		Expect(fakeClient.Create(ctx, resources.ControllerRegistrationDNS)).To(Succeed())
 		Expect(fakeClient.Create(ctx, resources.ReferencedSecret)).To(Succeed())
 		Expect(fakeClient.Create(ctx, resources.ReferencedConfigMap)).To(Succeed())
-		Expect(fakeClient.Create(ctx, resources.ReferencedOCISecret)).To(Succeed())
+		Expect(fakeClient.Create(ctx, resources.ReferencedOCIPullSecret)).To(Succeed())
+		Expect(fakeClient.Create(ctx, resources.ReferencedOCICABundleSecret)).To(Succeed())
 
 		backupBucketSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -195,7 +196,8 @@ var _ = Describe("Existing", func() {
 				ContainSubstring("Exported ControllerRegistration/"+resources.ControllerRegistrationDNS.Name),
 				ContainSubstring("Exported Secret/"+resources.ReferencedSecret.Name),
 				ContainSubstring("Exported ConfigMap/"+resources.ReferencedConfigMap.Name),
-				ContainSubstring("Exported Secret/"+resources.ReferencedOCISecret.Name),
+				ContainSubstring("Exported Secret/"+resources.ReferencedOCIPullSecret.Name),
+				ContainSubstring("Exported Secret/"+resources.ReferencedOCICABundleSecret.Name),
 				ContainSubstring("Exported Secret/"+backupBucketSecret.Name),
 				ContainSubstring("Exported Secret/"+backupBucketGeneratedSecret.Name),
 				ContainSubstring("Exported BackupBucket/"+backupBucket.Name),
@@ -219,7 +221,8 @@ var _ = Describe("Existing", func() {
 				fmt.Sprintf("controllerregistration-%s.yaml", resources.ControllerRegistrationDNS.Name),
 				fmt.Sprintf("secret-%s.yaml", resources.ReferencedSecret.Name),
 				fmt.Sprintf("configmap-%s.yaml", resources.ReferencedConfigMap.Name),
-				fmt.Sprintf("secret-%s.yaml", resources.ReferencedOCISecret.Name),
+				fmt.Sprintf("secret-%s.yaml", resources.ReferencedOCIPullSecret.Name),
+				fmt.Sprintf("secret-%s.yaml", resources.ReferencedOCICABundleSecret.Name),
 				fmt.Sprintf("secret-%s.yaml", backupBucketSecret.Name),
 				fmt.Sprintf("secret-%s.yaml", backupBucketGeneratedSecret.Name),
 				fmt.Sprintf("backupbucket-%s.yaml", backupBucket.Name),

--- a/pkg/gardenadm/cmd/discover/internal/shared/shared.go
+++ b/pkg/gardenadm/cmd/discover/internal/shared/shared.go
@@ -12,15 +12,19 @@ import (
 
 	"github.com/spf13/afero"
 	gonumgraph "gonum.org/v1/gonum/graph"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1helper "github.com/gardener/gardener/pkg/api/core/v1/helper"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenadm"
@@ -122,6 +126,28 @@ func RunForShoot(
 				return getAndExportObject(ctx, c, fs, opts, "ControllerDeployment", extension.ControllerDeployment)
 			},
 		)
+
+		// Export the Secrets/ConfigMaps referenced in the ControllerDeployment's `.resources` field (used for
+		// templating Helm values via `{{ .resources.<name>.data.<key> }}`) as well as any Secrets referenced by the
+		// Helm OCIRepository (pull secret and CA bundle). All of these reside in the garden namespace and are required
+		// for a later `gardenadm init` to resolve the Helm values.
+		for _, ref := range extension.ControllerDeployment.Resources {
+			taskFns = append(taskFns, func(ctx context.Context) error {
+				return getAndExportReferencedResource(ctx, c, fs, opts, ref.ResourceRef)
+			})
+		}
+
+		if extension.ControllerDeployment.Helm != nil {
+			for _, secretName := range v1helper.GetSecretsForOCIRepository(extension.ControllerDeployment.Helm.OCIRepository) {
+				taskFns = append(taskFns, func(ctx context.Context) error {
+					return getAndExportReferencedResource(ctx, c, fs, opts, autoscalingv1.CrossVersionObjectReference{
+						APIVersion: corev1.SchemeGroupVersion.String(),
+						Kind:       "Secret",
+						Name:       secretName,
+					})
+				})
+			}
+		}
 	}
 
 	fmt.Fprintf(opts.Out, "Fetching required resources for from garden cluster...\n\n")
@@ -217,6 +243,30 @@ func getAndExportObject(ctx context.Context, c client.Client, fs afero.Afero, op
 		return nil
 	}
 	return exportObject(fs, opts, kind, obj)
+}
+
+// getAndExportReferencedResource exports a Secret/ConfigMap referenced by a ControllerDeployment (either via its
+// `.resources` field or via the Helm OCIRepository). The referenced object is expected to reside in the garden
+// namespace. Only `Secret`s and `ConfigMap`s with apiVersion `v1` are supported (mirroring the resolution performed by
+// the controllerdeployment-reference controller); references to other kinds are ignored.
+func getAndExportReferencedResource(ctx context.Context, c client.Client, fs afero.Afero, opts *CommonOptions, ref autoscalingv1.CrossVersionObjectReference) error {
+	if ref.APIVersion != corev1.SchemeGroupVersion.String() {
+		return nil
+	}
+
+	var obj client.Object
+	switch ref.Kind {
+	case "Secret":
+		obj = &corev1.Secret{}
+	case "ConfigMap":
+		obj = &corev1.ConfigMap{}
+	default:
+		return nil
+	}
+
+	obj.SetName(ref.Name)
+	obj.SetNamespace(v1beta1constants.GardenNamespace)
+	return getAndExportObject(ctx, c, fs, opts, ref.Kind, obj)
 }
 
 func exportObject(fs afero.Afero, opts *CommonOptions, kind string, obj client.Object) error {

--- a/pkg/gardenadm/cmd/discover/internal/shared/shared.go
+++ b/pkg/gardenadm/cmd/discover/internal/shared/shared.go
@@ -12,19 +12,15 @@ import (
 
 	"github.com/spf13/afero"
 	gonumgraph "gonum.org/v1/gonum/graph"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1helper "github.com/gardener/gardener/pkg/api/core/v1/helper"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenadm"
@@ -70,6 +66,11 @@ func RunForShoot(
 
 	fmt.Fprintf(opts.Out, "Computing required resources for Shoot...\n")
 
+	extensions, err := requiredExtensions(ctx, c, shoot, opts.ManagedInfrastructure)
+	if err != nil {
+		return fmt.Errorf("failed computing required extensions: %w", err)
+	}
+
 	g := graph.New(opts.Log, c, true)
 	g.HandleShootCreateOrUpdate(ctx, shoot)
 	if binding != nil {
@@ -85,6 +86,13 @@ func RunForShoot(
 	}
 	if backupBucket != nil {
 		g.HandleBackupBucketCreateOrUpdate(backupBucket)
+	}
+	// Feed the required ControllerDeployments into the graph so that the Secrets/ConfigMaps they reference (via their
+	// `.resources` field and the Helm OCIRepository pull secret/CA bundle) become vertices and get exported by the
+	// generic vertex walk below. These referenced resources reside in the garden namespace and are required for a later
+	// `gardenadm init`/`restore` to resolve the extension Helm values.
+	for _, extension := range extensions {
+		g.HandleControllerDeploymentCreateOrUpdate(extension.ControllerDeployment)
 	}
 
 	var taskFns []flow.TaskFn
@@ -114,42 +122,12 @@ func RunForShoot(
 		return getAndExportObject(ctx, c, fs, opts, "Project", project)
 	})
 
-	extensions, err := requiredExtensions(ctx, c, shoot, opts.ManagedInfrastructure)
-	if err != nil {
-		return fmt.Errorf("failed computing required extensions: %w", err)
-	}
-
+	// The ControllerDeployments themselves are exported via the generic vertex walk above (they were fed into the graph
+	// together with their referenced Secrets/ConfigMaps), so only the ControllerRegistrations need to be exported here.
 	for _, extension := range extensions {
-		taskFns = append(taskFns,
-			func(ctx context.Context) error {
-				return getAndExportObject(ctx, c, fs, opts, "ControllerRegistration", extension.ControllerRegistration)
-			},
-			func(ctx context.Context) error {
-				return getAndExportObject(ctx, c, fs, opts, "ControllerDeployment", extension.ControllerDeployment)
-			},
-		)
-
-		// Export the Secrets/ConfigMaps referenced in the ControllerDeployment's `.resources` field (used for
-		// templating Helm values via `{{ .resources.<name>.data.<key> }}`) as well as any Secrets referenced by the
-		// Helm OCIRepository (pull secret and CA bundle). All of these reside in the garden namespace and are required
-		// for a later `gardenadm init` to resolve the Helm values.
-		for _, ref := range extension.ControllerDeployment.Resources {
-			taskFns = append(taskFns, func(ctx context.Context) error {
-				return getAndExportReferencedResource(ctx, c, fs, opts, ref.ResourceRef)
-			})
-		}
-
-		if extension.ControllerDeployment.Helm != nil {
-			for _, secretName := range v1helper.GetSecretsForOCIRepository(extension.ControllerDeployment.Helm.OCIRepository) {
-				taskFns = append(taskFns, func(ctx context.Context) error {
-					return getAndExportReferencedResource(ctx, c, fs, opts, autoscalingv1.CrossVersionObjectReference{
-						APIVersion: corev1.SchemeGroupVersion.String(),
-						Kind:       "Secret",
-						Name:       secretName,
-					})
-				})
-			}
-		}
+		taskFns = append(taskFns, func(ctx context.Context) error {
+			return getAndExportObject(ctx, c, fs, opts, "ControllerRegistration", extension.ControllerRegistration)
+		})
 	}
 
 	fmt.Fprintf(opts.Out, "Fetching required resources for from garden cluster...\n\n")
@@ -245,30 +223,6 @@ func getAndExportObject(ctx context.Context, c client.Client, fs afero.Afero, op
 		return nil
 	}
 	return exportObject(fs, opts, kind, obj)
-}
-
-// getAndExportReferencedResource exports a Secret/ConfigMap referenced by a ControllerDeployment (either via its
-// `.resources` field or via the Helm OCIRepository). The referenced object is expected to reside in the garden
-// namespace. Only `Secret`s and `ConfigMap`s with apiVersion `v1` are supported (mirroring the resolution performed by
-// the controllerdeployment-reference controller); references to other kinds are ignored.
-func getAndExportReferencedResource(ctx context.Context, c client.Client, fs afero.Afero, opts *CommonOptions, ref autoscalingv1.CrossVersionObjectReference) error {
-	if ref.APIVersion != corev1.SchemeGroupVersion.String() {
-		return nil
-	}
-
-	var obj client.Object
-	switch ref.Kind {
-	case "Secret":
-		obj = &corev1.Secret{}
-	case "ConfigMap":
-		obj = &corev1.ConfigMap{}
-	default:
-		return nil
-	}
-
-	obj.SetName(ref.Name)
-	obj.SetNamespace(v1beta1constants.GardenNamespace)
-	return getAndExportObject(ctx, c, fs, opts, ref.Kind, obj)
 }
 
 func exportObject(fs afero.Afero, opts *CommonOptions, kind string, obj client.Object) error {

--- a/pkg/gardenadm/cmd/discover/internal/shared/shared.go
+++ b/pkg/gardenadm/cmd/discover/internal/shared/shared.go
@@ -87,10 +87,8 @@ func RunForShoot(
 	if backupBucket != nil {
 		g.HandleBackupBucketCreateOrUpdate(backupBucket)
 	}
-	// Feed the required ControllerDeployments into the graph so that the Secrets/ConfigMaps they reference (via their
-	// `.resources` field and the Helm OCIRepository pull secret/CA bundle) become vertices and get exported by the
-	// generic vertex walk below. These referenced resources reside in the garden namespace and are required for a later
-	// `gardenadm init`/`restore` to resolve the extension Helm values.
+	// Feed the ControllerDeployments into the graph so the Secrets/ConfigMaps they reference become vertices and get
+	// exported by the generic vertex walk below.
 	for _, extension := range extensions {
 		g.HandleControllerDeploymentCreateOrUpdate(extension.ControllerDeployment)
 	}
@@ -122,8 +120,8 @@ func RunForShoot(
 		return getAndExportObject(ctx, c, fs, opts, "Project", project)
 	})
 
-	// The ControllerDeployments themselves are exported via the generic vertex walk above (they were fed into the graph
-	// together with their referenced Secrets/ConfigMaps), so only the ControllerRegistrations need to be exported here.
+	// ControllerDeployments are exported via the generic vertex walk above, so only the ControllerRegistrations need
+	// exporting here.
 	for _, extension := range extensions {
 		taskFns = append(taskFns, func(ctx context.Context) error {
 			return getAndExportObject(ctx, c, fs, opts, "ControllerRegistration", extension.ControllerRegistration)

--- a/pkg/gardenadm/cmd/discover/internal/shared/shared.go
+++ b/pkg/gardenadm/cmd/discover/internal/shared/shared.go
@@ -61,7 +61,9 @@ func RunForShoot(
 		if err != nil {
 			return fmt.Errorf("failed reading backup resources for shoot: %w", err)
 		}
-		if backupBucket != nil && backupEntry == nil {
+		if backupBucket == nil {
+			fmt.Fprintf(opts.Out, "WARNING: found no BackupBucket for Shoot %s - backup restoration may not be possible\n", client.ObjectKeyFromObject(shoot))
+		} else if backupEntry == nil {
 			fmt.Fprintf(opts.Out, "WARNING: found BackupBucket without a corresponding BackupEntry for Shoot %s - backup restoration may not be possible\n", client.ObjectKeyFromObject(shoot))
 		}
 	}

--- a/pkg/gardenadm/cmd/discover/internal/shared/test/test.go
+++ b/pkg/gardenadm/cmd/discover/internal/shared/test/test.go
@@ -30,6 +30,13 @@ type Resources struct {
 	ControllerDeploymentDNS        *gardencorev1.ControllerDeployment
 	ControllerRegistrationDNS      *gardencorev1beta1.ControllerRegistration
 
+	// ReferencedSecret and ReferencedConfigMap are referenced by ControllerDeploymentProvider via its `.resources`
+	// field. ReferencedOCISecret is referenced by ControllerDeploymentProvider via its Helm OCIRepository pull secret.
+	// All of them reside in the garden namespace.
+	ReferencedSecret    *corev1.Secret
+	ReferencedConfigMap *corev1.ConfigMap
+	ReferencedOCISecret *corev1.Secret
+
 	Shoot *gardencorev1beta1.Shoot
 }
 
@@ -83,9 +90,51 @@ func NewResources() *Resources {
 			Name: "test-cloud-profile",
 		},
 	}
+	referencedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-referenced-secret",
+			Namespace: "garden",
+		},
+	}
+	referencedConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-referenced-configmap",
+			Namespace: "garden",
+		},
+	}
+	referencedOCISecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-referenced-oci-secret",
+			Namespace: "garden",
+		},
+	}
 	controllerDeploymentProvider := &gardencorev1.ControllerDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-controller-deployment-provider",
+		},
+		Helm: &gardencorev1.HelmControllerDeployment{
+			OCIRepository: &gardencorev1.OCIRepository{
+				Ref:           new("test-registry.example.com/charts/provider:v1.0.0"),
+				PullSecretRef: &corev1.LocalObjectReference{Name: referencedOCISecret.Name},
+			},
+		},
+		Resources: []gardencorev1.NamedResourceReference{
+			{
+				Name: "config",
+				ResourceRef: autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       referencedSecret.Name,
+				},
+			},
+			{
+				Name: "log-level",
+				ResourceRef: autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Name:       referencedConfigMap.Name,
+				},
+			},
 		},
 	}
 	controllerRegistrationProvider := &gardencorev1beta1.ControllerRegistration{
@@ -195,6 +244,9 @@ func NewResources() *Resources {
 		ControllerRegistrationNetwork:  controllerRegistrationNetwork,
 		ControllerDeploymentDNS:        controllerDeploymentDNS,
 		ControllerRegistrationDNS:      controllerRegistrationDNS,
+		ReferencedSecret:               referencedSecret,
+		ReferencedConfigMap:            referencedConfigMap,
+		ReferencedOCISecret:            referencedOCISecret,
 		Shoot:                          shoot,
 	}
 }

--- a/pkg/gardenadm/cmd/discover/internal/shared/test/test.go
+++ b/pkg/gardenadm/cmd/discover/internal/shared/test/test.go
@@ -30,12 +30,11 @@ type Resources struct {
 	ControllerDeploymentDNS        *gardencorev1.ControllerDeployment
 	ControllerRegistrationDNS      *gardencorev1beta1.ControllerRegistration
 
-	// ReferencedSecret and ReferencedConfigMap are referenced by ControllerDeploymentProvider via its `.resources`
-	// field. ReferencedOCISecret is referenced by ControllerDeploymentProvider via its Helm OCIRepository pull secret.
-	// All of them reside in the garden namespace.
-	ReferencedSecret    *corev1.Secret
-	ReferencedConfigMap *corev1.ConfigMap
-	ReferencedOCISecret *corev1.Secret
+	// These are referenced by ControllerDeploymentProvider and reside in the garden namespace.
+	ReferencedSecret            *corev1.Secret
+	ReferencedConfigMap         *corev1.ConfigMap
+	ReferencedOCIPullSecret     *corev1.Secret
+	ReferencedOCICABundleSecret *corev1.Secret
 
 	Shoot *gardencorev1beta1.Shoot
 }
@@ -102,9 +101,15 @@ func NewResources() *Resources {
 			Namespace: "garden",
 		},
 	}
-	referencedOCISecret := &corev1.Secret{
+	referencedOCIPullSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-referenced-oci-secret",
+			Name:      "test-referenced-oci-pull-secret",
+			Namespace: "garden",
+		},
+	}
+	referencedOCICABundleSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-referenced-oci-ca-bundle-secret",
 			Namespace: "garden",
 		},
 	}
@@ -114,8 +119,9 @@ func NewResources() *Resources {
 		},
 		Helm: &gardencorev1.HelmControllerDeployment{
 			OCIRepository: &gardencorev1.OCIRepository{
-				Ref:           new("test-registry.example.com/charts/provider:v1.0.0"),
-				PullSecretRef: &corev1.LocalObjectReference{Name: referencedOCISecret.Name},
+				Ref:               new("test-registry.example.com/charts/provider:v1.0.0"),
+				PullSecretRef:     &corev1.LocalObjectReference{Name: referencedOCIPullSecret.Name},
+				CABundleSecretRef: &corev1.LocalObjectReference{Name: referencedOCICABundleSecret.Name},
 			},
 		},
 		Resources: []gardencorev1.NamedResourceReference{
@@ -246,7 +252,8 @@ func NewResources() *Resources {
 		ControllerRegistrationDNS:      controllerRegistrationDNS,
 		ReferencedSecret:               referencedSecret,
 		ReferencedConfigMap:            referencedConfigMap,
-		ReferencedOCISecret:            referencedOCISecret,
+		ReferencedOCIPullSecret:        referencedOCIPullSecret,
+		ReferencedOCICABundleSecret:    referencedOCICABundleSecret,
 		Shoot:                          shoot,
 	}
 }

--- a/pkg/gardenadm/cmd/discover/new/new_test.go
+++ b/pkg/gardenadm/cmd/discover/new/new_test.go
@@ -79,6 +79,9 @@ var _ = Describe("New", func() {
 		Expect(fakeClient.Create(ctx, resources.ControllerRegistrationNetwork)).To(Succeed())
 		Expect(fakeClient.Create(ctx, resources.ControllerDeploymentDNS)).To(Succeed())
 		Expect(fakeClient.Create(ctx, resources.ControllerRegistrationDNS)).To(Succeed())
+		Expect(fakeClient.Create(ctx, resources.ReferencedSecret)).To(Succeed())
+		Expect(fakeClient.Create(ctx, resources.ReferencedConfigMap)).To(Succeed())
+		Expect(fakeClient.Create(ctx, resources.ReferencedOCISecret)).To(Succeed())
 
 		shootRaw, err := runtime.Encode(&json.Serializer{}, resources.Shoot)
 		Expect(err).NotTo(HaveOccurred())
@@ -106,6 +109,9 @@ var _ = Describe("New", func() {
 				ContainSubstring("Exported ControllerRegistration/"+resources.ControllerRegistrationNetwork.Name),
 				ContainSubstring("Exported ControllerDeployment/"+resources.ControllerDeploymentDNS.Name),
 				ContainSubstring("Exported ControllerRegistration/"+resources.ControllerRegistrationDNS.Name),
+				ContainSubstring("Exported Secret/"+resources.ReferencedSecret.Name),
+				ContainSubstring("Exported ConfigMap/"+resources.ReferencedConfigMap.Name),
+				ContainSubstring("Exported Secret/"+resources.ReferencedOCISecret.Name),
 			))
 
 			for _, path := range []string{
@@ -121,6 +127,9 @@ var _ = Describe("New", func() {
 				fmt.Sprintf("controllerregistration-%s.yaml", resources.ControllerRegistrationNetwork.Name),
 				fmt.Sprintf("controllerdeployment-%s.yaml", resources.ControllerDeploymentDNS.Name),
 				fmt.Sprintf("controllerregistration-%s.yaml", resources.ControllerRegistrationDNS.Name),
+				fmt.Sprintf("secret-%s.yaml", resources.ReferencedSecret.Name),
+				fmt.Sprintf("configmap-%s.yaml", resources.ReferencedConfigMap.Name),
+				fmt.Sprintf("secret-%s.yaml", resources.ReferencedOCISecret.Name),
 			} {
 				exists, err := fs.Exists(path)
 				Expect(err).NotTo(HaveOccurred(), "for path "+path)

--- a/pkg/gardenadm/cmd/discover/new/new_test.go
+++ b/pkg/gardenadm/cmd/discover/new/new_test.go
@@ -81,7 +81,8 @@ var _ = Describe("New", func() {
 		Expect(fakeClient.Create(ctx, resources.ControllerRegistrationDNS)).To(Succeed())
 		Expect(fakeClient.Create(ctx, resources.ReferencedSecret)).To(Succeed())
 		Expect(fakeClient.Create(ctx, resources.ReferencedConfigMap)).To(Succeed())
-		Expect(fakeClient.Create(ctx, resources.ReferencedOCISecret)).To(Succeed())
+		Expect(fakeClient.Create(ctx, resources.ReferencedOCIPullSecret)).To(Succeed())
+		Expect(fakeClient.Create(ctx, resources.ReferencedOCICABundleSecret)).To(Succeed())
 
 		shootRaw, err := runtime.Encode(&json.Serializer{}, resources.Shoot)
 		Expect(err).NotTo(HaveOccurred())
@@ -111,7 +112,8 @@ var _ = Describe("New", func() {
 				ContainSubstring("Exported ControllerRegistration/"+resources.ControllerRegistrationDNS.Name),
 				ContainSubstring("Exported Secret/"+resources.ReferencedSecret.Name),
 				ContainSubstring("Exported ConfigMap/"+resources.ReferencedConfigMap.Name),
-				ContainSubstring("Exported Secret/"+resources.ReferencedOCISecret.Name),
+				ContainSubstring("Exported Secret/"+resources.ReferencedOCIPullSecret.Name),
+				ContainSubstring("Exported Secret/"+resources.ReferencedOCICABundleSecret.Name),
 			))
 
 			for _, path := range []string{
@@ -129,7 +131,8 @@ var _ = Describe("New", func() {
 				fmt.Sprintf("controllerregistration-%s.yaml", resources.ControllerRegistrationDNS.Name),
 				fmt.Sprintf("secret-%s.yaml", resources.ReferencedSecret.Name),
 				fmt.Sprintf("configmap-%s.yaml", resources.ReferencedConfigMap.Name),
-				fmt.Sprintf("secret-%s.yaml", resources.ReferencedOCISecret.Name),
+				fmt.Sprintf("secret-%s.yaml", resources.ReferencedOCIPullSecret.Name),
+				fmt.Sprintf("secret-%s.yaml", resources.ReferencedOCICABundleSecret.Name),
 			} {
 				exists, err := fs.Exists(path)
 				Expect(err).NotTo(HaveOccurred(), "for path "+path)

--- a/pkg/utils/graph/eventhandler_controllerdeployment.go
+++ b/pkg/utils/graph/eventhandler_controllerdeployment.go
@@ -75,6 +75,13 @@ func extractControllerDeploymentInfo(obj any) (string, []string, []string) {
 	return controllerDeployment.Name, secretNames, configMapsNames
 }
 
+// HandleControllerDeploymentCreateOrUpdate adds edges from the Secrets/ConfigMaps referenced by the ControllerDeployment
+// (via its Helm OCIRepository pull secret/CA bundle and its `.resources` field) to the ControllerDeployment vertex.
+func (g *graph) HandleControllerDeploymentCreateOrUpdate(controllerDeployment *gardencorev1.ControllerDeployment) {
+	name, secretNames, configMapNames := extractControllerDeploymentInfo(controllerDeployment)
+	g.handleControllerDeploymentCreateOrUpdate(name, secretNames, configMapNames)
+}
+
 func (g *graph) handleControllerDeploymentCreateOrUpdate(controllerDeploymentName string, secretNames, configMapNames []string) {
 	start := time.Now()
 	defer func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area disaster-recovery control-plane ipcei
/kind enhancement

**What this PR does / why we need it**:

ControllerDeployments can reference Secrets/ConfigMaps via their `.resources` field (templated into the Helm values as `{{ .resources.<name>.data.<key> }}`) as well as OCI image pull secrets and CA bundle secrets via the Helm OCIRepository. This mechanism was introduced with https://github.com/gardener/gardener/pull/14979. `gardenadm discover new`/`existing` exported the ControllerDeployments themselves but not these referenced resources, so a subsequent `gardenadm init`/`restore` failed to resolve the Helm values in the init flow:

```
Error: 1 error occurred:
	* task "Running init flow" failed: 1 error occurred:
	* task "Deploying extension controllers" failed: retry failed with context deadline exceeded, last error: failed running ControllerInstallation controller for "provider-local": failed resolving resource references: referenced Secret "provider-local-provider-local-image-names" for resource reference "imageNames" not found in namespace "garden"
```

Export the referenced Secrets/ConfigMaps and OCI-related Secrets from the `garden` namespace for each required extension's ControllerDeployment. The set of exported resources mirrors the resolution performed by the controllerdeployment-reference controller (garden namespace, `v1` apiVersion, `Secret`/`ConfigMap` kinds, plus OCI pull-secret and CA-bundle secrets). Labels are preserved on export, so correctly labeled `gardener.cloud/role: resource-reference` resources resolve as expected during the later init/restore flow.

Additional warning in case no `BackupBucket` is found for the Shoot is also added.

**Which issue(s) this PR fixes**:
Fixes #15608 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardenadm discover new`/`existing` now also export the `Secret`s/`ConfigMap`s referenced by a `ControllerDeployment` (via its `.resources` field as well as the Helm `OCIRepository` pull secret and CA bundle). This ensures a subsequent `gardenadm init`/`restore` can resolve the referenced resources when templating the extension Helm values.
```
