### PR TITLE
Flatten traefik providerConfig in NGINX migration guide for v1alpha2

### DIFF
--- a/docs/operations/nginx_ingress.md
+++ b/docs/operations/nginx_ingress.md
@@ -244,12 +244,11 @@ spec:
   extensions:
   - type: shoot-traefik
     providerConfig:
-      apiVersion: traefik.extensions.gardener.cloud/v1alpha1
+      apiVersion: traefik.extensions.gardener.cloud/v1alpha2
       kind: TraefikConfig
-      spec:
-        replicas: 2
-        # KubernetesIngressNGINX enables NGINX annotation compatibility
-        ingressProvider: KubernetesIngressNGINX
+      replicas: 2
+      # KubernetesIngressNGINX enables NGINX annotation compatibility
+      ingressProvider: KubernetesIngressNGINX
 ```
 
 Apply the change and wait for the Shoot to reconcile:


### PR DESCRIPTION
The `providerConfig` of the shoot-traefik extension no longer uses a top-level `spec` since the API was flattened in [gardener-extension-shoot-traefik#120](https://github.com/gardener/gardener-extension-shoot-traefik/pull/120) (new `v1alpha2` version). This reverts the `spec` wrapper added in #15468 and updates the example in the NGINX Ingress migration guide to the flat `v1alpha2` structure.