### PR TITLE
Prevent auto-update from downgrading a supported version to deprecated

### DIFF
--- a/pkg/api/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile.go
@@ -301,6 +301,9 @@ func GetOverallLatestVersionForAutoUpdate(versions []gardencorev1beta1.Expirable
 // getVersionForAutoUpdate finds the latest eligible version higher than a given <currentVersion> from a slice of versions.
 // Versions <= the current version, preview and expired versions do not qualify for patch updates.
 // First tries to find a non-deprecated version.
+// If none is found and the current version is itself already deprecated or expired (i.e. it has to be moved away
+// from regardless), also considers deprecated versions. A current version that is still supported or in preview is
+// never auto-updated to a deprecated version, since that would downgrade its classification without any need to do so.
 // In case no newer patch version is found, returns false and an empty string. Otherwise, returns true and the found version.
 func getVersionForAutoUpdate(versions []gardencorev1beta1.ExpirableVersion, currentSemVerVersion *semver.Version, predicates []VersionPredicate) (bool, string, error) {
 	versionPredicates := append([]VersionPredicate{FilterExpiredVersion(), FilterSameVersion(*currentSemVerVersion), FilterLowerVersion(*currentSemVerVersion)}, predicates...)
@@ -314,6 +317,10 @@ func getVersionForAutoUpdate(versions []gardencorev1beta1.ExpirableVersion, curr
 		return true, latestNonDeprecatedImageVersion.Version, nil
 	}
 
+	if !currentVersionQualifiesForDeprecatedFallback(versions, currentSemVerVersion) {
+		return false, "", nil
+	}
+
 	// otherwise, also consider deprecated versions
 	qualifyingVersionFound, latestVersion, err := GetLatestQualifyingVersion(versions, versionPredicates...)
 	if err != nil {
@@ -325,6 +332,25 @@ func getVersionForAutoUpdate(versions []gardencorev1beta1.ExpirableVersion, curr
 	}
 
 	return true, latestVersion.Version, nil
+}
+
+// currentVersionQualifiesForDeprecatedFallback reports whether the auto-update logic is allowed to fall back to a
+// deprecated version because no non-deprecated qualifying version could be found. This is only the case if the
+// current version itself is not currently supported or in preview, i.e. it already has to be moved away from. If the
+// current version cannot be found in the given versions (e.g. it was removed from the CloudProfile), it is treated
+// as if it needs to be moved away from as well.
+func currentVersionQualifiesForDeprecatedFallback(versions []gardencorev1beta1.ExpirableVersion, currentSemVerVersion *semver.Version) bool {
+	for _, version := range versions {
+		semVerVersion, err := semver.NewVersion(version.Version)
+		if err != nil || !semVerVersion.Equal(currentSemVerVersion) {
+			continue
+		}
+
+		classification := CurrentLifecycleClassification(version)
+		return classification != gardencorev1beta1.ClassificationSupported && classification != gardencorev1beta1.ClassificationPreview
+	}
+
+	return true
 }
 
 // GetVersionForForcefulUpdateToConsecutiveMinor finds a version from a slice of expirable versions that qualifies for a minor level update given a <currentVersion>.

--- a/pkg/api/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile_test.go
@@ -578,6 +578,42 @@ var _ = Describe("CloudProfile Helper", func() {
 			"1.17.1",
 			false,
 		),
+		Entry("Expect no version to be found, as the current version is still supported and no non-deprecated higher version exists",
+			[]gardencorev1beta1.ExpirableVersion{
+				{
+					Version:        "2.3.0",
+					Classification: &deprecatedClassification,
+				},
+				{
+					Version:        "2.2.0",
+					Classification: &supportedClassification,
+				},
+				{
+					Version:        "2.1.0",
+					ExpirationDate: &expirationDateInThePast,
+				},
+			},
+			"2.2.0",
+			false,
+			"",
+			false,
+		),
+		Entry("Expect newer deprecated version to be selected, as the current version is already deprecated",
+			[]gardencorev1beta1.ExpirableVersion{
+				{
+					Version:        "2.3.0",
+					Classification: &deprecatedClassification,
+				},
+				{
+					Version:        "2.2.0",
+					Classification: &deprecatedClassification,
+				},
+			},
+			"2.2.0",
+			true,
+			"2.3.0",
+			false,
+		),
 	)
 
 	DescribeTable("#GetLatestQualifyingVersion",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area os
/kind bug

**What this PR does / why we need it**:

During Shoot maintenance, auto-update for a Kubernetes or machine image version could pick a newer but `Deprecated` version even though the Shoot's current version was still `Supported` (or `Preview`). This happened because `getVersionForAutoUpdate` in `pkg/api/core/v1beta1/helper/cloudprofile.go` falls back to considering deprecated versions whenever no non-deprecated qualifying version is found, without checking whether the current version actually needs to move away from its classification.

Example from the linked issue: a Shoot on OS `2.1` (deprecated) auto-updates to `2.2` (supported) during one maintenance run — correct. If the CloudProfile is later extended with a `2.3` (deprecated) version and no non-deprecated version newer than `2.2` exists yet, the *next* maintenance run auto-updates the Shoot again, from `2.2` (supported) to `2.3` (deprecated) — an unwanted classification downgrade. This is especially problematic when `2.3` was deprecated specifically because it was found to be buggy.

**Approach**: `getVersionForAutoUpdate` now only falls back to a deprecated version if the current version's own classification is not `Supported` and not `Preview` (i.e. it already needs to move away from its current classification, e.g. because it is `Deprecated`, `Expired` or was removed from the CloudProfile). This preserves the existing behavior of upgrading a deprecated/expired version to the next best available one, while no longer downgrading a Shoot that is already on a supported (or preview) version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This is a targeted fix; no design change to the CloudProfile API or the maintenance controller flow is needed. `getVersionForAutoUpdate` is the single shared code path used by `GetLatestVersionForPatchAutoUpdate`, `GetLatestVersionForMinorAutoUpdate` and `GetOverallLatestVersionForAutoUpdate`, so the fix applies uniformly to both Kubernetes version and machine image auto-updates without touching call sites in `pkg/controllermanager/controller/shoot/maintenance/`.

**Validation**:
- Added a targeted Ginkgo entry ("Expect no version to be found, as the current version is still supported and no non-deprecated higher version exists") to the `#GetOverallLatestVersionForAutoUpdate` table in `pkg/api/core/v1beta1/helper/cloudprofile_test.go` reproducing the exact scenario from the issue. Verified it FAILS against the pre-fix code (`ok` expected `false`, got `true`) and PASSES after the fix.
- Added a second entry ("Expect newer deprecated version to be selected, as the current version is already deprecated") to guard the pre-existing, still-desired behavior of upgrading an already-deprecated version to a newer deprecated one when no supported version exists.
- Ran `go build ./pkg/api/core/v1beta1/helper/... ./pkg/controllermanager/controller/shoot/maintenance/...` — succeeds.
- Ran `go test ./pkg/api/core/v1beta1/helper/... ./pkg/controllermanager/controller/shoot/maintenance/...` — all packages pass (743 specs in the helper package).
- Ran `golangci-lint` against the changed package using the repo's `.golangci.yaml.in` configuration (with the custom `logcheck`/`kubeapilinter` plugins excluded, since those require building `.so` plugins not present in this environment) — 0 issues. `gofmt -l` reports no formatting issues.
- Did not run the full `make check`/`make test` targets (they require building additional local tooling such as `import-boss`, `kube-api-linter` and `logcheck` as compiler plugins, which was not done in this environment); the above build, unit test and lint runs cover the changed code paths.

**Release note**:
```bugfix user
Fixed a bug where Shoot maintenance could auto-update a Kubernetes or machine image version from a supported version to a newer but deprecated version when no newer supported version was yet available.
```

Fixes #13647

```release-note
Prevent auto-update from downgrading a supported version to deprecated
```