### PR TITLE
Add HPA for `gardener-apiserver` and `gardener-admission-controller`

### DIFF
--- a/pkg/component/gardener/admissioncontroller/admission_controller.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller.go
@@ -67,8 +67,6 @@ type Values struct {
 
 // AutoscalingConfig contains information for configuring autoscaling settings for the admission controller.
 type AutoscalingConfig struct {
-	// Replicas is the number of pod replicas for the admission controller.
-	Replicas *int32
 	// MinReplicas are the minimum Replicas for horizontal autoscaling.
 	MinReplicas int32
 	// MaxReplicas are the maximum Replicas for horizontal autoscaling.

--- a/pkg/component/gardener/admissioncontroller/admission_controller.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller.go
@@ -61,6 +61,18 @@ type Values struct {
 	AuthorizerRestrictionsEnabled bool
 	// TopologyAwareRoutingEnabled determines whether topology aware hints are intended for the gardener-admission-controller.
 	TopologyAwareRoutingEnabled bool
+	//
+	Autoscaling AutoscalingConfig
+}
+
+// AutoscalingConfig contains information for configuring autoscaling settings for the admission controller.
+type AutoscalingConfig struct {
+	// Replicas is the number of pod replicas for the admission controller.
+	Replicas *int32
+	// MinReplicas are the minimum Replicas for horizontal autoscaling.
+	MinReplicas int32
+	// MaxReplicas are the maximum Replicas for horizontal autoscaling.
+	MaxReplicas int32
 }
 
 // New creates a new instance of DeployWaiter for the gardener-admission-controller.
@@ -111,6 +123,7 @@ func (a *gardenerAdmissionController) Deploy(ctx context.Context) error {
 		a.podDisruptionBudget(),
 		a.service(),
 		a.vpa(),
+		a.hpa(),
 		admissionConfigConfigMap,
 		a.serviceMonitor(),
 	)

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -561,7 +561,7 @@ func deployment(namespace, configSecretName, serverCertSecretName string, testVa
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas:             new(int32(1)),
+			Replicas:             &testValues.Autoscaling.MinReplicas,
 			RevisionHistoryLimit: new(int32(2)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -17,6 +17,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -68,7 +69,9 @@ var _ = Describe("GardenerAdmissionController", func() {
 		testValues        Values
 		consistOf         func(...client.Object) types.GomegaMatcher
 
-		namespace = "some-namespace"
+		namespace            = "some-namespace"
+		hpaMinReplicas int32 = 2
+		hpaMaxReplicas int32 = 6
 	)
 
 	BeforeEach(func() {
@@ -120,6 +123,10 @@ var _ = Describe("GardenerAdmissionController", func() {
 				},
 				AuthorizerRestrictionsEnabled: true,
 				TopologyAwareRoutingEnabled:   false,
+				Autoscaling: AutoscalingConfig{
+					MinReplicas: hpaMinReplicas,
+					MaxReplicas: hpaMaxReplicas,
+				},
 			}
 
 			Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-gardener", Namespace: namespace}})).To(Succeed())
@@ -450,6 +457,7 @@ func verifyExpectations(ctx context.Context, fakeClient client.Client, consistOf
 		deployment(namespace, "gardener-admission-controller-"+configMapChecksum, serverCert.Name, testValues),
 		service(namespace, testValues),
 		vpa(namespace),
+		hpa(namespace, testValues),
 		podDisruptionBudget(namespace),
 		serviceMonitor(namespace),
 	))
@@ -816,6 +824,73 @@ func vpa(namespace string) *vpaautoscalingv1.VerticalPodAutoscaler {
 					{
 						ContainerName: "*",
 						Mode:          new(vpaautoscalingv1.ContainerScalingModeOff),
+					},
+				},
+			},
+		},
+	}
+}
+
+func hpa(namespace string, testValues Values) *autoscalingv2.HorizontalPodAutoscaler {
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gardener-admission-controller-hpa",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":  "gardener",
+				"role": "admission-controller",
+				"high-availability-config.resources.gardener.cloud/type": "server",
+			},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			MinReplicas: &testValues.Autoscaling.MinReplicas,
+			MaxReplicas: testValues.Autoscaling.MaxReplicas,
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "gardener-admission-controller",
+			},
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:         autoscalingv2.AverageValueMetricType,
+							AverageValue: new(resource.MustParse("6")),
+						},
+					},
+				},
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceMemory,
+						Target: autoscalingv2.MetricTarget{
+							Type:         autoscalingv2.AverageValueMetricType,
+							AverageValue: new(resource.MustParse("24G")),
+						},
+					},
+				},
+			},
+			Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+				ScaleUp: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: new((int32)(60)),
+					Policies: []autoscalingv2.HPAScalingPolicy{
+						{
+							Type:          autoscalingv2.PercentScalingPolicy,
+							Value:         100,
+							PeriodSeconds: 60,
+						},
+					},
+				},
+				ScaleDown: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: new((int32)(1800)),
+					Policies: []autoscalingv2.HPAScalingPolicy{
+						{
+							Type:          autoscalingv2.PodsScalingPolicy,
+							Value:         1,
+							PeriodSeconds: 300,
+						},
 					},
 				},
 			},

