### PR TITLE
Fix `DeploymentHasExactNumberOfPods` to only count pods owned by the Deployment

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -4471,11 +4471,22 @@ anonymous:
 			Expect(fakeClient.Create(ctx, deploy)).To(Succeed())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(Succeed())
 
+			replicaSet := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "replicaset",
+					Namespace:       deployment.Namespace,
+					Labels:          GetLabels(),
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deploy, appsv1.SchemeGroupVersion.WithKind("Deployment"))},
+				},
+			}
+			Expect(fakeClient.Create(ctx, replicaSet)).To(Succeed())
+
 			Expect(fakeClient.Create(ctx, &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod",
-					Namespace: deployment.Namespace,
-					Labels:    GetLabels(),
+					Name:            "pod",
+					Namespace:       deployment.Namespace,
+					Labels:          GetLabels(),
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(replicaSet, appsv1.SchemeGroupVersion.WithKind("ReplicaSet"))},
 				},
 			})).To(Succeed())
 

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -949,11 +949,22 @@ namespace: kube-system
 			Expect(c.Create(ctx, deploy)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(Succeed())
 
+			replicaSet := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "replicaset",
+					Namespace:       deployment.Namespace,
+					Labels:          labels,
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deploy, appsv1.SchemeGroupVersion.WithKind("Deployment"))},
+				},
+			}
+			Expect(c.Create(ctx, replicaSet)).To(Succeed())
+
 			Expect(c.Create(ctx, &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod",
-					Namespace: deployment.Namespace,
-					Labels:    labels,
+					Name:            "pod",
+					Namespace:       deployment.Namespace,
+					Labels:          labels,
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(replicaSet, appsv1.SchemeGroupVersion.WithKind("ReplicaSet"))},
 				},
 			})).To(Succeed())
 

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -740,11 +740,22 @@ subjects:
 			Expect(fakeClient.Create(ctx, deploy)).To(Succeed())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(Succeed())
 
+			replicaSet := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "replicaset",
+					Namespace:       deployment.Namespace,
+					Labels:          deployment.Spec.Selector.MatchLabels,
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deploy, appsv1.SchemeGroupVersion.WithKind("Deployment"))},
+				},
+			}
+			Expect(fakeClient.Create(ctx, replicaSet)).To(Succeed())
+
 			Expect(fakeClient.Create(ctx, &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod",
-					Namespace: deployment.Namespace,
-					Labels:    deployment.Spec.Selector.MatchLabels,
+					Name:            "pod",
+					Namespace:       deployment.Namespace,
+					Labels:          deployment.Spec.Selector.MatchLabels,
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(replicaSet, appsv1.SchemeGroupVersion.WithKind("ReplicaSet"))},
 				},
 			})).To(Succeed())
 

--- a/pkg/resourcemanager/controller/health/progressing/add_test.go
+++ b/pkg/resourcemanager/controller/health/progressing/add_test.go
@@ -115,7 +115,13 @@ var _ = Describe("Add", func() {
 						deploy := obj.(*appsv1.Deployment)
 						deploy.Generation++
 
-						pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{GenerateName: "pod-", Labels: map[string]string{"foo": "bar"}}}
+						replicaSet := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{GenerateName: "replicaset-", Labels: map[string]string{"foo": "bar"}, OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deploy, appsv1.SchemeGroupVersion.WithKind("Deployment"))}}}
+						Expect(fakeClient.Create(ctx, replicaSet)).To(Succeed())
+						DeferCleanup(func() {
+							Expect(fakeClient.Delete(ctx, replicaSet)).To(Succeed())
+						})
+
+						pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{GenerateName: "pod-", Labels: map[string]string{"foo": "bar"}, OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(replicaSet, appsv1.SchemeGroupVersion.WithKind("ReplicaSet"))}}}
 						Expect(fakeClient.Create(ctx, pod)).To(Succeed())
 						DeferCleanup(func() {
 							Expect(fakeClient.Delete(ctx, pod)).To(Succeed())

--- a/pkg/utils/kubernetes/health/deployment.go
+++ b/pkg/utils/kubernetes/health/deployment.go
@@ -11,6 +11,9 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -136,9 +139,21 @@ func IsDeploymentUpdated(reader client.Reader, deployment *appsv1.Deployment) fu
 	}
 }
 
