### PR TITLE
Validate generated worker pool names

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -57,6 +57,10 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 		return fmt.Errorf("failed to generate the machine deployments: %w", err)
 	}
 
+	if err := validateMachineDeploymentPoolNames(worker, wantedMachineDeployments); err != nil {
+		return err
+	}
+
 	var (
 		clusterAutoscalerUsed = extensionsv1alpha1helper.ClusterAutoscalerRequired(worker.Spec.Pools)
 		isHibernationEnabled  = extensionscontroller.IsHibernationEnabled(cluster)
@@ -170,6 +174,20 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 	// Call post reconciliation hook after Worker reconciliation has happened.
 	if err := workerDelegate.PostReconcileHook(ctx); err != nil {
 		return fmt.Errorf("post worker reconciliation hook failed: %w", err)
+	}
+
+	return nil
+}
+
+func validateMachineDeploymentPoolNames(worker *extensionsv1alpha1.Worker, machineDeployments extensionsworkercontroller.MachineDeployments) error {
+	workerPoolNames := sets.New[string]()
+	for _, pool := range worker.Spec.Pools {
+		workerPoolNames.Insert(pool.Name)
+	}
+	for _, deployment := range machineDeployments {
+		if !workerPoolNames.Has(deployment.PoolName) {
+			return fmt.Errorf("generated MachineDeployment %q references unknown worker pool %q", deployment.Name, deployment.PoolName)
+		}
 	}
 
 	return nil

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
@@ -34,6 +34,41 @@ import (
 )
 
 var _ = Describe("ActuatorReconcile", func() {
+	Describe("#validateMachineDeploymentPoolNames", func() {
+		It("should reject unknown worker pools", func() {
+			worker := &extensionsv1alpha1.Worker{
+				Spec: extensionsv1alpha1.WorkerSpec{
+					Pools: []extensionsv1alpha1.WorkerPool{{Name: "pool1"}},
+				},
+			}
+
+			deployments := extensionsworkercontroller.MachineDeployments{{Name: "machine-deployment", PoolName: "unknown"}}
+			Expect(validateMachineDeploymentPoolNames(worker, deployments)).To(MatchError(`generated MachineDeployment "machine-deployment" references unknown worker pool "unknown"`))
+		})
+
+		It("should reject an unset worker pool", func() {
+			worker := &extensionsv1alpha1.Worker{
+				Spec: extensionsv1alpha1.WorkerSpec{
+					Pools: []extensionsv1alpha1.WorkerPool{{Name: "pool1"}},
+				},
+			}
+
+			deployments := extensionsworkercontroller.MachineDeployments{{Name: "machine-deployment"}}
+			Expect(validateMachineDeploymentPoolNames(worker, deployments)).To(MatchError(`generated MachineDeployment "machine-deployment" references unknown worker pool ""`))
+		})
+
+		It("should accept deployments for defined worker pools", func() {
+			worker := &extensionsv1alpha1.Worker{
+				Spec: extensionsv1alpha1.WorkerSpec{
+					Pools: []extensionsv1alpha1.WorkerPool{{Name: "pool1"}},
+				},
+			}
+
+			deployments := extensionsworkercontroller.MachineDeployments{{Name: "machine-deployment", PoolName: "pool1"}}
+			Expect(validateMachineDeploymentPoolNames(worker, deployments)).To(Succeed())
+		})
+	})
+
 	Describe("#deployMachineDeployments", func() {
 		var (
 			ctx                        context.Context


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

The generic worker actuator now verifies that every generated `MachineDeployment` references a worker pool declared in the `Worker` resource. This rejects unset or unknown `PoolName` values before resources are reconciled, preventing Shoot worker rollouts from failing later with `no MachineDeployment found for worker pool ...`.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Should this be classified as a breaking change? It will break shoot reconciliation for the GDC provider-extension without this fix: https://github.com/gardener/gardener-extension-provider-gdc/pull/4. On the other hand it has probably always been part of the implicit contract without being explicitly checked.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy dependency
Provider extensions now must define `MachineDeployment.PoolName` or Gardener will through an error. Before the fix this value was not checked causing issues during manual worker pool rollout.
```