--- a/pkg/component/gardener/admissioncontroller/deployment.go
+++ b/pkg/component/gardener/admissioncontroller/deployment.go
@@ -41,7 +41,7 @@ func (a *gardenerAdmissionController) deployment(secretServerCert, secretGeneric
 			}),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas:             new(int32(1)),
+			Replicas:             &a.values.Autoscaling.MinReplicas,
 			RevisionHistoryLimit: new(int32(2)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: GetLabels(),

--- a/pkg/component/gardener/admissioncontroller/hpa.go
+++ b/pkg/component/gardener/admissioncontroller/hpa.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package admissioncontroller
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+)
+
+func (a *gardenerAdmissionController) hpa() *autoscalingv2.HorizontalPodAutoscaler {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName + "-hpa",
+			Namespace: a.namespace,
+			Labels:    GetLabels(),
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			MinReplicas: &a.values.Autoscaling.MinReplicas,
+			MaxReplicas: a.values.Autoscaling.MaxReplicas,
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       "Deployment",
+				Name:       DeploymentName,
+			},
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type: autoscalingv2.AverageValueMetricType,
+							// The chosen value of 6 CPU is aligned with the average value for memory - 24G. Preserve the cpu:memory ratio of 1:4.
+							AverageValue: new(resource.MustParse("6")),
+						},
+					},
+				},
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceMemory,
+						Target: autoscalingv2.MetricTarget{
+							Type: autoscalingv2.AverageValueMetricType,
+							// The chosen value of 24G is aligned with the average value for cpu - 6 CPU cores. Preserve the cpu:memory ratio of 1:4.
+							AverageValue: new(resource.MustParse("24G")),
+						},
+					},
+				},
+			},
+			Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+				ScaleUp: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: new((int32)(60)),
+					Policies: []autoscalingv2.HPAScalingPolicy{
+						// Allow to upscale 100% of the current number of pods every 1 minute to see whether any upscale recommendation will still hold true after the cluster has settled
+						{
+							Type:          autoscalingv2.PercentScalingPolicy,
+							Value:         100,
+							PeriodSeconds: 60,
+						},
+					},
+				},
+				ScaleDown: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: new((int32)(1800)),
+					Policies: []autoscalingv2.HPAScalingPolicy{
+						// Allow to downscale one pod every 5 minutes to see whether any downscale recommendation will still hold true after the cluster has settled (conservatively)
+						{
+							Type:          autoscalingv2.PodsScalingPolicy,
+							Value:         1,
+							PeriodSeconds: 300,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	metav1.SetMetaDataLabel(&hpa.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigType, resourcesv1alpha1.HighAvailabilityConfigTypeServer)
+
+	return hpa
+}

--- a/pkg/component/gardener/apiserver/apiserver.go
+++ b/pkg/component/gardener/apiserver/apiserver.go
@@ -99,6 +99,10 @@ type AutoscalingConfig struct {
 	APIServerResources corev1.ResourceRequirements
 	// Replicas is the number of pod replicas for the API server.
 	Replicas *int32
+	// MinReplicas are the minimum Replicas for horizontal autoscaling.
+	MinReplicas int32
+	// MaxReplicas are the maximum Replicas for horizontal autoscaling.
+	MaxReplicas int32
 }
 
 // New creates a new instance of DeployWaiter for the gardener-apiserver.
@@ -189,6 +193,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		g.podDisruptionBudget(),
 		g.serviceRuntime(),
 		g.verticalPodAutoscaler(),
+		g.horizontalPodAutoscaler(),
 		g.deployment(secretCAETCD, secretETCDClient, secretGenericTokenKubeconfig, secretServer, secretAdmissionKubeconfigs, secretETCDEncryptionConfiguration, secretAuditWebhookKubeconfig, secretWorkloadIdentityKey, secretVirtualGardenAccess, configMapAuditPolicy, configMapAdmissionConfigs),
 		g.serviceMonitor(),
 	)

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -15,6 +15,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -26,6 +27,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -58,7 +60,8 @@ var _ = Describe("GardenerAPIServer", func() {
 		workloadIdentityIssuer           = "https://issuer.gardener.cloud.local"
 		logLevel                         = "log-level"
 		logFormat                        = "log-format"
-		replicas                   int32 = 1337
+		minReplicas                int32 = 2
+		maxReplicas                int32 = 6
 		resources                        = corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("20Mi")},
 			Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("90Mi")},