-// DeploymentHasExactNumberOfPods returns true when there are exactly as many pods as the .spec.replicas field of the
-// deployment mandates.
+// DeploymentHasExactNumberOfPods returns true when there are exactly as many pods owned by the deployment (via its
+// ReplicaSets) as the .spec.replicas field of the deployment mandates.
 func DeploymentHasExactNumberOfPods(ctx context.Context, reader client.Reader, deployment *appsv1.Deployment) (bool, error) {
+	replicaSetList := &appsv1.ReplicaSetList{}
+	if err := reader.List(ctx, replicaSetList, client.InNamespace(deployment.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels)); err != nil {
+		return false, err
+	}
+
+	ownedReplicaSetUIDs := sets.New[types.UID]()
+	for _, replicaSet := range replicaSetList.Items {
+		if metav1.IsControlledBy(&replicaSet, deployment) {
+			ownedReplicaSetUIDs.Insert(replicaSet.UID)
+		}
+	}
+
 	podList := &corev1.PodList{}
 	if err := reader.List(ctx, podList, client.InNamespace(deployment.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels)); err != nil {
 		return false, err
@@ -146,6 +161,11 @@ func DeploymentHasExactNumberOfPods(ctx context.Context, reader client.Reader, d
 
 	var numberOfRelevantPods int32
 	for _, pod := range podList.Items {
+		controller := metav1.GetControllerOf(&pod)
+		if controller == nil || !ownedReplicaSetUIDs.Has(controller.UID) {
+			continue
+		}
+
 		if !IsPodTerminal(pod.Status.Phase) && !IsPodStale(pod.Status.Reason) && !IsPodCompleted(pod.Status.Conditions) && !IsPodDisrupted(pod.Status.Conditions) {
 			numberOfRelevantPods++
 		}

--- a/pkg/utils/kubernetes/health/deployment_test.go
+++ b/pkg/utils/kubernetes/health/deployment_test.go
@@ -160,6 +160,7 @@ var _ = Describe("Deployment", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "deploy",
 					Namespace: "namespace",
+					UID:       "deploy-uid",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: new(int32(1)),
@@ -182,11 +183,23 @@ var _ = Describe("Deployment", func() {
 
 			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
 
+			replicaSet := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "replicaset",
+					Namespace:       deployment.Namespace,
+					UID:             "replicaset-uid",
+					Labels:          labels,
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deployment, appsv1.SchemeGroupVersion.WithKind("Deployment"))},
+				},
+			}
+			Expect(fakeClient.Create(ctx, replicaSet)).To(Succeed())
+
 			Expect(fakeClient.Create(ctx, &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod",
-					Namespace: deployment.Namespace,
-					Labels:    labels,
+					Name:            "pod",
+					Namespace:       deployment.Namespace,
+					Labels:          labels,
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(replicaSet, appsv1.SchemeGroupVersion.WithKind("ReplicaSet"))},
 				},
 			})).To(Succeed())
 
@@ -209,12 +222,24 @@ var _ = Describe("Deployment", func() {
 
 			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
 
+			replicaSet := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "replicaset",
+					Namespace:       deployment.Namespace,
+					UID:             "replicaset-uid",
+					Labels:          labels,
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deployment, appsv1.SchemeGroupVersion.WithKind("Deployment"))},
+				},
+			}
+			Expect(fakeClient.Create(ctx, replicaSet)).To(Succeed())
+
 			for i := range 2 {
 				Expect(fakeClient.Create(ctx, &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("pod%d", i),
-						Namespace: deployment.Namespace,
-						Labels:    labels,
+						Name:            fmt.Sprintf("pod%d", i),
+						Namespace:       deployment.Namespace,
+						Labels:          labels,
+						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(replicaSet, appsv1.SchemeGroupVersion.WithKind("ReplicaSet"))},
 					},
 				})).To(Succeed())
 			}
@@ -267,6 +292,7 @@ var _ = Describe("Deployment", func() {
 			fakeClient client.Client
 
 			deployment *appsv1.Deployment
+			replicaSet *appsv1.ReplicaSet
 			pod        *corev1.Pod
 		)
 
@@ -277,21 +303,34 @@ var _ = Describe("Deployment", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "deploy",
 					Namespace: "namespace",
+					UID:       "deploy-uid",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: new(int32(1)),
 					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
 				},
 			}
-			pod = &corev1.Pod{
+			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
+
+			replicaSet = &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "pod-",
-					Namespace:    deployment.Namespace,
-					Labels:       deployment.Spec.Selector.MatchLabels,
+					Name:            "replicaset",
+					Namespace:       deployment.Namespace,
+					UID:             "replicaset-uid",
+					Labels:          deployment.Spec.Selector.MatchLabels,
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deployment, appsv1.SchemeGroupVersion.WithKind("Deployment"))},
 				},
 			}
