### PR TITLE
feat: add documentation-approvers OWNERS alias and docs/OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -79,3 +79,7 @@ aliases:
   - timebertt
   - timuthy
   - tobschli
+  documentation-approvers: # Approvers for the Gardener documentation and its aggregate sources, see https://gardener.cloud/contribute/contribution-process/documentation-roles/#documentation-approver
+  - BoHristova
+  - VelmiraS
+  - klocke-io

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- documentation-approvers


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area documentation
/kind enhancement

**What this PR does / why we need it**:
Adds a `documentation-approvers` OWNERS alias and a `docs/OWNERS` file so that the documentation approver role can approve changes under `docs/` via Prow.
See the documentation approver role: https://gardener.cloud/contribute/contribution-process/documentation-roles/#documentation-approver

**Which issue(s) this PR fixes**:
Fixes gardener/documentation#1078

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```