@@ -81,6 +84,7 @@ var _ = Describe("GardenerAPIServer", func() {
 		podDisruptionBudget *policyv1.PodDisruptionBudget
 		serviceRuntime      *corev1.Service
 		vpa                 *vpaautoscalingv1.VerticalPodAutoscaler
+		hpa                 *autoscalingv2.HorizontalPodAutoscaler
 		deployment          *appsv1.Deployment
 		apiServiceFor       = func(group, version string) *apiregistrationv1.APIService {
 			return &apiregistrationv1.APIService{
@@ -132,7 +136,8 @@ var _ = Describe("GardenerAPIServer", func() {
 				RuntimeVersion: semver.MustParse("1.33.1"),
 			},
 			Autoscaling: AutoscalingConfig{
-				Replicas:           &replicas,
+				MinReplicas:        minReplicas,
+				MaxReplicas:        maxReplicas,
 				APIServerResources: resources,
 			},
 			ClusterIdentity:                   clusterIdentity,
@@ -265,6 +270,70 @@ var _ = Describe("GardenerAPIServer", func() {
 				},
 			},
 		}
+		hpa = &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener-apiserver-hpa",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app":  "gardener",
+					"role": "apiserver",
+					"high-availability-config.resources.gardener.cloud/type": "server",
+				},
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				MinReplicas: &values.Autoscaling.MinReplicas,
+				MaxReplicas: values.Autoscaling.MaxReplicas,
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "gardener-apiserver",
+				},
+				Metrics: []autoscalingv2.MetricSpec{
+					{
+						Type: autoscalingv2.ResourceMetricSourceType,
+						Resource: &autoscalingv2.ResourceMetricSource{
+							Name: corev1.ResourceCPU,
+							Target: autoscalingv2.MetricTarget{
+								Type:         autoscalingv2.AverageValueMetricType,
+								AverageValue: ptr.To(resource.MustParse("6")),
+							},
+						},
+					},
+					{
+						Type: autoscalingv2.ResourceMetricSourceType,
+						Resource: &autoscalingv2.ResourceMetricSource{
+							Name: corev1.ResourceMemory,
+							Target: autoscalingv2.MetricTarget{
+								Type:         autoscalingv2.AverageValueMetricType,
+								AverageValue: ptr.To(resource.MustParse("24G")),
+							},
+						},
+					},
+				},
+				Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+					ScaleUp: &autoscalingv2.HPAScalingRules{
+						StabilizationWindowSeconds: ptr.To[int32](60),
+						Policies: []autoscalingv2.HPAScalingPolicy{
+							{
+								Type:          autoscalingv2.PercentScalingPolicy,
+								Value:         100,
+								PeriodSeconds: 60,
+							},
+						},
+					},
+					ScaleDown: &autoscalingv2.HPAScalingRules{
+						StabilizationWindowSeconds: ptr.To[int32](1800),
+						Policies: []autoscalingv2.HPAScalingPolicy{
+							{
+								Type:          autoscalingv2.PodsScalingPolicy,
+								Value:         1,
+								PeriodSeconds: 300,
+							},
+						},
+					},
+				},
+			},
+		}
 		deployment = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "gardener-apiserver",