+			Expect(fakeClient.Create(ctx, replicaSet)).To(Succeed())
 
-			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
+			pod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName:    "pod-",
+					Namespace:       deployment.Namespace,
+					Labels:          deployment.Spec.Selector.MatchLabels,
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(replicaSet, appsv1.SchemeGroupVersion.WithKind("ReplicaSet"))},
+				},
+			}
 		})
 
 		It("should consider the deployment as updated", func() {
@@ -363,6 +402,44 @@ var _ = Describe("Deployment", func() {
 
 			p2 := pod.DeepCopy()
 			Expect(fakeClient.Create(ctx, p2)).To(Succeed())
+
+			ok, err := health.DeploymentHasExactNumberOfPods(ctx, fakeClient, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should not consider pods of an unrelated Deployment sharing the same selector labels", func() {
+			Expect(fakeClient.Create(ctx, pod)).To(Succeed())
+
+			otherDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-deploy",
+					Namespace: deployment.Namespace,
+					UID:       "other-deploy-uid",
+				},
+			}
+			Expect(fakeClient.Create(ctx, otherDeployment)).To(Succeed())
+
+			otherReplicaSet := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "other-replicaset",
+					Namespace:       deployment.Namespace,
+					UID:             "other-replicaset-uid",
+					Labels:          deployment.Spec.Selector.MatchLabels,
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(otherDeployment, appsv1.SchemeGroupVersion.WithKind("Deployment"))},
+				},
+			}
+			Expect(fakeClient.Create(ctx, otherReplicaSet)).To(Succeed())
+
+			otherPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName:    "other-pod-",
+					Namespace:       deployment.Namespace,
+					Labels:          deployment.Spec.Selector.MatchLabels,
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(otherReplicaSet, appsv1.SchemeGroupVersion.WithKind("ReplicaSet"))},
+				},
+			}
+			Expect(fakeClient.Create(ctx, otherPod)).To(Succeed())
 
 			ok, err := health.DeploymentHasExactNumberOfPods(ctx, fakeClient, deployment)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/utils/kubernetes/health/deployment_test.go
+++ b/pkg/utils/kubernetes/health/deployment_test.go
@@ -417,6 +417,9 @@ var _ = Describe("Deployment", func() {
 					Namespace: deployment.Namespace,
 					UID:       "other-deploy-uid",
 				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: deployment.Spec.Selector.MatchLabels},
+				},
 			}
 			Expect(fakeClient.Create(ctx, otherDeployment)).To(Succeed())
 

