### PR TITLE
Enable optionalfields linter in kube-api-linter

### DIFF
--- a/.golangci.yaml.in
+++ b/.golangci.yaml.in
@@ -279,6 +279,16 @@ linters:
               - "*"
             enable:
               - jsontags
+              - optionalfields
+          lintersConfig:
+            optionalfields:
+              pointers:
+                preference: "WhenRequired"
+                policy: "SuggestFix"
+              omitempty:
+                policy: "SuggestFix"
+              omitzero:
+                policy: "Forbid"
   exclusions:
     generated: lax
     rules:
@@ -323,6 +333,18 @@ linters:
       - linters:
           - kubeapilinter
         path-except: 'pkg/apis/[^/]+(/[^/]+)?/v[0-9]+((alpha|beta)[0-9]+)?/[^/]+$'
+      # optionalfields: Spec/Status and other struct fields on top-level API objects have established non-pointer
+      # conventions in Kubernetes APIs. Similarly, scalar fields (int64, string) with incomplete validation
+      # are intentionally kept as value types. Converting these to pointers would be API-breaking.
+      - linters:
+          - kubeapilinter
+        text: 'optionalfields: field .* has a valid zero value'
+      # optionalfields: These optional fields are intentionally pointers even though their validation makes
+      # the zero value invalid (e.g. Enum constraints, MinLength). The pointer allows callers to detect
+      # whether the field was explicitly set. Removing the pointer would break downstream callers.
+      - linters:
+          - kubeapilinter
+        text: 'optionalfields: field .* does not allow the zero value\. The field does not need to be a pointer\.'
 formatters:
   settings:
     gofmt:

--- a/pkg/apis/config/controllermanager/v1alpha1/types.go
+++ b/pkg/apis/config/controllermanager/v1alpha1/types.go
@@ -347,10 +347,10 @@ type ShootMaintenanceControllerConfiguration struct {
 	ConcurrentSyncs *int `json:"concurrentSyncs,omitempty"`
 	// EnableShootControlPlaneRestarter configures whether adequate pods of the shoot control plane are restarted during maintenance.
 	// +optional
-	EnableShootControlPlaneRestarter *bool `json:"enableShootControlPlaneRestarter"`
+	EnableShootControlPlaneRestarter *bool `json:"enableShootControlPlaneRestarter,omitempty"`
 	// EnableShootCoreAddonRestarter configures whether some core addons to be restarted during maintenance.
 	// +optional
-	EnableShootCoreAddonRestarter *bool `json:"enableShootCoreAddonRestarter"`
+	EnableShootCoreAddonRestarter *bool `json:"enableShootCoreAddonRestarter,omitempty"`
 }
 
 // ShootQuotaControllerConfiguration defines the configuration of the