@@ -289,7 +358,7 @@ var _ = Describe("GardenerAPIServer", func() {
 			Spec: appsv1.DeploymentSpec{
 				MinReadySeconds:      30,
 				RevisionHistoryLimit: new(int32(2)),
-				Replicas:             &replicas,
+				Replicas:             &minReplicas,
 				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
 					"app":  "gardener",
 					"role": "apiserver",
@@ -1386,7 +1455,7 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					managedResourceSecretVirtual.Name = managedResourceVirtual.Spec.SecretRefs[0].Name
 					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(Succeed())
 
-					expectedRuntimeObjects = []client.Object{deployment, serviceMonitor, vpa, podDisruptionBudget}
+					expectedRuntimeObjects = []client.Object{deployment, serviceMonitor, vpa, hpa, podDisruptionBudget}
 					Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
 					Expect(managedResourceSecretRuntime.Immutable).To(Equal(new(true)))
 					Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -27,7 +27,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -295,7 +294,7 @@ var _ = Describe("GardenerAPIServer", func() {
 							Name: corev1.ResourceCPU,
 							Target: autoscalingv2.MetricTarget{
 								Type:         autoscalingv2.AverageValueMetricType,
-								AverageValue: ptr.To(resource.MustParse("6")),
+								AverageValue: new(resource.MustParse("6")),
 							},
 						},
 					},
@@ -305,14 +304,14 @@ var _ = Describe("GardenerAPIServer", func() {
 							Name: corev1.ResourceMemory,
 							Target: autoscalingv2.MetricTarget{
 								Type:         autoscalingv2.AverageValueMetricType,
-								AverageValue: ptr.To(resource.MustParse("24G")),
+								AverageValue: new(resource.MustParse("24G")),
 							},
 						},
 					},
 				},
 				Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
 					ScaleUp: &autoscalingv2.HPAScalingRules{
-						StabilizationWindowSeconds: ptr.To[int32](60),
+						StabilizationWindowSeconds: new(int32(60)),
 						Policies: []autoscalingv2.HPAScalingPolicy{
 							{
 								Type:          autoscalingv2.PercentScalingPolicy,
@@ -322,7 +321,7 @@ var _ = Describe("GardenerAPIServer", func() {
 						},
 					},
 					ScaleDown: &autoscalingv2.HPAScalingRules{
-						StabilizationWindowSeconds: ptr.To[int32](1800),
+						StabilizationWindowSeconds: new(int32(1800)),
 						Policies: []autoscalingv2.HPAScalingPolicy{
 							{
 								Type:          autoscalingv2.PodsScalingPolicy,

--- a/pkg/component/gardener/apiserver/deployment.go
+++ b/pkg/component/gardener/apiserver/deployment.go
@@ -72,7 +72,7 @@ func (g *gardenerAPIServer) deployment(
 		Spec: appsv1.DeploymentSpec{
 			MinReadySeconds:      30,
 			RevisionHistoryLimit: new(int32(2)),
-			Replicas:             g.values.Autoscaling.Replicas,
+			Replicas:             new(g.values.Autoscaling.MinReplicas),
 			Selector:             &metav1.LabelSelector{MatchLabels: GetLabels()},
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,

--- a/pkg/component/gardener/apiserver/hpa.go
+++ b/pkg/component/gardener/apiserver/hpa.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apiserver
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+)
+
+func (g *gardenerAPIServer) horizontalPodAutoscaler() *autoscalingv2.HorizontalPodAutoscaler {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName + "-hpa",
+			Namespace: g.namespace,
+			Labels:    GetLabels(),
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			MinReplicas: &g.values.Autoscaling.MinReplicas,
+			MaxReplicas: g.values.Autoscaling.MaxReplicas,
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       "Deployment",
+				Name:       DeploymentName,
+			},
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type: autoscalingv2.AverageValueMetricType,
+							// The chosen value of 6 CPU is aligned with the average value for memory - 24G. Preserve the cpu:memory ratio of 1:4.
+							AverageValue: ptr.To(resource.MustParse("6")),
+						},
+					},
+				},
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceMemory,
+						Target: autoscalingv2.MetricTarget{
+							Type: autoscalingv2.AverageValueMetricType,
+							// The chosen value of 24G is aligned with the average value for cpu - 6 CPU cores. Preserve the cpu:memory ratio of 1:4.
+							AverageValue: ptr.To(resource.MustParse("24G")),
+						},
+					},
+				},
+			},
+			Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+				ScaleUp: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: ptr.To[int32](60),
+					Policies: []autoscalingv2.HPAScalingPolicy{
+						// Allow to upscale 100% of the current number of pods every 1 minute to see whether any upscale recommendation will still hold true after the cluster has settled
+						{
+							Type:          autoscalingv2.PercentScalingPolicy,
+							Value:         100,
+							PeriodSeconds: 60,
+						},
+					},
+				},
+				ScaleDown: &autoscalingv2.HPAScalingRules{
+					StabilizationWindowSeconds: ptr.To[int32](1800),
+					Policies: []autoscalingv2.HPAScalingPolicy{
+						// Allow to downscale one pod every 5 minutes to see whether any downscale recommendation will still hold true after the cluster has settled (conservatively)
+						{
+							Type:          autoscalingv2.PodsScalingPolicy,
+							Value:         1,
+							PeriodSeconds: 300,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	metav1.SetMetaDataLabel(&hpa.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigType, resourcesv1alpha1.HighAvailabilityConfigTypeServer)
+
+	return hpa
+}

--- a/pkg/component/gardener/apiserver/hpa.go
+++ b/pkg/component/gardener/apiserver/hpa.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
@@ -38,7 +37,7 @@ func (g *gardenerAPIServer) horizontalPodAutoscaler() *autoscalingv2.HorizontalP
 						Target: autoscalingv2.MetricTarget{
 							Type: autoscalingv2.AverageValueMetricType,
 							// The chosen value of 6 CPU is aligned with the average value for memory - 24G. Preserve the cpu:memory ratio of 1:4.
-							AverageValue: ptr.To(resource.MustParse("6")),
+							AverageValue: new(resource.MustParse("6")),
 						},
 					},
 				},
@@ -49,14 +48,14 @@ func (g *gardenerAPIServer) horizontalPodAutoscaler() *autoscalingv2.HorizontalP
 						Target: autoscalingv2.MetricTarget{
 							Type: autoscalingv2.AverageValueMetricType,
 							// The chosen value of 24G is aligned with the average value for cpu - 6 CPU cores. Preserve the cpu:memory ratio of 1:4.
-							AverageValue: ptr.To(resource.MustParse("24G")),
+							AverageValue: new(resource.MustParse("24G")),
 						},
 					},
 				},
 			},
 			Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
 				ScaleUp: &autoscalingv2.HPAScalingRules{
-					StabilizationWindowSeconds: ptr.To[int32](60),
+					StabilizationWindowSeconds: new((int32)(60)),
 					Policies: []autoscalingv2.HPAScalingPolicy{
 						// Allow to upscale 100% of the current number of pods every 1 minute to see whether any upscale recommendation will still hold true after the cluster has settled
 						{
@@ -67,7 +66,7 @@ func (g *gardenerAPIServer) horizontalPodAutoscaler() *autoscalingv2.HorizontalP
 					},
 				},
 				ScaleDown: &autoscalingv2.HPAScalingRules{
-					StabilizationWindowSeconds: ptr.To[int32](1800),
+					StabilizationWindowSeconds: new((int32)(1800)),
 					Policies: []autoscalingv2.HPAScalingPolicy{
 						// Allow to downscale one pod every 5 minutes to see whether any downscale recommendation will still hold true after the cluster has settled (conservatively)
 						{

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -802,6 +802,18 @@ func gardenerAPIServerAutoscalingConfig(garden *operatorv1alpha1.Garden) gardene
 	}
 }
 
+func gardenerAdmissionControllerAutoscalingConfig(garden *operatorv1alpha1.Garden) gardeneradmissioncontroller.AutoscalingConfig {
+	minReplicas := int32(2)
+	if helper.HighAvailabilityEnabled(garden) {
+		minReplicas = 3
+	}
+
+	return gardeneradmissioncontroller.AutoscalingConfig{
+		MinReplicas: minReplicas,
+		MaxReplicas: 6,
+	}
+}
+
 func kubeAPIServerAutoscalingConfig(garden *operatorv1alpha1.Garden) kubeapiserver.AutoscalingConfig {
 	minReplicas := int32(2)
 	if helper.HighAvailabilityEnabled(garden) {
@@ -1253,6 +1265,7 @@ func (r *Reconciler) newGardenerAdmissionController(garden *operatorv1alpha1.Gar
 		LogLevel:                      logger.InfoLevel,
 		RuntimeVersion:                r.RuntimeVersion,
 		AuthorizerRestrictionsEnabled: enableAuthorizerRestrictions,
+		Autoscaling:                   gardenerAdmissionControllerAutoscalingConfig(garden),
 		TopologyAwareRoutingEnabled:   helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),
 	}
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -785,9 +785,9 @@ func (r *Reconciler) newKubeAPIServer(
 }
 
 func gardenerAPIServerAutoscalingConfig(garden *operatorv1alpha1.Garden) gardenerapiserver.AutoscalingConfig {
-	replicas := int32(2)
+	minReplicas := int32(2)
 	if helper.HighAvailabilityEnabled(garden) {
-		replicas = 3
+		minReplicas = 3
 	}
 
 	return gardenerapiserver.AutoscalingConfig{
@@ -797,7 +797,8 @@ func gardenerAPIServerAutoscalingConfig(garden *operatorv1alpha1.Garden) gardene
 				corev1.ResourceMemory: resource.MustParse("512Mi"),
 			},
 		},
-		Replicas: new(replicas),
+		MinReplicas: minReplicas,
+		MaxReplicas: 6,
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
/area auto-scaling
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR introduces horizontal pod autoscaling (in addition to existing VPA) for `gardener-apiserver` and `gardener-admission-controller` deployments in the runtime cluster. This could potentially enhance the availability and robustness of these components in large-scale Gardener landscapes during high-load conditions, e.g., scenarios that require simultaneous reconciliations of multiple `managedseeds` during a Gardener upgrade for example. Adding HPA could help overcome potential autoscaling limitations of VPA (i.e., it being confined by the available node capacity). 

The HPA for the two components is configured on CPU usage and not utilisation to avoid potential conflicts with VPA as pointed out [here](https://gardener.cloud/docs/guides/applications/shoot-pod-autoscaling-best-practices/#combining-hpa-and-vpa). The idea is to follow the same principles of HPA/VPA combination that we already use for the `kube-apiserver`s of `virtual-garden` and Shoot's control planes. 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
For the time being, I have kept the same values and CPU/memory ratios as already configured for the HPA of `kube-apiserver`, but I am open to adjusting the values and ratios that may be more suitable for the `gardener-apiserver` and `gardener-admission-controller` deployments. Ideas and feedback would be highly appreciated. 🙂 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Horizontal Pod Autoscaling (HPA) has been enabled for `gardener-apiserver` and `gardener-admission-controller` to increase robustness under high-load conditions.
```
