### PR TITLE
Reject VPA minAllowed/maxAllowed quantities the vpa.k8s.io webhook would refuse

### DIFF
--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -1723,6 +1723,7 @@ func ValidateVerticalPodAutoscalerMaxAllowed(maxAllowed corev1.ResourceList, fld
 		}
 
 		allErrs = append(allErrs, kubernetescorevalidation.ValidateResourceQuantityValue(resource.String(), quantity, resourcePath)...)
+		allErrs = append(allErrs, validateResourceQuantityResolution(resource, quantity, resourcePath)...)
 	}
 
 	return allErrs
@@ -3932,6 +3933,28 @@ func ValidateControlPlaneAutoscaling(autoscaling *core.ControlPlaneAutoscaling, 
 			}
 
 			allErrs = append(allErrs, kubernetescorevalidation.ValidateResourceQuantityValue(resource.String(), quantity, resourcePath)...)
+			allErrs = append(allErrs, validateResourceQuantityResolution(resource, quantity, resourcePath)...)
+		}
+	}
+
+	return allErrs
+}
+
+// validateResourceQuantityResolution validates that the given quantity does not exceed the resolution supported by
+// the `vpa.k8s.io` admission webhook, i.e., that CPU quantities are a whole number of milli CPUs and memory
+// quantities are a whole number of bytes. Otherwise, the VerticalPodAutoscaler resource created from this value
+// would be rejected by the webhook, causing the reconciliation to fail.
+func validateResourceQuantityResolution(resourceName corev1.ResourceName, quantity resource.Quantity, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	switch resourceName {
+	case corev1.ResourceCPU:
+		if _, precisionPreserved := quantity.AsScale(resource.Milli); !precisionPreserved {
+			allErrs = append(allErrs, field.Invalid(fldPath, quantity.String(), "must be a whole number of milli CPUs"))
+		}
+	case corev1.ResourceMemory:
+		if _, precisionPreserved := quantity.AsScale(resource.Scale(0)); !precisionPreserved {
+			allErrs = append(allErrs, field.Invalid(fldPath, quantity.String(), "must be a whole number of bytes"))
 		}
 	}
 

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -10945,6 +10945,42 @@ var _ = Describe("Shoot Validation Tests", func() {
 			))
 		})
 
+		It("should fail for memory values that are not a whole number of bytes", func() {
+			autoscaling := &core.ControlPlaneAutoscaling{
+				MinAllowed: map[corev1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("10m"),
+					"memory": resource.MustParse("7118908293120m"),
+				},
+			}
+
+			Expect(ValidateControlPlaneAutoscaling(autoscaling, nil, field.NewPath("autoscaling"))).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("autoscaling.minAllowed.memory"),
+					"BadValue": Equal("7118908293120m"),
+					"Detail":   Equal("must be a whole number of bytes"),
+				})),
+			))
+		})
+
+		It("should fail for CPU values that are not a whole number of milli CPUs", func() {
+			autoscaling := &core.ControlPlaneAutoscaling{
+				MinAllowed: map[corev1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("100u"),
+					"memory": resource.MustParse("50Mi"),
+				},
+			}
+
+			Expect(ValidateControlPlaneAutoscaling(autoscaling, nil, field.NewPath("autoscaling"))).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("autoscaling.minAllowed.cpu"),
+					"BadValue": Equal("100u"),
+					"Detail":   Equal("must be a whole number of milli CPUs"),
+				})),
+			))
+		})
+
 		When("minimum required values are configured", func() {
 			var minRequired corev1.ResourceList
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area auto-scaling
/kind bug

**What this PR does / why we need it**:

A Shoot can be created with `spec.kubernetes.kubeAPIServer.autoscaling.minAllowed.memory` (or the equivalent fields for etcd main/events, kube-controller-manager, and the VPA recommender's global `maxAllowed`) set to a resource quantity that is not a whole number of bytes for memory, or not a whole number of milli-CPUs for CPU (e.g. `7118908293120m`). Gardener's Shoot API validation accepted such values, but the `vpa.k8s.io` admission webhook running in the seed rejects the `VerticalPodAutoscaler` object created from them, causing shoot reconciliation to fail late with a confusing error:

```
task "Deploying Kubernetes API server" failed: retry failed with context deadline exceeded, last error: admission webhook "vpa.k8s.io" denied the request: VerticalPodAutoscaler.autoscaling.k8s.io "kube-apiserver-vpa" is invalid: spec.resourcePolicy.containerPolicies[0].minAllowed[memory]: Invalid value: "7118908293120m": must be a whole number of bytes
```

This PR adds the same precision check that the `vpa.k8s.io` webhook performs (see `k8s.io/autoscaler/vertical-pod-autoscaler` `pkg/admission-controller/resource/vpa/validation.go`) to Gardener's own Shoot API validation, so invalid values are rejected immediately at `kubectl apply`/`kubectl create` time instead of failing reconciliation in the seed.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/15666

**Special notes for your reviewer**:

The new `validateResourceQuantityResolution` helper is wired into the two shared validation functions `ValidateControlPlaneAutoscaling` and `ValidateVerticalPodAutoscalerMaxAllowed`, which are already used by every `minAllowed`/`maxAllowed` VPA resource field in the API (kube-apiserver, kube-controller-manager, etcd main/events autoscaling, VPA recommender `maxAllowed`, and the `Seed`/`Garden` equivalents), so the fix applies consistently without touching each call site.

Validation performed:
- `go build ./pkg/api/core/validation/...` succeeds.
- `go test ./pkg/api/core/validation/...` passes, including two new test cases reproducing the exact value from the issue report (`7118908293120m` for memory) and an analogous case for CPU (`100u`).
- Confirmed these new tests fail without the fix and pass with it (targeted before/after reproduction of the reported defect).
- `gofmt -l` and `go vet` on the changed files are clean.
- Could not run a full-repo `make check`/`make verify` or a live reconciliation against a real seed/VPA webhook in this environment (local disk space was exhausted during a whole-repo build attempt, unrelated to this change); the fix was validated via the failing-then-passing unit test against the vendored `k8s.io/autoscaler/vertical-pod-autoscaler` validation logic instead.

**Release note**:
```other operator
Shoot API validation now rejects `minAllowed`/`maxAllowed` VPA resource values that would later be rejected by the `vpa.k8s.io` admission webhook in the seed (e.g. memory quantities that are not a whole number of bytes), surfacing the error immediately instead of during shoot reconciliation.
```

Fixes #15666

```release-note
Reject VPA minAllowed/maxAllowed quantities the vpa.k8s.io webhook would refuse
```