--- a/pkg/apis/config/resourcemanager/v1alpha1/types.go
+++ b/pkg/apis/config/resourcemanager/v1alpha1/types.go
@@ -19,7 +19,7 @@ type ResourceManagerConfiguration struct {
 	// SourceClientConnection specifies the client connection settings for the proxy server
 	// to use when communicating with the source apiserver.
 	// +optional
-	SourceClientConnection ClientConnection `json:"sourceClientConnection"`
+	SourceClientConnection ClientConnection `json:"sourceClientConnection,omitempty"`
 	// TargetClientConnection specifies the client connection settings for the proxy server
 	// to use when communicating with the target apiserver.
 	// +optional

--- a/pkg/apis/extensions/v1alpha1/types_backupbucket.go
+++ b/pkg/apis/extensions/v1alpha1/types_backupbucket.go
@@ -34,7 +34,7 @@ type BackupBucket struct {
 	// If the object's deletion timestamp is set, this field is immutable.
 	Spec BackupBucketSpec `json:"spec"`
 	// +optional
-	Status BackupBucketStatus `json:"status"`
+	Status BackupBucketStatus `json:"status,omitempty"`
 }
 
 // GetExtensionSpec implements Object.

--- a/pkg/apis/extensions/v1alpha1/types_backupentry.go
+++ b/pkg/apis/extensions/v1alpha1/types_backupentry.go
@@ -36,7 +36,7 @@ type BackupEntry struct {
 	// If the object's deletion timestamp is set, this field is immutable.
 	Spec BackupEntrySpec `json:"spec"`
 	// +optional
-	Status BackupEntryStatus `json:"status"`
+	Status BackupEntryStatus `json:"status,omitempty"`
 }
 
 // GetExtensionSpec implements Object.

--- a/pkg/apis/extensions/v1alpha1/types_containerruntime.go
+++ b/pkg/apis/extensions/v1alpha1/types_containerruntime.go
@@ -37,7 +37,7 @@ type ContainerRuntime struct {
 	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ContainerRuntimeSpec `json:"spec"`
 	// +optional
-	Status ContainerRuntimeStatus `json:"status"`
+	Status ContainerRuntimeStatus `json:"status,omitempty"`
 }
 
 // GetExtensionSpec implements Object.

--- a/pkg/apis/extensions/v1alpha1/types_controlplane.go
+++ b/pkg/apis/extensions/v1alpha1/types_controlplane.go
@@ -32,7 +32,7 @@ type ControlPlane struct {
 	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ControlPlaneSpec `json:"spec"`
 	// +optional
-	Status ControlPlaneStatus `json:"status"`
+	Status ControlPlaneStatus `json:"status,omitempty"`
 }
 
 // GetExtensionSpec implements Object.

--- a/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
+++ b/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
@@ -33,7 +33,7 @@ type DNSRecord struct {
 	// If the object's deletion timestamp is set, this field is immutable.
 	Spec DNSRecordSpec `json:"spec"`
 	// +optional
-	Status DNSRecordStatus `json:"status"`
+	Status DNSRecordStatus `json:"status,omitempty"`
 }
 
 // GetExtensionSpec implements Object.

--- a/pkg/apis/extensions/v1alpha1/types_extension.go
+++ b/pkg/apis/extensions/v1alpha1/types_extension.go
@@ -31,7 +31,7 @@ type Extension struct {
 	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ExtensionSpec `json:"spec"`
 	// +optional
-	Status ExtensionStatus `json:"status"`
+	Status ExtensionStatus `json:"status,omitempty"`
 }
 
 // GetExtensionSpec implements Object.

--- a/pkg/apis/extensions/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/extensions/v1alpha1/types_infrastructure.go
@@ -33,7 +33,7 @@ type Infrastructure struct {
 	// If the object's deletion timestamp is set, this field is immutable.
 	Spec InfrastructureSpec `json:"spec"`
 	// +optional
-	Status InfrastructureStatus `json:"status"`
+	Status InfrastructureStatus `json:"status,omitempty"`
 }
 
 // GetExtensionSpec implements Object.

--- a/pkg/apis/extensions/v1alpha1/types_network.go
+++ b/pkg/apis/extensions/v1alpha1/types_network.go
@@ -33,7 +33,7 @@ type Network struct {
 	// If the object's deletion timestamp is set, this field is immutable.
 	Spec NetworkSpec `json:"spec"`
 	// +optional
-	Status NetworkStatus `json:"status"`
+	Status NetworkStatus `json:"status,omitempty"`
 }
 
 // GetExtensionSpec implements Object.

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -34,7 +34,7 @@ type OperatingSystemConfig struct {
 	// If the object's deletion timestamp is set, this field is immutable.
 	Spec OperatingSystemConfigSpec `json:"spec"`
 	// +optional
-	Status OperatingSystemConfigStatus `json:"status"`
+	Status OperatingSystemConfigStatus `json:"status,omitempty"`
 }
 
 // GetExtensionSpec implements Object.

--- a/pkg/apis/extensions/v1alpha1/types_selfhostedshootexposure.go
+++ b/pkg/apis/extensions/v1alpha1/types_selfhostedshootexposure.go
@@ -34,7 +34,7 @@ type SelfHostedShootExposure struct {
 	// If the object's deletion timestamp is set, this field is immutable.
 	Spec SelfHostedShootExposureSpec `json:"spec"`
 	// +optional
-	Status SelfHostedShootExposureStatus `json:"status"`
+	Status SelfHostedShootExposureStatus `json:"status,omitempty"`
 }
 
 // GetExtensionSpec implements Object.

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -50,7 +50,7 @@ type Worker struct {
 	// If the object's deletion timestamp is set, this field is immutable.
 	Spec WorkerSpec `json:"spec"`
 	// +optional
-	Status WorkerStatus `json:"status"`
+	Status WorkerStatus `json:"status,omitempty"`
 }
 
 // GetExtensionSpec implements Object.

--- a/pkg/apis/operations/v1alpha1/types_bastion.go
+++ b/pkg/apis/operations/v1alpha1/types_bastion.go
@@ -31,7 +31,7 @@ type Bastion struct {
 	Spec BastionSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 	// Most recently observed status of the Bastion.
 	// +optional
-	Status BastionStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
+	Status BastionStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/component/gardener/controllermanager/controller_manager_test.go
+++ b/pkg/component/gardener/controllermanager/controller_manager_test.go
@@ -318,7 +318,7 @@ var _ = Describe("GardenerControllerManager", func() {
 				managedResourceSecretRuntime.Name = managedResourceRuntime.Spec.SecretRefs[0].Name
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(Succeed())
 				cm := configMap(namespace, values)
-				Expect(cm.Name).To(Equal("gardener-controller-manager-config-960e3f19"))
+				Expect(cm.Name).To(Equal("gardener-controller-manager-config-25f211e9"))
 				expectedRuntimeObjects = []client.Object{
 					cm,
 					podDisruptionBudget,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Enables the optionalfields kube-api-linter and adapts the affected API types to satisfy it.

**Which issue(s) this PR fixes**:
Part of #12756

**Special notes for your reviewer**:
The linter is configured with `pointers.preference: WhenRequired` plus exclusions for established non-pointer conventions(`Spec`/`Status` structs, `ObservedGeneration`) that would be API-breaking to change.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