--- a/test/integration/resourcemanager/health/health_test.go
+++ b/test/integration/resourcemanager/health/health_test.go
@@ -360,6 +360,7 @@ var _ = Describe("Health controller tests", func() {
 		Context("with existing resources", func() {
 			var (
 				deployment   *appsv1.Deployment
+				replicaSet   *appsv1.ReplicaSet
 				pod          *corev1.Pod
 				statefulSet  *appsv1.StatefulSet
 				daemonSet    *appsv1.DaemonSet
@@ -377,7 +378,10 @@ var _ = Describe("Health controller tests", func() {
 				deployment.Status = *deploymentStatus
 				Expect(testClient.Status().Update(ctx, deployment)).To(Succeed())
 
-				pod = generatePodForDeployment(deployment)
+				replicaSet = generateReplicaSetForDeployment(deployment)
+				Expect(testClient.Create(ctx, replicaSet)).To(Succeed())
+
+				pod = generatePodForDeployment(replicaSet)
 				Expect(testClient.Create(ctx, pod)).To(Succeed())
 
 				statefulSet = generateStatefulSetTestResource(managedResource.Name)
@@ -419,6 +423,7 @@ var _ = Describe("Health controller tests", func() {
 				DeferCleanup(func() {
 					By("Delete test resources")
 					Expect(testClient.Delete(ctx, pod)).To(Or(Succeed(), BeNotFoundError()))
+					Expect(testClient.Delete(ctx, replicaSet)).To(Or(Succeed(), BeNotFoundError()))
 					Expect(testClient.Delete(ctx, deployment)).To(Or(Succeed(), BeNotFoundError()))
 					Expect(testClient.Delete(ctx, statefulSet)).To(Or(Succeed(), BeNotFoundError()))
 					Expect(testClient.Delete(ctx, daemonSet)).To(Or(Succeed(), BeNotFoundError()))
@@ -519,7 +524,7 @@ var _ = Describe("Health controller tests", func() {
 			})
 
 			It("sets Progressing to true as Deployment still has non-terminated pods", func() {
-				pod2 := generatePodForDeployment(deployment)
+				pod2 := generatePodForDeployment(replicaSet)
 				Expect(testClient.Create(ctx, pod2)).To(Succeed())
 				DeferCleanup(func() {
 					Expect(testClient.Delete(ctx, pod2)).To(Or(Succeed(), BeNotFoundError()))
@@ -780,12 +785,28 @@ func generateDeploymentTestResource(name string) *appsv1.Deployment {
 	}
 }
 
-func generatePodForDeployment(deployment *appsv1.Deployment) *corev1.Pod {
+func generateReplicaSetForDeployment(deployment *appsv1.Deployment) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName:    deployment.Name + "-rs-",
+			Namespace:       deployment.Namespace,
+			Labels:          deployment.Spec.Selector.MatchLabels,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deployment, appsv1.SchemeGroupVersion.WithKind("Deployment"))},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Selector: deployment.Spec.Selector,
+			Template: deployment.Spec.Template,
+		},
+	}
+}
+
+func generatePodForDeployment(replicaSet *appsv1.ReplicaSet) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: deployment.Name + "-pod-",
-			Namespace:    deployment.Namespace,
-			Labels:       deployment.Spec.Selector.MatchLabels,
+			GenerateName:    replicaSet.Name + "-pod-",
+			Namespace:       replicaSet.Namespace,
+			Labels:          replicaSet.Labels,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(replicaSet, appsv1.SchemeGroupVersion.WithKind("ReplicaSet"))},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug

**What this PR does / why we need it**:
`DeploymentHasExactNumberOfPods` (used by the resource-manager's `Progressing` health check and by `IsDeploymentUpdated`) counts every Pod in the Deployment's namespace whose labels match `.spec.selector.matchLabels`, without verifying that those Pods are actually owned (via a ReplicaSet) by the Deployment. An unrelated Deployment in the same namespace that happens to create Pods with the same labels (e.g. a workload placed into `kube-system` on a Shoot cluster) is silently counted alongside the real Pods, permanently skewing the count and leaving the owning ManagedResource stuck in `Progressing`.

**Which issue(s) this PR fixes**:
Fixes #13691

**Special notes for your reviewer**:
This PR fixes the count so only Pods owned (via a ReplicaSet that is in turn owned by the Deployment) by the given Deployment are considered. Several existing unit tests created bare Pods with matching labels but no ReplicaSet/OwnerReference chain; those fixtures were updated (in `pkg/utils/kubernetes/health/deployment_test.go`, `pkg/resourcemanager/controller/health/progressing/add_test.go`, `pkg/component/kubernetes/controllermanager/controllermanager_test.go`, `pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go`, and `pkg/component/kubernetes/apiserver/apiserver_test.go`) to create a real, owned ReplicaSet so their pod-counting assertions keep exercising the intended scenario after the fix.

Validation performed:
- `go build ./pkg/...` and `go vet ./...` pass.
- `go test ./pkg/utils/kubernetes/health/... ./pkg/resourcemanager/controller/health/progressing/... ./pkg/component/kubernetes/controllermanager/... ./pkg/component/nodemanagement/machinecontrollermanager/... ./pkg/component/kubernetes/apiserver/... ./pkg/component/gardener/resourcemanager/...` pass.
- Added a targeted regression test, `#DeploymentHasExactNumberOfPods "should not consider pods of an unrelated Deployment sharing the same selector labels"`, that reproduces the exact scenario from the issue (a second Deployment/ReplicaSet in the same namespace creating Pods with matching labels). Verified it fails against the old code and passes with the fix (`git stash push -- pkg/utils/kubernetes/health/deployment.go && go test ./pkg/utils/kubernetes/health/... -run TestHealth` shows the new test as the sole failure; restoring the fix makes it pass).
- Note: three unrelated `#Deploy`/`PrometheusRule` specs in `pkg/component/kubernetes/apiserver` and `pkg/component/kubernetes/controllermanager` fail locally with `exec: "promtool": executable file not found in $PATH` — this reproduces identically on unmodified `master` in this environment (missing local binary) and is unrelated to this change.
- Could not run a full live-cluster/e2e reproduction of the reported `kube-system` scenario; the fix is validated via the unit test above and the `#Wait` fixtures for real component Deployments (kube-apiserver, kube-controller-manager, machine-controller-manager).

**Release note**:
```bugfix operator
Fixed a bug in the `Progressing` health check for `Deployment`s managed by `gardener-resource-manager`: Pods belonging to an unrelated `Deployment` in the same namespace that happen to share the same selector labels are no longer counted, so a `ManagedResource` no longer gets stuck in `Progressing` state because of such Pods.
```
