### PR TITLE
Reconcile healthy shoots in failed state during maintenance window

### DIFF
--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -512,7 +512,7 @@ func maintainOperation(shoot *gardencorev1beta1.Shoot, credentialsToRotationUpda
 
 	switch shoot.Status.LastOperation.State {
 	case gardencorev1beta1.LastOperationStateFailed:
-		if needsRetry(shoot) {
+		if needsRetry(shoot) || allShootConditionsTrue(shoot) {
 			metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRetry)
 			delete(shoot.Annotations, v1beta1constants.FailedShootNeedsRetryOperation)
 		}
@@ -772,6 +772,18 @@ func needsRetry(shoot *gardencorev1beta1.Shoot) bool {
 	}
 
 	return needsRetryOperation
+}
+
+func allShootConditionsTrue(shoot *gardencorev1beta1.Shoot) bool {
+	if len(shoot.Status.Conditions) == 0 {
+		return false
+	}
+	for _, condition := range shoot.Status.Conditions {
+		if condition.Status != gardencorev1beta1.ConditionTrue {
+			return false
+		}
+	}
+	return true
 }
 
 func getOperation(shoot *gardencorev1beta1.Shoot, credentialsToRotationUpdate map[string]updateResult) string {

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -2433,6 +2433,101 @@ var _ = Describe("Shoot Maintenance", func() {
 			Expect(failureReason).To(Equal(`Worker pool "gpu-worker": Kubernetes maintenance failure due to: no higher patch version available`))
 		})
 	})
+
+	Describe("#maintainOperation", func() {
+		var shoot *gardencorev1beta1.Shoot
+
+		BeforeEach(func() {
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shoot",
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					LastOperation: &gardencorev1beta1.LastOperation{
+						State: gardencorev1beta1.LastOperationStateFailed,
+					},
+				},
+			}
+		})
+
+		Context("shoot lastOperation is Failed", func() {
+			It("should not set retry annotation when conditions are absent", func() {
+				maintainOperation(shoot, nil)
+				Expect(shoot.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+			})
+
+			It("should not set retry annotation when at least one condition is not True", func() {
+				shoot.Status.Conditions = []gardencorev1beta1.Condition{
+					{Type: "APIServerAvailable", Status: gardencorev1beta1.ConditionTrue},
+					{Type: "ControlPlaneHealthy", Status: gardencorev1beta1.ConditionFalse},
+				}
+				maintainOperation(shoot, nil)
+				Expect(shoot.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+			})
+
+			It("should set retry annotation when all conditions are True", func() {
+				shoot.Status.Conditions = []gardencorev1beta1.Condition{
+					{Type: "APIServerAvailable", Status: gardencorev1beta1.ConditionTrue},
+					{Type: "ControlPlaneHealthy", Status: gardencorev1beta1.ConditionTrue},
+					{Type: "SystemComponentsHealthy", Status: gardencorev1beta1.ConditionTrue},
+				}
+				maintainOperation(shoot, nil)
+				Expect(shoot.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRetry))
+			})
+
+			It("should set retry annotation when FailedShootNeedsRetryOperation is true, regardless of conditions", func() {
+				shoot.Annotations = map[string]string{
+					v1beta1constants.FailedShootNeedsRetryOperation: "true",
+				}
+				maintainOperation(shoot, nil)
+				Expect(shoot.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRetry))
+				Expect(shoot.Annotations).NotTo(HaveKey(v1beta1constants.FailedShootNeedsRetryOperation))
+			})
+
+			It("should clear FailedShootNeedsRetryOperation annotation when all conditions are True", func() {
+				shoot.Annotations = map[string]string{
+					v1beta1constants.FailedShootNeedsRetryOperation: "true",
+				}
+				shoot.Status.Conditions = []gardencorev1beta1.Condition{
+					{Type: "APIServerAvailable", Status: gardencorev1beta1.ConditionTrue},
+				}
+				maintainOperation(shoot, nil)
+				Expect(shoot.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRetry))
+				Expect(shoot.Annotations).NotTo(HaveKey(v1beta1constants.FailedShootNeedsRetryOperation))
+			})
+		})
+	})
+
+	Describe("#allShootConditionsTrue", func() {
+		It("should return false when conditions slice is empty", func() {
+			shoot := &gardencorev1beta1.Shoot{}
+			Expect(allShootConditionsTrue(shoot)).To(BeFalse())
+		})
+
+		It("should return false when at least one condition is not True", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				Status: gardencorev1beta1.ShootStatus{
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: "APIServerAvailable", Status: gardencorev1beta1.ConditionTrue},
+						{Type: "ControlPlaneHealthy", Status: gardencorev1beta1.ConditionUnknown},
+					},
+				},
+			}
+			Expect(allShootConditionsTrue(shoot)).To(BeFalse())
+		})
+
+		It("should return true when all conditions are True", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				Status: gardencorev1beta1.ShootStatus{
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: "APIServerAvailable", Status: gardencorev1beta1.ConditionTrue},
+						{Type: "ControlPlaneHealthy", Status: gardencorev1beta1.ConditionTrue},
+					},
+				},
+			}
+			Expect(allShootConditionsTrue(shoot)).To(BeTrue())
+		})
+	})
 })
 
 func assertWorkerMachineImageVersion(worker *gardencorev1beta1.Worker, imageName string, imageVersion string) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/area robustness performance ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the maintenance controller to reconcile shoots in the failed state if all of its conditions are healthy.

See motivation https://github.com/gardener/gardener/issues/15705

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/15705

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Shoots in failed state are now reconciled during the maintenance window if all of its conditions are healthy.
```
